### PR TITLE
Add a `make install` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ else()
     add_library(h3.1 SHARED ${SOURCE_FILES})
 endif()
 
+# Automatic code formatting
 option(ENABLE_FORMAT "Enable running clang-format before compiling." ON)
 find_program(CLANG_FORMAT_PATH clang-format)
 if (CLANG_FORMAT_PATH AND ENABLE_FORMAT)
@@ -319,3 +320,17 @@ if(ENABLE_TESTS)
     add_h3_benchmark(benchmarkH3Api src/apps/benchmarks/benchmarkH3Api.c)
     add_h3_benchmark(benchmarkPolyfill src/apps/benchmarks/benchmarkPolyfill.c)
 endif()
+
+# Installing the library and filters system-wide. Does not include miscapps.
+install(TARGETS h3.1
+        geoToH3
+        h3ToComponents
+        h3ToGeo
+        h3ToGeoBoundary
+        hexRange
+        kRing
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib/static)
+# Only the h3api.h header is needed by applications using H3.
+install(FILES src/h3lib/include/h3api.h DESTINATION include/h3)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ cmake .
 make
 ```
 
+You can install system-wide with:
+
+```
+sudo make install
+```
+
 #### Testing
 
 After making the project, you can test with `make test`, and if `lcov` is installed you can `make coverage` to generate a code coverage report.
@@ -108,9 +114,8 @@ This will produce some coordinate:
 The above features of H3 can also be used from C. For example, you can compile and run [examples/index.c](./examples/index.c) like so:
 
 ```
-cc -Isrc/h3lib/include/ -Llib -lh3.1 examples/index.c -o example
-# LD_LIBRARY_PATH is needed if you did not install the library system-wide.
-LD_LIBRARY_PATH=lib ./example
+cc -lh3.1 examples/index.c -o example
+./example
 ```
 
 You should get output like:

--- a/examples/index.c
+++ b/examples/index.c
@@ -18,13 +18,14 @@
  * and then finds the vertices and center coordinates of the index.
  */
 
-#include <h3api.h>
+#include <h3/h3api.h>
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
     // Get the H3 index of some location and print it.
     GeoCoord location;
-    setGeoDegs(&location, 40.689167, -74.044444);
+    location.lat = degsToRads(40.689167);
+    location.lon = degsToRads(-74.044444);
     int resolution = 10;
     H3Index indexed = geoToH3(&location, resolution);
     printf("The index is: %llx\n", indexed);


### PR DESCRIPTION
Makes it easy to install H3 system-wide. Assuming the library was installed system-wide, the commands for building the example become much simpler.