### PR TITLE
Fix typo in compact test

### DIFF
--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -85,7 +85,7 @@ TEST(res0) {
     }
 
     H3Index* decompressed = calloc(
-        H3_EXPORT(maxUncompactSize)(compressed, hexCount, 9), sizeof(H3Index));
+        H3_EXPORT(maxUncompactSize)(compressed, hexCount, 0), sizeof(H3Index));
     int err2 =
         H3_EXPORT(uncompact)(compressed, hexCount, decompressed, hexCount, 0);
     t_assert(err2 == 0, "no error on uncompact");


### PR DESCRIPTION
This resolves issue #3 

The correct amount of memory was not being allocated for the uncompacted hexagons, so the test was writing to memory it shouldn't have been, and was caught on my laptop only when checking code coverage. I'm not sure why, though. :man_shrugging: 