### PR TITLE
Add coveralls report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,21 @@ matrix:
           packages:
             - clang-format-5.0
       script: make format && git diff --exit-code
+      # Submit coverage report to Coveralls.io
+    - env: NAME="Coverage report"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - lcov
+      install:
+        - pip install --user cpp-coveralls
+      before_script:
+        - cmake -DCMAKE_BUILD_TYPE=Debug .
+      script:
+        - make && make coverage
+      after_success:
+        - coveralls --lcov-file coverage.cleaned.info --verbose
 
 # Configure the build script, out of source.
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 set(CMAKE_MACOSX_RPATH 1)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -fno-inline -fno-eliminate-unused-debug-types --coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -fno-inline -fno-eliminate-unused-debug-types --coverage -std=c1x")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -fPIC -std=c1x")
 endif()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # H3: A Hexagonal Hierarchical Geospatial Indexing System
 
 [![Build Status](https://travis-ci.org/uber/h3.svg?branch=master)](https://travis-ci.org/uber/h3)
+[![Coverage Status](https://coveralls.io/repos/github/uber/h3/badge.svg?branch=master)](https://coveralls.io/github/uber/h3?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 H3 is a geospatial indexing system using a hexagonal grid that can be (approximately) subdivided into finer and finer hexagonal grids, combining the benefits of a hexagonal grid with [S2](https://code.google.com/archive/p/s2-geometry-library/)'s hierarchical subdivisions.


### PR DESCRIPTION
Adds a coverage report as a separate build in Travis CI.

It shows 100% coverage on Coveralls.io (https://coveralls.io/github/uber/h3), but I did notice it's calculation of lines covered differs from lcov/genhtml run locally:
```
Overall coverage rate:
  lines......: 100.0% (1449 of 1449 lines)
  functions..: 100.0% (137 of 137 functions)
[100%] Built target coverage
```
vs in Coveralls:
```
1407 of 1407 relevant lines covered (100.0%)
```

In both cases, coverage only considers the core library, and not the filter apps.