### PR TITLE
Remove H3IndexFat from h3ToComponents app

### DIFF
--- a/src/apps/filters/h3ToComponents.c
+++ b/src/apps/filters/h3ToComponents.c
@@ -45,20 +45,21 @@ char resDigitToChar(int d) {
 }
 
 void doCell(H3Index h, int verboseMode) {
-    H3IndexFat hf;
-    h3ToH3Fat(h, &hf);
+    int h3Mode = H3_GET_MODE(h);
+    int h3Res = H3_GET_RESOLUTION(h);
+    int h3BaseCell = H3_GET_BASE_CELL(h);
     if (verboseMode == 0) {
-        if (hf.mode == H3_HEXAGON_MODE) {
-            printf("%d:%d:%d:", hf.mode, hf.res, hf.baseCell);
-            for (int i = 0; i < hf.res; i++) {
-                printf("%c", resDigitToChar(hf.index[i]));
+        if (h3Mode == H3_HEXAGON_MODE) {
+            printf("%d:%d:%d:", h3Mode, h3Res, h3BaseCell);
+            for (int i = 1; i <= h3Res; i++) {
+                printf("%c", resDigitToChar(H3_GET_INDEX_DIGIT(h, i)));
             }
             printf("\n");
-        } else if (hf.mode == H3_UNIEDGE_MODE) {
-            printf("%d:%d:%d:%d:", hf.mode, H3_GET_RESERVED_BITS(h), hf.res,
-                   hf.baseCell);
-            for (int i = 0; i < hf.res; i++) {
-                printf("%c", resDigitToChar(hf.index[i]));
+        } else if (h3Mode == H3_UNIEDGE_MODE) {
+            printf("%d:%d:%d:%d:", h3Mode, H3_GET_RESERVED_BITS(h), h3Res,
+                   h3BaseCell);
+            for (int i = 1; i <= h3Res; i++) {
+                printf("%c", resDigitToChar(H3_GET_INDEX_DIGIT(h, i)));
             }
             printf("\n");
         } else {
@@ -88,14 +89,15 @@ void doCell(H3Index h, int verboseMode) {
         H3_EXPORT(h3ToString)(h, hStr, BUFF_SIZE);
         printf("║ H3Index    ║ %s\n", hStr);
         printf("╠════════════╣\n");
-        printf("║ Mode       ║ %s (%i)\n", modes[hf.mode], hf.mode);
-        printf("║ Resolution ║ %i\n", hf.res);
-        if (hf.mode == H3_UNIEDGE_MODE) {
+        printf("║ Mode       ║ %s (%i)\n", modes[h3Mode], h3Mode);
+        printf("║ Resolution ║ %i\n", h3Res);
+        if (h3Mode == H3_UNIEDGE_MODE) {
             printf("║ Edge       ║ %i\n", H3_GET_RESERVED_BITS(h));
         }
-        printf("║ Base Cell  ║ %i\n", hf.baseCell);
-        for (int i = 0; i < hf.res; i++) {
-            printf("║%3i Child   ║ %c\n", i + 1, resDigitToChar(hf.index[i]));
+        printf("║ Base Cell  ║ %i\n", h3BaseCell);
+        for (int i = 1; i <= h3Res; i++) {
+            printf("║%3i Child   ║ %c\n", i,
+                   resDigitToChar(H3_GET_INDEX_DIGIT(h, i)));
         }
         printf("╚════════════╝\n\n");
     }


### PR DESCRIPTION
This one was pretty simple, so I did it over lunch. :)

There are no tests for the apps (yet?) so I tested it by just exhaustively executing all paths in the application (therefore just two kinds of H3 indexes in normal and verbose mode ;) ).

```
damocles@Talyn:~/oss/h3(slim-components)$ ./bin/h3ToComponents
811fbffffffffff
1:1:15:6
149283080dcbffff
2:4:9:20:060401562
^C
damocles@Talyn:~/oss/h3(slim-components)$ ./bin/h3ToComponents --verbose
811fbffffffffff
╔════════════╗
║ H3Index    ║ 811fbffffffffff
╠════════════╣
║ Mode       ║ Hexagon (1)
║ Resolution ║ 1
║ Base Cell  ║ 15
║  1 Child   ║ 6
╚════════════╝

149283080dcbffff
╔════════════╗
║ H3Index    ║ 149283080dcbffff
╠════════════╣
║ Mode       ║ Unidirectional Edge (2)
║ Resolution ║ 9
║ Edge       ║ 4
║ Base Cell  ║ 20
║  1 Child   ║ 0
║  2 Child   ║ 6
║  3 Child   ║ 0
║  4 Child   ║ 4
║  5 Child   ║ 0
║  6 Child   ║ 1
║  7 Child   ║ 5
║  8 Child   ║ 6
║  9 Child   ║ 2
╚════════════╝

^C
damocles@Talyn:~/oss/h3(slim-components)$
```