### PR TITLE
Remove H3IndexFat from geoToH3

### DIFF
--- a/src/h3lib/lib/h3api.c
+++ b/src/h3lib/lib/h3api.c
@@ -18,33 +18,8 @@
  */
 
 #include "h3api.h"
-#include <math.h>
 #include <stdio.h>
 #include "h3Index.h"
-
-/**
- * Encodes a coordinate on the sphere to the H3 index of the containing cell at
- * the specified resolution.
- *
- * Returns 0 on invalid input.
- *
- * @param g The spherical coordinates to encode.
- * @param res The desired H3 resolution for the encoding.
- * @return The encoded H3Index (or 0 on failure).
- */
-H3Index H3_EXPORT(geoToH3)(const GeoCoord* g, int res) {
-    H3IndexFat hf;
-
-    if (res < 0 || res > MAX_H3_RES) {
-        return 0;
-    }
-    if (!isfinite(g->lat) || !isfinite(g->lon)) {
-        return 0;
-    }
-
-    geoToH3Fat(g, res, &hf);
-    return h3FatToH3(&hf);
-}
 
 /**
  * Determines the spherical coordinates of the center point of an H3 index.


### PR DESCRIPTION
Another diff to remove another piece of H3IndexFat. This one focuses on the `geoToH3` function.

I only did one function from the API because it was complex enough on its own, and I also didn't want to complete the refactoring without input from @isaacbrodsky and crew.

Since this implementation needed internals of H3Index, I put it into the `h3Index.c` file and removed `geoToH3` from the `h3api.c` file entirely. I'm planning on completely removing the `h3api.c` file along with the `h3IndexFat` files, unless there are objections. In this way `h3api.h` is just a header for exported functions, whereever they live, and that seems fine to me.

I also removed the dead code from `h3IndexFat.c` that the code coverage told me was unused. I figured that'd be better than a temporary dip on coverage percentage?