### PR TITLE
Change _hashVertex to use fmod.

### DIFF
--- a/src/h3lib/lib/vertexGraph.c
+++ b/src/h3lib/lib/vertexGraph.c
@@ -64,8 +64,8 @@ void destroyVertexGraph(VertexGraph* graph) {
 uint32_t _hashVertex(const GeoCoord* vertex, int res, int numBuckets) {
     // Simple hash: Take the sum of the lat and lon with a precision level
     // determined by the resolution, converted to int, modulo bucket count.
-    return (uint32_t)((vertex->lat + vertex->lon) * pow(10, 15 - res)) %
-           numBuckets;
+    return (uint32_t)fmod((vertex->lat + vertex->lon) * pow(10, 15 - res),
+                          numBuckets);
 }
 
 void _initVertexNode(VertexNode* node, const GeoCoord* fromVtx,


### PR DESCRIPTION
@nrabinowitz This hash function encounters undefined behavior (C99 6.3.1.4.1, casting a float where the integral part cannot be represented by the integer type is undefined), which causes the test suite to fail on armv7. The change here is to put the integral part in range of uint32_t before casting.

It looks to me like the standard way of writing this function would be something like `lat * 37 + lon`, to avoid `lat=1,lon=2` having the same hash as `lat=2,lon=1`. It also looks like this could be done with `union`s of `double` and `uint64_t`, but not sure we want to do that since it would be undefined behavior as I understand.