### PR TITLE
Don't require BUILD_STATIC for Windows tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(WIN32)
     set(SHELL PowerShell -Command)
+
+    set(EXECUTABLE_OUTPUT_PATH bin)
+    set(LIBRARY_OUTPUT_PATH bin)
 else()
     set(SHELL sh -c)
 
@@ -50,6 +53,9 @@ else()
     else()
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -fPIC -std=c1x")
     endif()
+
+    set(EXECUTABLE_OUTPUT_PATH bin)
+    set(LIBRARY_OUTPUT_PATH lib)
 endif()
 
 file(READ VERSION H3_VERSION LIMIT_COUNT 1)
@@ -57,9 +63,6 @@ file(READ VERSION H3_VERSION LIMIT_COUNT 1)
 string(REPLACE "\n" "" H3_VERSION "${H3_VERSION}")
 
 find_library(M_LIB m)
-
-set(EXECUTABLE_OUTPUT_PATH bin)
-set(LIBRARY_OUTPUT_PATH lib)
 
 include_directories(src/h3lib/include)
 

--- a/docs/build_windows.md
+++ b/docs/build_windows.md
@@ -2,26 +2,17 @@
 
 H3 has been successfully built on Windows using Visual Studio 2017.
 
-You can use the CMake GUI to configure the Visual Studio project files needed to build H3. You will need to set `BUILD_STATIC` to `ON`. Alternately, you can do the same from the command line:
+You can use the CMake GUI to configure the Visual Studio project files needed to build H3. Alternately, you can do the same from the command line:
 
 ```
 mkdir build
 cd build
-cmake -DBUILD_STATIC=ON ..
+cmake ..
 ```
 
-You can now open `h3.sln` and build the `ALL_BUILD` project to build the H3 static library, filter applications, and tests. Tests can be run by building the `RUN_TESTS` project. From the command line:
+You can now open `h3.sln` and build the `ALL_BUILD` project to build the H3 library, filter applications, and tests. Tests can be run by building the `RUN_TESTS` project. From the command line:
 
 ```
 msbuild ALL_BUILD.vcxproj
 msbuild RUN_TESTS.vcxproj
-```
-
-## Building a DLL
-
-To build a DLL (`h3.1.dll`) you will need to rerun CMake with the `BUILD_STATIC` option set to `OFF`, and then build the `h3.1` project. From the command line:
-
-```
-cmake -DBUILD_STATIC=OFF ..
-msbuild h3.1.vcxproj
 ```

--- a/src/apps/miscapps/generateBaseCellNeighbors.c
+++ b/src/apps/miscapps/generateBaseCellNeighbors.c
@@ -67,7 +67,7 @@ void auditBaseCellNeighbors(int baseCellNeighbors[NUM_BASE_CELLS][7],
 
             // This is wrong for moving into pentagons. One neighbor for most
             // pentagons, and four neighbors for the polar pentagons 4 and 117.
-            if (!baseCellData[baseCellNeighbors[i][j]].isPentagon) {
+            if (!_isBaseCellPentagon(baseCellNeighbors[i][j])) {
                 if (ourDir.i != theirDir.i || ourDir.j != theirDir.j ||
                     ourDir.k != theirDir.k) {
                     printf("WRONG DIRECTION between %d and %d\n", i,
@@ -101,16 +101,14 @@ void generate() {
     int baseCellRotations[NUM_BASE_CELLS][7];
 
     for (int i = 0; i < NUM_BASE_CELLS; i++) {
-        if (!baseCellData[i].isPentagon) {
+        if (!_isBaseCellPentagon(i)) {
             for (int dir = 0; dir <= NUM_DIRS; dir++) {
-                CoordIJK ijk = baseCellData[i].homeFijk.coord;
-                _neighbor(&ijk, dir);
+                FaceIJK fijk;
+                _baseCellToFaceIjk(i, &fijk);
+                _neighbor(&fijk.coord, dir);
 
                 // Should never happen, but just in case :)
-                if (ijk.i < 3 && ijk.j < 3 && ijk.k < 3) {
-                    FaceIJK fijk;
-                    fijk.face = baseCellData[i].homeFijk.face;
-                    fijk.coord = ijk;
+                if (fijk.coord.i < 3 && fijk.coord.j < 3 && fijk.coord.k < 3) {
                     baseCellNeighbors[i][dir] = _faceIjkToBaseCell(&fijk);
                     baseCellRotations[i][dir] =
                         _faceIjkToBaseCellCCWrot60(&fijk);

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -341,16 +341,16 @@ TEST(cwOffsetPent) {
         }
 
         for (int neighbor = 0; neighbor < NUM_BASE_CELLS; neighbor++) {
-            int neighborFace = baseCellData[neighbor].homeFijk.face;
+            FaceIJK homeFaceIjk;
+            _baseCellToFaceIjk(neighbor, &homeFaceIjk);
+            int neighborFace = homeFaceIjk.face;
 
             // Only direction 2 needs to be checked, because that is the only
             // direction where we can move from digit 2 to digit 1, and into the
             // deleted k subsequence.
-            t_assert(
-                baseCellNeighbors[neighbor][2] != pentagon ||
-                    baseCellData[pentagon].cwOffsetPent[0] == neighborFace ||
-                    baseCellData[pentagon].cwOffsetPent[1] == neighborFace,
-                "cwOffsetPent is reachable");
+            t_assert(_getBaseCellNeighbor(neighbor, 2) != pentagon ||
+                         _baseCellIsCwOffset(pentagon, neighborFace),
+                     "cwOffsetPent is reachable");
         }
     }
 }

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -46,5 +46,8 @@ extern const BaseCellData baseCellData[NUM_BASE_CELLS];
 int _isBaseCellPentagon(int baseCell);
 int _faceIjkToBaseCell(const FaceIJK* h);
 int _faceIjkToBaseCellCCWrot60(const FaceIJK* h);
+void _baseCellToFaceIjk(int baseCell, FaceIJK* h);
+bool _baseCellIsCwOffset(int origin, int test);
+int _getBaseCellNeighbor(int baseCell, int dir);
 
 #endif

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -47,7 +47,7 @@ int _isBaseCellPentagon(int baseCell);
 int _faceIjkToBaseCell(const FaceIJK* h);
 int _faceIjkToBaseCellCCWrot60(const FaceIJK* h);
 void _baseCellToFaceIjk(int baseCell, FaceIJK* h);
-bool _baseCellIsCwOffset(int origin, int test);
+bool _baseCellIsCwOffset(int baseCell, int testFace);
 int _getBaseCellNeighbor(int baseCell, int dir);
 
 #endif

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -287,10 +287,8 @@ H3Index h3NeighborRotations(H3Index origin, const CoordIJK* translationIjk,
                 // on how we got here.
                 // check for a cw/ccw offset face; default is ccw
 
-                if (baseCellData[newBaseCell].cwOffsetPent[0] ==
-                        baseCellData[oldBaseCell].homeFijk.face ||
-                    baseCellData[newBaseCell].cwOffsetPent[1] ==
-                        baseCellData[oldBaseCell].homeFijk.face) {
+                if (_baseCellIsCwOffset(
+                        newBaseCell, baseCellData[oldBaseCell].homeFijk.face)) {
                     out = _h3Rotate60cw(out);
                 } else {
                     // See cwOffsetPent in testKRing.c for why this is

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -848,3 +848,22 @@ int _faceIjkToBaseCellCCWrot60(const FaceIJK* h) {
     return faceIjkBaseCells[h->face][h->coord.i][h->coord.j][h->coord.k]
         .ccwRot60;
 }
+
+/** @brief Find the FaceIJK given a base cell.
+ */
+void _baseCellToFaceIjk(int baseCell, FaceIJK* h) {
+    *h = baseCellData[baseCell].homeFijk;
+}
+
+/** @brief Return whether or not the tested face is a cw offset face.
+ */
+bool _baseCellIsCwOffset(int origin, int test) {
+    return baseCellData[origin].cwOffsetPent[0] == test ||
+           baseCellData[origin].cwOffsetPent[1] == test;
+}
+
+/** @brief Return the neighboring base cell in the given direction.
+ */
+int _getBaseCellNeighbor(int baseCell, int dir) {
+    return baseCellNeighbors[baseCell][dir];
+}

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -857,9 +857,9 @@ void _baseCellToFaceIjk(int baseCell, FaceIJK* h) {
 
 /** @brief Return whether or not the tested face is a cw offset face.
  */
-bool _baseCellIsCwOffset(int origin, int test) {
-    return baseCellData[origin].cwOffsetPent[0] == test ||
-           baseCellData[origin].cwOffsetPent[1] == test;
+bool _baseCellIsCwOffset(int baseCell, int testFace) {
+    return baseCellData[baseCell].cwOffsetPent[0] == testFace ||
+           baseCellData[baseCell].cwOffsetPent[1] == testFace;
 }
 
 /** @brief Return the neighboring base cell in the given direction.

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -605,8 +605,7 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
         // force rotation out of missing k-axes sub-sequence
         if (_h3LeadingNonZeroDigit(h) == K_AXES_DIGIT) {
             // check for a cw/ccw offset face; default is ccw
-            if (baseCellData[baseCell].cwOffsetPent[0] == fijkBC.face ||
-                baseCellData[baseCell].cwOffsetPent[1] == fijkBC.face) {
+            if (_baseCellIsCwOffset(baseCell, fijkBC.face)) {
                 h = _h3Rotate60cw(h);
             } else {
                 h = _h3Rotate60ccw(h);


### PR DESCRIPTION
Makes the tests and misc. apps compatible with BUILD_STATIC=OFF on Windows. Previously, they didn't work because the base cell tables were not exported. It also changes the build to place the DLL in the `bin` directory, only on Windows.