### PR TITLE
Automatically run tests under Valgrind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,14 @@ option(ENABLE_TESTS "Enable building tests." ON)
 if(ENABLE_TESTS)
     option(PRINT_TEST_FILES "Print which test files correspond to which tests." OFF)
 
+    find_program(VALGRIND valgrind)
+    option(WRAP_VALGRIND "Wrap tests in valgrind." OFF)
+    if(WRAP_VALGRIND AND VALGRIND)
+        set(TEST_WRAPPER ${VALGRIND} --leak-check=full --error-exitcode=99)
+    else()
+        set(TEST_WRAPPER)
+    endif()
+
     enable_testing()
 
     # Macros and support code needed to build and add the tests
@@ -222,7 +230,7 @@ if(ENABLE_TESTS)
 
     macro(add_h3_test name srcfile)
         add_h3_test_common(${name} ${srcfile})
-        add_test(NAME ${name}_test${test_number} COMMAND ${name})
+        add_test(NAME ${name}_test${test_number} COMMAND ${TEST_WRAPPER} "$<TARGET_FILE:${name}>")
 
         if(ENABLE_COVERAGE)
             add_custom_target(${name}_coverage${test_number}
@@ -239,7 +247,7 @@ if(ENABLE_TESTS)
         add_h3_test_common(${name} ${srcfile})
         # add a special command (so we don't need to read the test file from the test program)
         add_test(NAME ${name}_test${test_number}
-            COMMAND ${SHELL} "$<TARGET_FILE:${name}> < ${argfile}"
+            COMMAND ${TEST_WRAPPER} ${SHELL} "$<TARGET_FILE:${name}> < ${argfile}"
             )
         if(PRINT_TEST_FILES)
             message("${name}_test${test_number} - ${argfile}")
@@ -259,7 +267,7 @@ if(ENABLE_TESTS)
     macro(add_h3_test_with_arg name srcfile arg)
         add_h3_test_common(${name} ${srcfile})
         add_test(NAME ${name}_test${test_number}
-            COMMAND $<TARGET_FILE:${name}> ${arg}
+            COMMAND ${TEST_WRAPPER} $<TARGET_FILE:${name}> ${arg}
             )
         if(PRINT_TEST_FILES)
             message("${name}_test${test_number} - ${arg}")

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -96,6 +96,7 @@ TEST(multipleResSteps) {
     H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
 
     verifyCountAndUniqueness(children, paddedCount, expectedCount);
+    free(children);
 }
 
 TEST(sameRes) {

--- a/src/apps/testapps/testVertexGraph.c
+++ b/src/apps/testapps/testVertexGraph.c
@@ -235,10 +235,7 @@ TEST(removeVertexNode) {
     t_assert(graph.size == 2, "Graph size decremented");
 
     // Remove non-existent node
-    node = malloc(sizeof(VertexNode));
-    node->next = NULL;
-    setGeoDegs(&node->from, 0, 0);
-    setGeoDegs(&node->to, 0, 0);
+    node = calloc(1, sizeof(VertexNode));
     success = removeVertexNode(&graph, node) == 0;
 
     t_assert(!success, "Removal of non-existent node fails");

--- a/src/apps/testapps/testVertexGraph.c
+++ b/src/apps/testapps/testVertexGraph.c
@@ -236,6 +236,9 @@ TEST(removeVertexNode) {
 
     // Remove non-existent node
     node = malloc(sizeof(VertexNode));
+    node->next = NULL;
+    setGeoDegs(&node->from, 0, 0);
+    setGeoDegs(&node->to, 0, 0);
     success = removeVertexNode(&graph, node) == 0;
 
     t_assert(!success, "Removal of non-existent node fails");


### PR DESCRIPTION
Adds an option for running all tests under Valgrind, `WRAP_VALGRIND`, or another wrapper using `TEST_WRAPPER`.

Another possible improvement would be to automatically run Valgrind as part of CI.