### PR TITLE
Add check for out of range coordinates when indexing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
 ## [Unreleased]
+### Changed
+- Improved resilience to out of range inputs.
 
 ## [3.0.2] - 2018-01-24
 ### Removed

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -30,10 +30,10 @@
 BEGIN_TESTS(h3Index);
 
 TEST(geoToH3ExtremeCoordinates) {
-    GeoCoord g = { 0, 1E45 };
+    GeoCoord g = {0, 1E45};
     t_assert(H3_EXPORT(geoToH3)(&g, 14) == 0, "extreme longitude");
 
-    GeoCoord g2 = { 1E46, 1E45 };
+    GeoCoord g2 = {1E46, 1E45};
     t_assert(H3_EXPORT(geoToH3)(&g2, 15) == 0, "extreme latitude longitude");
 
     GeoCoord g4;

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -29,6 +29,18 @@
 
 BEGIN_TESTS(h3Index);
 
+TEST(geoToH3ExtremeCoordinates) {
+    GeoCoord g = { 0, 1E45 };
+    t_assert(H3_EXPORT(geoToH3)(&g, 14) == 0, "extreme longitude");
+
+    GeoCoord g2 = { 1E46, 1E45 };
+    t_assert(H3_EXPORT(geoToH3)(&g2, 15) == 0, "extreme latitude longitude");
+
+    GeoCoord g4;
+    setGeoDegs(&g4, 2, -3E39);
+    t_assert(H3_EXPORT(geoToH3)(&g4, 0) == 0, "extreme negative longitude");
+}
+
 TEST(h3IsValidAtResolution) {
     for (int i = 0; i <= MAX_H3_RES; i++) {
         GeoCoord geoCoord = {0, 0};

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -30,15 +30,39 @@
 BEGIN_TESTS(h3Index);
 
 TEST(geoToH3ExtremeCoordinates) {
+    // Check that none of these cause crashes.
     GeoCoord g = {0, 1E45};
-    t_assert(H3_EXPORT(geoToH3)(&g, 14) == 0, "extreme longitude");
+    H3_EXPORT(geoToH3)(&g, 14);
 
     GeoCoord g2 = {1E46, 1E45};
-    t_assert(H3_EXPORT(geoToH3)(&g2, 15) == 0, "extreme latitude longitude");
+    H3_EXPORT(geoToH3)(&g2, 15);
 
     GeoCoord g4;
     setGeoDegs(&g4, 2, -3E39);
-    t_assert(H3_EXPORT(geoToH3)(&g4, 0) == 0, "extreme negative longitude");
+    H3_EXPORT(geoToH3)(&g4, 0);
+}
+
+TEST(faceIjkToH3ExtremeCoordinates) {
+    FaceIJK fijk0I = {0, {3, 0, 0}};
+    t_assert(_faceIjkToH3(&fijk0I, 0) == 0, "i out of bounds at res 0");
+    FaceIJK fijk0J = {1, {0, 4, 0}};
+    t_assert(_faceIjkToH3(&fijk0J, 0) == 0, "j out of bounds at res 0");
+    FaceIJK fijk0K = {2, {2, 0, 5}};
+    t_assert(_faceIjkToH3(&fijk0K, 0) == 0, "k out of bounds at res 0");
+
+    FaceIJK fijk1I = {3, {6, 0, 0}};
+    t_assert(_faceIjkToH3(&fijk1I, 1) == 0, "i out of bounds at res 1");
+    FaceIJK fijk1J = {4, {0, 7, 1}};
+    t_assert(_faceIjkToH3(&fijk1J, 1) == 0, "j out of bounds at res 1");
+    FaceIJK fijk1K = {5, {2, 0, 8}};
+    t_assert(_faceIjkToH3(&fijk1K, 1) == 0, "k out of bounds at res 1");
+
+    FaceIJK fijk2I = {6, {18, 0, 0}};
+    t_assert(_faceIjkToH3(&fijk2I, 2) == 0, "i out of bounds at res 2");
+    FaceIJK fijk2J = {7, {0, 19, 1}};
+    t_assert(_faceIjkToH3(&fijk2J, 2) == 0, "j out of bounds at res 2");
+    FaceIJK fijk2K = {8, {2, 0, 20}};
+    t_assert(_faceIjkToH3(&fijk2K, 2) == 0, "k out of bounds at res 2");
 }
 
 TEST(h3IsValidAtResolution) {

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -42,6 +42,9 @@ extern const int baseCellNeighbor60CCWRots[NUM_BASE_CELLS][7];
 // resolution 0 base cell data lookup-table (global)
 extern const BaseCellData baseCellData[NUM_BASE_CELLS];
 
+/** Maximum input for any component to face-to-base-cell lookup functions */
+#define MAX_FACE_COORD 2
+
 // Internal functions
 int _isBaseCellPentagon(int baseCell);
 int _faceIjkToBaseCell(const FaceIJK* h);

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -152,6 +152,7 @@ int isResClassIII(int res);
 
 // Internal functions
 
+H3Index _faceIjkToH3(const FaceIJK* fijk, int res);
 int _h3LeadingNonZeroDigit(H3Index h);
 H3Index _h3RotatePent60ccw(H3Index h);
 H3Index _h3Rotate60ccw(H3Index h);

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -120,14 +120,15 @@
             H3_DIGIT_MASK)))
 
 /**
- * Sets a value in the reserved space. USE WISELY, PRODUCES INVALID ADDRESSES
+ * Sets a value in the reserved space. Setting to non-zero may produce invalid
+ * indexes.
  */
 #define H3_SET_RESERVED_BITS(h3, v)            \
     (h3) = (((h3)&H3_RESERVED_MASK_NEGATIVE) | \
             (((uint64_t)(v)) << H3_RESERVED_OFFSET))
 
 /**
- * Gets a value in the reserved space. SHOULD ALWAYS BE ZERO
+ * Gets a value in the reserved space. Should always be zero for valid indexes.
  */
 #define H3_GET_RESERVED_BITS(h3) \
     ((int)((((h3)&H3_RESERVED_MASK) >> H3_RESERVED_OFFSET)))
@@ -140,6 +141,11 @@
                        << ((MAX_H3_RES - (res)) * H3_PER_DIGIT_OFFSET)))) | \
             (((uint64_t)(digit))                                            \
              << ((MAX_H3_RES - (res)) * H3_PER_DIGIT_OFFSET)))
+
+/**
+ * Invalid index used to indicate an error from geoToH3 and related functions.
+ */
+#define H3_INVALID_INDEX 0
 
 void setH3Index(H3Index* h, int res, int baseCell, int initDigit);
 int isResClassIII(int res);

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -46,7 +46,7 @@ int H3_EXPORT(h3GetBaseCell)(H3Index h) { return H3_GET_BASE_CELL(h); }
  * @return The H3 index corresponding to the string argument, or 0 if invalid.
  */
 H3Index H3_EXPORT(stringToH3)(const char* str) {
-    H3Index h = 0;
+    H3Index h = H3_INVALID_INDEX;
     // If failed, h will be unmodified and we should return 0 anyways.
     sscanf(str, "%" PRIx64, &h);
     return h;
@@ -122,11 +122,11 @@ void setH3Index(H3Index* hp, int res, int baseCell, int initDigit) {
 H3Index H3_EXPORT(h3ToParent)(H3Index h, int parentRes) {
     int childRes = H3_GET_RESOLUTION(h);
     if (parentRes > childRes) {
-        return 0;
+        return H3_INVALID_INDEX;
     } else if (parentRes == childRes) {
         return h;
     } else if (parentRes < 0 || parentRes > MAX_H3_RES) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
     H3Index parentH = H3_SET_RESOLUTION(h, parentRes);
     for (int i = parentRes + 1; i <= childRes; i++) {
@@ -557,9 +557,10 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
 
     // check for res 0/base cell
     if (res == 0) {
-        if (fijk->coord.i > 2 || fijk->coord.j > 2 || fijk->coord.k > 2) {
+        if (fijk->coord.i > MAX_FACE_COORD || fijk->coord.j > MAX_FACE_COORD ||
+            fijk->coord.k > MAX_FACE_COORD) {
             // out of range input
-            return 0;
+            return H3_INVALID_INDEX;
         }
 
         H3_SET_BASE_CELL(h, _faceIjkToBaseCell(fijk));
@@ -599,9 +600,10 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
     // fijkBC should now hold the IJK of the base cell in the
     // coordinate system of the current face
 
-    if (fijkBC.coord.i > 2 || fijkBC.coord.j > 2 || fijkBC.coord.k > 2) {
+    if (fijkBC.coord.i > MAX_FACE_COORD || fijkBC.coord.j > MAX_FACE_COORD ||
+        fijkBC.coord.k > MAX_FACE_COORD) {
         // out of range input
-        return 0;
+        return H3_INVALID_INDEX;
     }
 
     // lookup the correct base cell
@@ -644,10 +646,10 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
  */
 H3Index H3_EXPORT(geoToH3)(const GeoCoord* g, int res) {
     if (res < 0 || res > MAX_H3_RES) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
     if (!isfinite(g->lat) || !isfinite(g->lon)) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
 
     FaceIJK fijk;

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -548,6 +548,7 @@ H3Index _h3Rotate60cw(H3Index h) {
  * Convert an FaceIJK address to the corresponding H3Index.
  * @param fijk The FaceIJK address.
  * @param res The cell resolution.
+ * @return The encoded H3Index (or 0 on failure).
  */
 H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
     // initialize the index

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -557,6 +557,11 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
 
     // check for res 0/base cell
     if (res == 0) {
+        if (fijk->coord.i > 2 || fijk->coord.j > 2 || fijk->coord.k > 2) {
+            // out of range input
+            return 0;
+        }
+
         H3_SET_BASE_CELL(h, _faceIjkToBaseCell(fijk));
         return h;
     }
@@ -593,6 +598,11 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
 
     // fijkBC should now hold the IJK of the base cell in the
     // coordinate system of the current face
+
+    if (fijkBC.coord.i > 2 || fijkBC.coord.j > 2 || fijkBC.coord.k > 2) {
+        // out of range input
+        return 0;
+    }
 
     // lookup the correct base cell
     int baseCell = _faceIjkToBaseCell(&fijkBC);

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -96,7 +96,7 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
                                            H3Index destination) {
     // Short-circuit and return an invalid index value if they are not neighbors
     if (H3_EXPORT(h3IndexesAreNeighbors)(origin, destination) == 0) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
 
     // Otherwise, determine the IJK direction from the origin to the destination
@@ -116,7 +116,7 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
     }
 
     // This should be impossible, return an invalid H3Index in this case;
-    return 0;  // LCOV_EXCL_LINE
+    return H3_INVALID_INDEX;  // LCOV_EXCL_LINE
 }
 
 /**


### PR DESCRIPTION
Increase the library's resilience to out of range and defective inputs.