### PR TITLE
Fix references lacking `H3_EXPORT`

### DIFF
--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -28,12 +28,12 @@ BEGIN_TESTS(compact);
 
 TEST(roundtrip) {
     int k = 9;
-    int hexCount = maxKringSize(k);
+    int hexCount = H3_EXPORT(maxKringSize)(k);
     int expectedCompactCount = 73;
 
     // Generate a set of hexagons to compact
     H3Index* sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
-    kRing(sunnyvale, k, sunnyvaleExpanded);
+    H3_EXPORT(kRing)(sunnyvale, k, sunnyvaleExpanded);
 
     H3Index* compressed = calloc(hexCount, sizeof(H3Index));
     int err = H3_EXPORT(compact)(sunnyvaleExpanded, compressed, hexCount);

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -91,7 +91,7 @@ TEST(h3IsValidBaseCell) {
         H3_SET_BASE_CELL(h, i);
         char failureMessage[BUFF_SIZE];
         sprintf(failureMessage, "h3IsValid failed on base cell %d", i);
-        t_assert(h3IsValid(h), failureMessage);
+        t_assert(H3_EXPORT(h3IsValid)(h), failureMessage);
 
         t_assert(H3_EXPORT(h3GetBaseCell)(h) == i,
                  "failed to recover base cell");
@@ -102,7 +102,7 @@ TEST(h3IsValidBaseCellInvalid) {
     H3Index hWrongBaseCell = H3_INIT;
     H3_SET_MODE(hWrongBaseCell, H3_HEXAGON_MODE);
     H3_SET_BASE_CELL(hWrongBaseCell, NUM_BASE_CELLS);
-    t_assert(!h3IsValid(hWrongBaseCell),
+    t_assert(!H3_EXPORT(h3IsValid)(hWrongBaseCell),
              "h3IsValid failed on invalid base cell");
 }
 
@@ -112,7 +112,7 @@ TEST(h3IsValidWithMode) {
         H3_SET_MODE(h, i);
         char failureMessage[BUFF_SIZE];
         sprintf(failureMessage, "h3IsValid failed on mode %d", i);
-        t_assert(!h3IsValid(h) || i == 1, failureMessage);
+        t_assert(!H3_EXPORT(h3IsValid)(h) || i == 1, failureMessage);
     }
 }
 
@@ -120,7 +120,7 @@ TEST(h3BadDigitInvalid) {
     H3Index h = H3_INIT;
     H3_SET_MODE(h, H3_HEXAGON_MODE);
     H3_SET_RESOLUTION(h, 1);
-    t_assert(!h3IsValid(h), "h3IsValid failed on too large digit");
+    t_assert(!H3_EXPORT(h3IsValid)(h), "h3IsValid failed on too large digit");
 }
 
 TEST(h3ToString) {

--- a/src/apps/testapps/testH3NeighborRotations.c
+++ b/src/apps/testapps/testH3NeighborRotations.c
@@ -97,7 +97,7 @@ void doCell(H3Index h, int maxK, TestOutput* testOutput) {
             testOutput->ret1++;
             int foundPent = 0;
             for (int i = 0; i < maxSz; i++) {
-                if (h3IsPentagon(kRingInternalOutput[i])) {
+                if (H3_EXPORT(h3IsPentagon)(kRingInternalOutput[i])) {
                     foundPent = 1;
                     break;
                 }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -189,7 +189,7 @@ void H3_EXPORT(h3ToChildren)(H3Index h, int childRes, H3Index* children) {
     }
     int bufferSize = H3_EXPORT(maxH3ToChildrenSize)(h, childRes);
     int bufferChildStep = (bufferSize / 7);
-    int isAPentagon = h3IsPentagon(h);
+    int isAPentagon = H3_EXPORT(h3IsPentagon)(h);
     for (int i = 0; i < 7; i++) {
         if (!isAPentagon || i != K_AXES_DIGIT) {
             H3_EXPORT(h3ToChildren)(makeDirectChild(h, i), childRes, children);
@@ -281,7 +281,8 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
             if (hashSetArray[i] == 0) continue;
             int count = H3_GET_RESERVED_BITS(hashSetArray[i]) + 1;
             // Include the deleted direction for pentagons as implicitly "there"
-            if (h3IsPentagon(hashSetArray[i] & H3_RESERVED_MASK_NEGATIVE)) {
+            if (H3_EXPORT(h3IsPentagon)(hashSetArray[i] &
+                                        H3_RESERVED_MASK_NEGATIVE)) {
                 // We need this later on, no need to recalculate
                 H3_SET_RESERVED_BITS(hashSetArray[i], count);
                 // Increment count after setting the reserved bits,
@@ -761,7 +762,8 @@ void H3_EXPORT(h3ToGeo)(H3Index h3, GeoCoord* g) {
 void H3_EXPORT(h3ToGeoBoundary)(H3Index h3, GeoBoundary* gb) {
     FaceIJK fijk;
     _h3ToFaceIjk(h3, &fijk);
-    _faceIjkToGeoBoundary(&fijk, H3_GET_RESOLUTION(h3), h3IsPentagon(h3), gb);
+    _faceIjkToGeoBoundary(&fijk, H3_GET_RESOLUTION(h3),
+                          H3_EXPORT(h3IsPentagon)(h3), gb);
 }
 
 /**


### PR DESCRIPTION
Out of curiosity, tried building with `-DH3_PREFIX=h3`. Got compilation and linking errors. These are the fixes I made locally.