### PR TITLE
Use default in switch with assertion

### DIFF
--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -594,6 +594,7 @@ void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g) {
                     edge0 = &v1;
                     edge1 = &v2;
                     break;
+                case KI:
                 default:
                     assert(adjacentFaceDir[tmpFijk.face][fijk.face] == KI);
                     edge0 = &v2;
@@ -747,6 +748,7 @@ void _faceIjkToGeoBoundary(const FaceIJK* h, int res, int isPentagon,
                     edge0 = &v1;
                     edge1 = &v2;
                     break;
+                case KI:
                 default:
                     assert(adjacentFaceDir[centerIJK.face][face2] == KI);
                     edge0 = &v2;

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -19,6 +19,7 @@
  */
 
 #include "faceijk.h"
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -593,7 +594,8 @@ void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g) {
                     edge0 = &v1;
                     edge1 = &v2;
                     break;
-                case KI:
+                default:
+                    assert(adjacentFaceDir[tmpFijk.face][fijk.face] == KI);
                     edge0 = &v2;
                     edge1 = &v0;
                     break;
@@ -745,7 +747,8 @@ void _faceIjkToGeoBoundary(const FaceIJK* h, int res, int isPentagon,
                     edge0 = &v1;
                     edge1 = &v2;
                     break;
-                case KI:
+                default:
+                    assert(adjacentFaceDir[centerIJK.face][face2] == KI);
                     edge0 = &v2;
                     edge1 = &v0;
                     break;


### PR DESCRIPTION
If you run `cmake -DCMAKE_BUILD_TYPE=Release` for the build, you might see this warning:

```
h3/src/h3lib/lib/faceijk.c:604:13: warning: ‘edge1’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             _v2dIntersect(&orig2d0, &orig2d1, edge0, edge1, &inter);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

There are a few more of the same type. I tracked down the root cause is the switch statements. In C, an enum isn't guaranteed to be the only values passed in. For example:

```
typedef enum my_enum { x = 1, y = 2, z = 3 } my_enum;
void func(my_enum e) {
    switch (e) {
    case x:
        /* ... */
    case y:
        /* ... */
    case z:
        /* ... */
    }
    /* Do stuff */
}
/* In some code later on. */
func((my_enum) 5);
```

In the case above, `5` is not handled correctly in the switch. So I've submitted this pull request to modify the switch case like so.

```
void func(my_enum e) {
    switch (e) {
    case x:
        /* ... */
    case y:
        /* ... */
    default:
        assert(e == z);
        /* ... */
    }
    /* Do stuff */
}
```

I've argued for this position [elsewhere](https://github.com/census-instrumentation/opencensus-cpp/issues/79#issuecomment-370602770), with some disagreement, so I understand if you do not accept this PR.