### PR TITLE
Replace existing bundle/styles with new bundle/styles

### DIFF
--- a/website/scripts/build-to-gh-pages.sh
+++ b/website/scripts/build-to-gh-pages.sh
@@ -30,6 +30,7 @@ git checkout "$TARGET_BRANCH"
 cd ..
 # Copy over the .gitignore file
 git checkout $CURRENT_COMMIT -- .gitignore
+git rm bundle-*.js styles-*.css
 cp -R website/dist/* .
 git add .
 git commit


### PR DESCRIPTION
This fixes a small bug in the publish to gh-pages script, it wouldn't drop the old bundle and styles when making the commit.