### PR TITLE
Change signature of h3NeighborRotations to not accept `CoordIJK*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
 ## [Unreleased]
+### Changed
+- Changed signature of internal function h3NeighborRotations.
 
 ## [3.0.5] - 2018-04-27
 ### Fixed

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,6 +325,14 @@ TEST(kRing_equals_kRingInternal) {
             free(children);
         }
     }
+}
+
+TEST(h3NeighborRotations_identity) {
+    // This is undefined behavior, but it's helpful for it to make sense.
+    H3Index origin = 0x811d7ffffffffffL;
+    int rotations = 0;
+    t_assert(h3NeighborRotations(origin, CENTER_DIGIT, &rotations) == origin,
+             "Moving to self goes to self");
 }
 
 TEST(cwOffsetPent) {

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -27,8 +27,7 @@
 #include "vertexGraph.h"
 
 // neighbor along the ijk coordinate system of the current face, rotated
-H3Index h3NeighborRotations(H3Index origin, const CoordIJK* translationIjk,
-                            int* rotations);
+H3Index h3NeighborRotations(H3Index origin, int dir, int* rotations);
 
 // k-ring implementation
 void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -54,6 +54,23 @@ static const CoordIJK UNIT_VECS[] = {
     {1, 1, 0}   // direction 6
 };
 
+// H3 digit representing ijk+ axes direction
+// see also unitVecs in coordijk.c
+/** H3 digit in center */
+#define CENTER_DIGIT 0
+/** H3 digit in k-axes direction */
+#define K_AXES_DIGIT 1
+/** H3 digit in j-axes direction */
+#define J_AXES_DIGIT 2
+/** H3 digit in j == k direction */
+#define JK_AXES_DIGIT (K_AXES_DIGIT | J_AXES_DIGIT) /* 3 */
+/** H3 digit in i-axes direction */
+#define I_AXES_DIGIT 4
+/** H3 digit in i == k direction */
+#define IK_AXES_DIGIT (I_AXES_DIGIT | K_AXES_DIGIT) /* 5 */
+/** H3 digit in i == j direction */
+#define IJ_AXES_DIGIT (I_AXES_DIGIT | J_AXES_DIGIT) /* 6 */
+
 // Internal functions
 
 void _setIJK(CoordIJK* ijk, int i, int j, int k);
@@ -74,5 +91,7 @@ void _downAp3r(CoordIJK* ijk);
 void _neighbor(CoordIJK* ijk, int digit);
 void _ijkRotate60ccw(CoordIJK* ijk);
 void _ijkRotate60cw(CoordIJK* ijk);
+int _rotate60ccw(int digit);
+int _rotate60cw(int digit);
 
 #endif

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -59,23 +59,6 @@ typedef struct {
 /** JK quadrant faceNeighbors table direction */
 #define JK 3
 
-// H3 digit representing ijk+ axes direction
-// see also unitVecs in coordijk.c
-/** H3 digit in center */
-#define CENTER_DIGIT 0
-/** H3 digit in k-axes direction */
-#define K_AXES_DIGIT 1
-/** H3 digit in j-axes direction */
-#define J_AXES_DIGIT 2
-/** H3 digit in j == k direction */
-#define JK_AXES_DIGIT (K_AXES_DIGIT | J_AXES_DIGIT) /* 3 */
-/** H3 digit in i-axes direction */
-#define I_AXES_DIGIT 4
-/** H3 digit in i == k direction */
-#define IK_AXES_DIGIT (I_AXES_DIGIT | K_AXES_DIGIT) /* 5 */
-/** H3 digit in i == j direction */
-#define IJ_AXES_DIGIT (I_AXES_DIGIT | J_AXES_DIGIT) /* 6 */
-
 // Internal functions
 
 void _geoToFaceIjk(const GeoCoord* g, int res, FaceIJK* h);

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -54,13 +54,13 @@
  *     \\2/
  * </pre>
  */
-static const CoordIJK DIRECTIONS[6] = {{0, 1, 0}, {0, 1, 1}, {0, 0, 1},
-                                       {1, 0, 1}, {1, 0, 0}, {1, 1, 0}};
+static const int DIRECTIONS[6] = {J_AXES_DIGIT,  JK_AXES_DIGIT, K_AXES_DIGIT,
+                                  IK_AXES_DIGIT, I_AXES_DIGIT,  IJ_AXES_DIGIT};
 
 /**
  * Direction used for traversing to the next outward hexagonal ring.
  */
-static const CoordIJK NEXT_RING_DIRECTION = {1, 0, 0};
+static const int NEXT_RING_DIRECTION = I_AXES_DIGIT;
 
 /**
  * Maximum number of indices that result from the kRing algorithm with the given
@@ -166,40 +166,32 @@ void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,
     // Recurse to all neighbors in no particular order.
     for (int i = 0; i < 6; i++) {
         int rotations = 0;
-        _kRingInternal(h3NeighborRotations(origin, &DIRECTIONS[i], &rotations),
+        _kRingInternal(h3NeighborRotations(origin, DIRECTIONS[i], &rotations),
                        k, out, distances, maxIdx, curK + 1);
     }
 }
 
 /**
- * Returns the hexagon index neighboring the origin, in the direction of
- * translationIjk.
- *
- * Calling this function with the absolute value of i, j, or k greater than 1
- * results in undefined behavior.
+ * Returns the hexagon index neighboring the origin, in the direction dir.
  *
  * Implementation note: The only reachable case where this returns 0 is if the
  * origin is a pentagon and the translation is in the k direction. Thus,
  * 0 can only be returned if origin is a pentagon.
  *
  * @param origin Origin index
- * @param translationIjk Direction to move in
+ * @param dir Direction to move in
  * @param rotations Number of ccw rotations to perform to reorient the
  *                  translation vector. Will be modified to the new number of
  *                  rotations to perform (such as when crossing a face edge.)
  * @return H3Index of the specified neighbor or 0 if deleted k-subsequence
  *         distortion is encountered.
  */
-H3Index h3NeighborRotations(H3Index origin, const CoordIJK* translationIjk,
-                            int* rotations) {
+H3Index h3NeighborRotations(H3Index origin, int dir, int* rotations) {
     H3Index out = origin;
-    CoordIJK adjustment = *translationIjk;
 
     for (int i = 0; i < *rotations; i++) {
-        _ijkRotate60ccw(&adjustment);
+        dir = _rotate60ccw(dir);
     }
-
-    int dir = _unitIjkToDigit(&adjustment);
 
     int newRotations = 0;
     int oldBaseCell = H3_GET_BASE_CELL(out);
@@ -425,7 +417,7 @@ int H3_EXPORT(hexRangeDistances)(H3Index origin, int k, H3Index* out,
             // Not putting in the output set as it will be done later, at
             // the end of this ring.
             origin =
-                h3NeighborRotations(origin, &NEXT_RING_DIRECTION, &rotations);
+                h3NeighborRotations(origin, NEXT_RING_DIRECTION, &rotations);
             if (origin == 0) {
                 // Should not be possible because `origin` would have to be a
                 // pentagon
@@ -438,8 +430,7 @@ int H3_EXPORT(hexRangeDistances)(H3Index origin, int k, H3Index* out,
             }
         }
 
-        origin =
-            h3NeighborRotations(origin, &DIRECTIONS[direction], &rotations);
+        origin = h3NeighborRotations(origin, DIRECTIONS[direction], &rotations);
         if (origin == 0) {
             // Should not be possible because `origin` would have to be a
             // pentagon
@@ -521,7 +512,7 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index* out) {
     }
 
     for (int ring = 0; ring < k; ring++) {
-        origin = h3NeighborRotations(origin, &NEXT_RING_DIRECTION, &rotations);
+        origin = h3NeighborRotations(origin, NEXT_RING_DIRECTION, &rotations);
         if (origin == 0) {
             // Should not be possible because `origin` would have to be a
             // pentagon
@@ -541,7 +532,7 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index* out) {
     for (int direction = 0; direction < 6; direction++) {
         for (int pos = 0; pos < k; pos++) {
             origin =
-                h3NeighborRotations(origin, &DIRECTIONS[direction], &rotations);
+                h3NeighborRotations(origin, DIRECTIONS[direction], &rotations);
             if (origin == 0) {
                 // Should not be possible because `origin` would have to be a
                 // pentagon

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -258,11 +258,12 @@ int _unitIjkToDigit(const CoordIJK* ijk) {
     _ijkNormalize(&c);
 
     int digit = INVALID_DIGIT;
-    for (int i = 0; i < 7; i++)
+    for (int i = 0; i < 7; i++) {
         if (_ijkMatches(&c, &UNIT_VECS[i])) {
             digit = i;
             break;
         }
+    }
 
     return digit;
 }
@@ -400,6 +401,54 @@ void _ijkRotate60cw(CoordIJK* ijk) {
     _ijkAdd(ijk, &kVec, ijk);
 
     _ijkNormalize(ijk);
+}
+
+/**
+ * Rotates indexing digit 60 degrees counter-clockwise. Returns result.
+ *
+ * @param digit Indexing digit (between 1 and 6 inclusive)
+ */
+int _rotate60ccw(int digit) {
+    switch (digit) {
+        case K_AXES_DIGIT:
+            return IK_AXES_DIGIT;
+        case IK_AXES_DIGIT:
+            return I_AXES_DIGIT;
+        case I_AXES_DIGIT:
+            return IJ_AXES_DIGIT;
+        case IJ_AXES_DIGIT:
+            return J_AXES_DIGIT;
+        case J_AXES_DIGIT:
+            return JK_AXES_DIGIT;
+        case JK_AXES_DIGIT:
+            return K_AXES_DIGIT;
+        default:
+            return digit;
+    }
+}
+
+/**
+ * Rotates indexing digit 60 degrees clockwise. Returns result.
+ *
+ * @param digit Indexing digit (between 1 and 6 inclusive)
+ */
+int _rotate60cw(int digit) {
+    switch (digit) {
+        case K_AXES_DIGIT:
+            return JK_AXES_DIGIT;
+        case JK_AXES_DIGIT:
+            return J_AXES_DIGIT;
+        case J_AXES_DIGIT:
+            return IJ_AXES_DIGIT;
+        case IJ_AXES_DIGIT:
+            return I_AXES_DIGIT;
+        case I_AXES_DIGIT:
+            return IK_AXES_DIGIT;
+        case IK_AXES_DIGIT:
+            return K_AXES_DIGIT;
+        default:
+            return digit;
+    }
 }
 
 /**

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -461,20 +461,11 @@ int _h3LeadingNonZeroDigit(H3Index h) {
  */
 H3Index _h3RotatePent60ccw(H3Index h) {
     // rotate in place; skips any leading 1 digits (k-axis)
-    const int rotDigit[] = {
-        0,  // original digit 0
-        5,  // original digit 1
-        3,  // original digit 2
-        1,  // original digit 3
-        6,  // original digit 4
-        4,  // original digit 5
-        2   // original digit 6
-    };
 
     int foundFirstNonZeroDigit = 0;
     for (int r = 1, res = H3_GET_RESOLUTION(h); r <= res; r++) {
         // rotate this digit
-        H3_SET_INDEX_DIGIT(h, r, rotDigit[H3_GET_INDEX_DIGIT(h, r)]);
+        H3_SET_INDEX_DIGIT(h, r, _rotate60ccw(H3_GET_INDEX_DIGIT(h, r)));
 
         // look for the first non-zero digit so we
         // can adjust for deleted k-axes sequence
@@ -495,19 +486,9 @@ H3Index _h3RotatePent60ccw(H3Index h) {
  * @param h The H3Index.
  */
 H3Index _h3Rotate60ccw(H3Index h) {
-    const int rotDigit[] = {
-        0,  // original digit 0
-        5,  // original digit 1
-        3,  // original digit 2
-        1,  // original digit 3
-        6,  // original digit 4
-        4,  // original digit 5
-        2   // original digit 6
-    };
-
     for (int r = 1, res = H3_GET_RESOLUTION(h); r <= res; r++) {
         int oldDigit = H3_GET_INDEX_DIGIT(h, r);
-        H3_SET_INDEX_DIGIT(h, r, rotDigit[oldDigit]);
+        H3_SET_INDEX_DIGIT(h, r, _rotate60ccw(oldDigit));
     }
 
     return h;
@@ -518,18 +499,8 @@ H3Index _h3Rotate60ccw(H3Index h) {
  * @param h The H3Index.
  */
 H3Index _h3Rotate60cw(H3Index h) {
-    const int rotDigit[] = {
-        0,  // original digit 0
-        3,  // original digit 1
-        6,  // original digit 2
-        2,  // original digit 3
-        5,  // original digit 4
-        1,  // original digit 5
-        4   // original digit 6
-    };
-
     for (int r = 1, res = H3_GET_RESOLUTION(h); r <= res; r++) {
-        H3_SET_INDEX_DIGIT(h, r, rotDigit[H3_GET_INDEX_DIGIT(h, r)]);
+        H3_SET_INDEX_DIGIT(h, r, _rotate60cw(H3_GET_INDEX_DIGIT(h, r)));
     }
 
     return h;

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -108,7 +108,7 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
     H3Index neighbor;
     for (int i = 1; i < 7; i++) {
         int rotations = 0;
-        neighbor = h3NeighborRotations(origin, &UNIT_VECS[i], &rotations);
+        neighbor = h3NeighborRotations(origin, i, &rotations);
         if (neighbor == destination) {
             H3_SET_RESERVED_BITS(output, i);
             return output;
@@ -140,8 +140,8 @@ H3Index H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(H3Index edge) {
     int direction = H3_GET_RESERVED_BITS(edge);
     int rotations = 0;
     H3Index destination = h3NeighborRotations(
-        H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edge),
-        &UNIT_VECS[direction], &rotations);
+        H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edge), direction,
+        &rotations);
     return destination;
 }
 

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -106,11 +106,11 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
     // Checks each neighbor, in order, to determine which direction the
     // destination neighbor is located.
     H3Index neighbor;
-    for (int i = 1; i < 7; i++) {
+    for (int direction = 1; direction < 7; direction++) {
         int rotations = 0;
-        neighbor = h3NeighborRotations(origin, i, &rotations);
+        neighbor = h3NeighborRotations(origin, direction, &rotations);
         if (neighbor == destination) {
-            H3_SET_RESERVED_BITS(output, i);
+            H3_SET_RESERVED_BITS(output, direction);
             return output;
         }
     }


### PR DESCRIPTION
This always required looking up the CoordIJK structure in some array, and then prompty changing it back to an indexing digit. Using an indexing digit also allows for some code to be cleaned up (deduplicated) in H3 index rotation.

This could set up for using an enum type for the indexing digits, which might provide some compiler niceties.

Did not clean up some defines like UNIT_VECS, which could now be replaced with some bitwise manipulation in `_unitIjkToDigit` (changes undefined behavior though.)