### PR TITLE
Add examples for compact, kring, unidirectional edge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,10 @@ set(APP_SOURCE_FILES
     src/apps/applib/lib/test.c)
 set(EXAMPLE_SOURCE_FILES
     examples/index.c
-    examples/distance.c)
+    examples/distance.c
+    examples/neighbors.c
+    examples/compact.c
+    examples/edge.c)
 set(OTHER_SOURCE_FILES
     src/apps/filters/h3ToGeo.c
     src/apps/filters/h3ToComponents.c

--- a/examples/compact.c
+++ b/examples/compact.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Example program that compacts a set of indexes, and then uncompacts
+ * to the original set.
+ */
+
+#include <assert.h>
+#include <h3/h3api.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    H3Index input[] = {
+        // All with the same parent index
+        0x8a2a1072b587fffL, 0x8a2a1072b5b7fffL, 0x8a2a1072b597fffL,
+        0x8a2a1072b59ffffL, 0x8a2a1072b58ffffL, 0x8a2a1072b5affffL,
+        0x8a2a1072b5a7fffL,
+        // These don't have the same parent indexas above.
+        0x8a2a1070c96ffffL, 0x8a2a1072b4b7fffL, 0x8a2a1072b4a7fffL};
+    int inputSize = sizeof(input) / sizeof(H3Index);
+
+    H3Index* compacted = calloc(inputSize, sizeof(H3Index));
+    // neighboring is the input set to be compacted
+    int err = compact(input, compacted, inputSize);
+    assert(err == 0);
+
+    int count = 0;
+    printf("Compacted:\n");
+    for (int i = 0; i < inputSize; i++) {
+        if (compacted[i] != 0) {
+            printf("%llx\n", compacted[i]);
+            count++;
+        }
+    }
+    printf("Compacted to %d indexes.\n", count);
+
+    int uncompactRes = 10;
+    int uncompactedSize = maxUncompactSize(compacted, inputSize, uncompactRes);
+    H3Index* uncompacted = calloc(uncompactedSize, sizeof(H3Index));
+    int err2 =
+        uncompact(compacted, count, uncompacted, uncompactedSize, uncompactRes);
+    assert(err2 == 0);
+
+    printf("Uncompacted:\n");
+    for (int i = 0; i < uncompactedSize; i++) {
+        if (uncompacted[i] != 0) {
+            printf("%llx\n", uncompacted[i]);
+        }
+    }
+
+    free(compacted);
+    free(uncompacted);
+}

--- a/examples/compact.c
+++ b/examples/compact.c
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
         0x8a2a1072b587fffL, 0x8a2a1072b5b7fffL, 0x8a2a1072b597fffL,
         0x8a2a1072b59ffffL, 0x8a2a1072b58ffffL, 0x8a2a1072b5affffL,
         0x8a2a1072b5a7fffL,
-        // These don't have the same parent indexas above.
+        // These don't have the same parent index as above.
         0x8a2a1070c96ffffL, 0x8a2a1072b4b7fffL, 0x8a2a1072b4a7fffL};
     int inputSize = sizeof(input) / sizeof(H3Index);
     printf("Starting with %d indexes.\n", inputSize);

--- a/examples/compact.c
+++ b/examples/compact.c
@@ -31,35 +31,41 @@ int main(int argc, char* argv[]) {
         // These don't have the same parent indexas above.
         0x8a2a1070c96ffffL, 0x8a2a1072b4b7fffL, 0x8a2a1072b4a7fffL};
     int inputSize = sizeof(input) / sizeof(H3Index);
+    printf("Starting with %d indexes.\n", inputSize);
 
     H3Index* compacted = calloc(inputSize, sizeof(H3Index));
-    // neighboring is the input set to be compacted
     int err = compact(input, compacted, inputSize);
+    // An error case can occur on e.g. duplicate input.
     assert(err == 0);
 
-    int count = 0;
+    int compactedCount = 0;
     printf("Compacted:\n");
     for (int i = 0; i < inputSize; i++) {
         if (compacted[i] != 0) {
             printf("%llx\n", compacted[i]);
-            count++;
+            compactedCount++;
         }
     }
-    printf("Compacted to %d indexes.\n", count);
+    printf("Compacted to %d indexes.\n", compactedCount);
 
     int uncompactRes = 10;
     int uncompactedSize = maxUncompactSize(compacted, inputSize, uncompactRes);
     H3Index* uncompacted = calloc(uncompactedSize, sizeof(H3Index));
-    int err2 =
-        uncompact(compacted, count, uncompacted, uncompactedSize, uncompactRes);
+    int err2 = uncompact(compacted, compactedCount, uncompacted,
+                         uncompactedSize, uncompactRes);
+    // An error case could happen if the output array is too small, or indexes
+    // have a higher resolution than uncompactRes.
     assert(err2 == 0);
 
+    int uncompactedCount = 0;
     printf("Uncompacted:\n");
     for (int i = 0; i < uncompactedSize; i++) {
         if (uncompacted[i] != 0) {
             printf("%llx\n", uncompacted[i]);
+            uncompactedCount++;
         }
     }
+    printf("Uncompacted to %d indexes.\n", uncompactedCount);
 
     free(compacted);
     free(uncompacted);

--- a/examples/edge.c
+++ b/examples/edge.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Example program that finds the edge between two indexes and prints their
+ * boundary vertices.
+ */
+
+#include <h3/h3api.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    H3Index origin = 0x8a2a1072b59ffffL;
+    H3Index destination = 0x8a2a1072b597fffL;  // north of the origin
+
+    H3Index edge = getH3UnidirectionalEdge(origin, destination);
+    printf("The edge is %llx\n", edge);
+
+    GeoBoundary boundary;
+    getH3UnidirectionalEdgeBoundary(edge, &boundary);
+    for (int v = 0; v < boundary.numVerts; v++) {
+        printf("Edge vertex #%d: %lf, %lf\n", v,
+               radsToDegs(boundary.verts[v].lat),
+               radsToDegs(boundary.verts[v].lon));
+    }
+}

--- a/examples/neighbors.c
+++ b/examples/neighbors.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Example program that finds neighboring indexes (within distance 2)
+ * of an index.
+ */
+
+#include <h3/h3api.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    H3Index indexed = 0x8a2a1072b59ffffL;
+    // Distance away from the origin to find:
+    int k = 2;
+
+    int maxNeighboring = maxKringSize(k);
+    H3Index* neighboring = calloc(maxNeighboring, sizeof(H3Index));
+    kRing(indexed, k, neighboring);
+
+    printf("Neighbors:\n");
+    for (int i = 0; i < maxNeighboring; i++) {
+        // Some indexes may be 0 to indicate fewer than the maximum
+        // number of indexes.
+        if (neighboring[i] != 0) {
+            printf("%llx\n", neighboring[i]);
+        }
+    }
+
+    free(neighboring);
+}

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -354,8 +354,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
  * @param maxHexes The size of the output array to bound check against
  * @param res The hexagon resolution to decompress to
  * @return An error code if output array is too small or any hexagon is
- * smaller
- * than the output resolution.
+ * smaller than the output resolution.
  */
 int H3_EXPORT(uncompact)(const H3Index* compactedSet, const int numHexes,
                          H3Index* h3Set, const int maxHexes, const int res) {


### PR DESCRIPTION
Adds some additional example programs.

It would be nice for CI to also check that the examples run (same for the filters), but that doesn't work directly because the examples assume `h3api.h` is at a different path. Perhaps this is something that can be added to the Travis CI config instead of to CMake? Or add a target for building the examples that can be run after installing in Travis CI?