### PR TITLE
Validate input when getting the origin or destination of an edge

### DIFF
--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -104,6 +104,25 @@ TEST(getH3UnidirectionalEdgeAndFriends) {
     t_assert(notEdge == 0, "Non-neighbors can't have edges");
 }
 
+TEST(getOriginH3IndexFromUnidirectionalEdgeBadInput) {
+    H3Index hexagon = 0x891ea6d6533ffffl;
+
+    t_assert(H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(hexagon) == 0,
+             "getting the origin from a hexagon index returns 0");
+    t_assert(H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(0) == 0,
+             "getting the origin from a null index returns 0");
+}
+
+TEST(getDestinationH3IndexFromUnidirectionalEdge) {
+    H3Index hexagon = 0x891ea6d6533ffffl;
+
+    t_assert(
+        H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(hexagon) == 0,
+        "getting the destination from a hexagon index returns 0");
+    t_assert(H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(0) == 0,
+             "getting the destination from a null index returns 0");
+}
+
 TEST(getH3UnidirectionalEdgeFromPentagon) {
     H3Index pentagon;
     setH3Index(&pentagon, 0, 4, 0);

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -125,6 +125,9 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
  * @return The origin H3 hexagon index
  */
 H3Index H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(H3Index edge) {
+    if (H3_GET_MODE(edge) != H3_UNIEDGE_MODE) {
+        return 0;
+    }
     H3Index origin = edge;
     H3_SET_MODE(origin, H3_HEXAGON_MODE);
     H3_SET_RESERVED_BITS(origin, 0);
@@ -137,6 +140,9 @@ H3Index H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(H3Index edge) {
  * @return The destination H3 hexagon index
  */
 H3Index H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(H3Index edge) {
+    if (H3_GET_MODE(edge) != H3_UNIEDGE_MODE) {
+        return 0;
+    }
     int direction = H3_GET_RESERVED_BITS(edge);
     int rotations = 0;
     H3Index destination = h3NeighborRotations(

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -126,7 +126,7 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
  */
 H3Index H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(H3Index edge) {
     if (H3_GET_MODE(edge) != H3_UNIEDGE_MODE) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
     H3Index origin = edge;
     H3_SET_MODE(origin, H3_HEXAGON_MODE);
@@ -141,7 +141,7 @@ H3Index H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(H3Index edge) {
  */
 H3Index H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(H3Index edge) {
     if (H3_GET_MODE(edge) != H3_UNIEDGE_MODE) {
-        return 0;
+        return H3_INVALID_INDEX;
     }
     int direction = H3_GET_RESERVED_BITS(edge);
     int rotations = 0;


### PR DESCRIPTION
Per #73, adding validation for `getOriginH3IndexFromUnidirectionalEdge` and `getDestinationH3IndexFromUnidirectionalEdge` to avoid unexpected results for bad input.

I've said this before, but these are really verbosely named functions. Couldn't we have gone with `getUnidirectionalEdgeOrigin`?