### PR TITLE
Fix for edge directions in getH3UnidirectionalEdgeBoundary

### DIFF
--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -213,6 +213,8 @@ TEST(getH3UnidirectionalEdgeBoundary) {
     const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
                                  {5, 0}, {4, 5}, {0, 1}};
 
+    // TODO: The current implementation relies on lat/lon comparison and fails on
+    // resolutions finer than 12
     for (int res = 0; res < 13; res++) {
         sf = H3_EXPORT(geoToH3)(&sfGeo, res);
         H3_EXPORT(h3ToGeoBoundary)(sf, &boundary);
@@ -241,6 +243,8 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
     const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
                                  {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
 
+    // TODO: The current implementation relies on lat/lon comparison and fails on
+    // resolutions finer than 12
     for (int res = 1; res < 13; res += 2) {
         setH3Index(&pentagon, res, 24, 0);
         H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
@@ -279,6 +283,8 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassII) {
     const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
                                  {4, 0},   {3, 4}, {0, 1}};
 
+    // TODO: The current implementation relies on lat/lon comparison and fails on
+    // resolutions finer than 12
     for (int res = 0; res < 12; res += 2) {
         setH3Index(&pentagon, res, 24, 0);
         H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -210,7 +210,7 @@ TEST(getH3UnidirectionalEdgeBoundary) {
     GeoBoundary edgeBoundary;
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
-    int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
+    const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
                                  {5, 0}, {4, 5}, {0, 1}};
 
     for (int res = 0; res < 13; res++) {
@@ -238,7 +238,7 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
     GeoBoundary edgeBoundary;
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
-    int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
+    const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
                                  {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
 
     for (int res = 1; res < 13; res += 2) {
@@ -276,7 +276,7 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassII) {
     GeoBoundary edgeBoundary;
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
-    int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
+    const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
                                  {4, 0},   {3, 4}, {0, 1}};
 
     for (int res = 0; res < 12; res += 2) {

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -211,10 +211,10 @@ TEST(getH3UnidirectionalEdgeBoundary) {
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
     const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
-                                 {5, 0}, {4, 5}, {0, 1}};
+                                       {5, 0}, {4, 5}, {0, 1}};
 
-    // TODO: The current implementation relies on lat/lon comparison and fails on
-    // resolutions finer than 12
+    // TODO: The current implementation relies on lat/lon comparison and fails
+    // on resolutions finer than 12
     for (int res = 0; res < 13; res++) {
         sf = H3_EXPORT(geoToH3)(&sfGeo, res);
         H3_EXPORT(h3ToGeoBoundary)(sf, &boundary);
@@ -241,10 +241,10 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
     const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
-                                 {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
+                                       {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
 
-    // TODO: The current implementation relies on lat/lon comparison and fails on
-    // resolutions finer than 12
+    // TODO: The current implementation relies on lat/lon comparison and fails
+    // on resolutions finer than 12
     for (int res = 1; res < 13; res += 2) {
         setH3Index(&pentagon, res, 24, 0);
         H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
@@ -281,10 +281,10 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassII) {
     STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
     const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
-                                 {4, 0},   {3, 4}, {0, 1}};
+                                       {4, 0},   {3, 4}, {0, 1}};
 
-    // TODO: The current implementation relies on lat/lon comparison and fails on
-    // resolutions finer than 12
+    // TODO: The current implementation relies on lat/lon comparison and fails
+    // on resolutions finer than 12
     for (int res = 0; res < 12; res += 2) {
         setH3Index(&pentagon, res, 24, 0);
         H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -213,7 +213,14 @@ void H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(H3Index origin,
     }
 }
 
-bool _hasMatchingVertex(const GeoCoord* vertex, const GeoBoundary* boundary) {
+/**
+ * Whether the given coordinate has a matching vertex in the given geo boundary.
+ * @param  vertex   Coordinate to check
+ * @param  boundary Geo boundary to look in
+ * @return          Whether a match was found
+ */
+static bool _hasMatchingVertex(const GeoCoord* vertex,
+                               const GeoBoundary* boundary) {
     for (int i = 0; i < boundary->numVerts; i++) {
         if (geoAlmostEqualThreshold(vertex, &boundary->verts[i], 0.000001)) {
             return true;
@@ -245,8 +252,6 @@ void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary* gb) {
         if (_hasMatchingVertex(&origin.verts[i], &destination)) {
             // If we are on vertex 0, we need to handle the case where it's the
             // end of the edge, not the beginning.
-            // TODO: This is fine for this limited case, but it might be
-            // better/cleaner to use a VertexGraph for this
             if (i == 0 &&
                 !_hasMatchingVertex(&origin.verts[i + 1], &destination)) {
                 postponedVertex = origin.verts[i];

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -213,7 +213,7 @@ void H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(H3Index origin,
     }
 }
 
-bool _hasMatchingVertex(GeoCoord* vertex, GeoBoundary* boundary) {
+bool _hasMatchingVertex(const GeoCoord* vertex, const GeoBoundary* boundary) {
     for (int i = 0; i < boundary->numVerts; i++) {
         if (geoAlmostEqualThreshold(vertex, &boundary->verts[i], 0.000001)) {
             return true;
@@ -232,6 +232,7 @@ void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary* gb) {
     GeoBoundary origin = {0};
     GeoBoundary destination = {0};
     GeoCoord postponedVertex = {0};
+    bool hasPostponedVertex = false;
 
     H3_EXPORT(h3ToGeoBoundary)
     (H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edge), &origin);
@@ -246,11 +247,10 @@ void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary* gb) {
             // end of the edge, not the beginning.
             // TODO: This is fine for this limited case, but it might be
             // better/cleaner to use a VertexGraph for this
-            printf("%d, %d\n", i,
-                   _hasMatchingVertex(&origin.verts[i + 1], &destination));
             if (i == 0 &&
                 !_hasMatchingVertex(&origin.verts[i + 1], &destination)) {
                 postponedVertex = origin.verts[i];
+                hasPostponedVertex = true;
             } else {
                 gb->verts[k] = origin.verts[i];
                 k++;
@@ -258,7 +258,7 @@ void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary* gb) {
         }
     }
     // If we postponed adding the last vertex, add it now
-    if (postponedVertex.lat && postponedVertex.lon) {
+    if (hasPostponedVertex) {
         gb->verts[k] = postponedVertex;
         k++;
     }


### PR DESCRIPTION
Fixes #75. This isn't the most elegant fix, but it does get the vertices into the correct order.

Longer term, I think the best option here is to do what we do in `h3SetToVertexGraph`, getting the edges and then walking them. But at the moment this was a bit too clunky to implement; it might be easier after a refactor of the `VertexGraph` structure.