### PR TITLE
Add h3Distance, and internal h3ToIjk and ijkDistance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The public API of this library consists of the functions declared in file
 
 ## [Unreleased]
 ### Added
-- h3ToIjk function for getting IJK+ coordinates from an index
-- ijkDistance function for determining the grid distance between IJK+ coordinates
-- h3Distance function for determining the grid distance between H3 indexes
+- `h3Distance` function for determining the grid distance between H3 indexes (#83)
+- Internal `h3ToIjk` function for getting IJK+ coordinates from an index (#83)
+- Internal `ijkDistance` function for determining the grid distance between IJK+ coordinates (#83)
 
 ## [3.0.8] - 2018-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The public API of this library consists of the functions declared in file
 - `h3Distance` function for determining the grid distance between H3 indexes (#83)
 - Internal `h3ToIjk` function for getting IJK+ coordinates from an index (#83)
 - Internal `ijkDistance` function for determining the grid distance between IJK+ coordinates (#83)
+- `h3ToIjk` filter application for experimenting with `h3ToIjk` (#83)
 
 ## [3.0.8] - 2018-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
 ## [Unreleased]
+### Added
+- h3ToIjk function for getting IJK+ coordinates from an index
+- ijkDistance function for determining the grid distance between IJK+ coordinates
+- h3Distance function for determining the grid distance between H3 indexes
 
 ## [3.0.8] - 2018-07-18
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(EXAMPLE_SOURCE_FILES
     examples/edge.c)
 set(OTHER_SOURCE_FILES
     src/apps/filters/h3ToGeo.c
+    src/apps/filters/h3ToIjk.c
     src/apps/filters/h3ToComponents.c
     src/apps/filters/geoToH3.c
     src/apps/filters/h3ToGeoBoundary.c
@@ -157,6 +158,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/mkRandGeo.c
     src/apps/testapps/testH3Api.c
     src/apps/testapps/testH3SetToLinkedGeo.c
+    src/apps/testapps/testH3ToIjk.c
     src/apps/miscapps/h3ToGeoBoundaryHier.c
     src/apps/miscapps/h3ToGeoHier.c
     src/apps/miscapps/generateBaseCellNeighbors.c
@@ -279,6 +281,7 @@ endmacro()
 add_h3_executable(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
+add_h3_executable(h3ToIjk src/apps/filters/h3ToIjk.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
 add_h3_executable(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
 add_h3_executable(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})
@@ -454,6 +457,7 @@ if(BUILD_TESTING)
     add_h3_test(testBBox src/apps/testapps/testBBox.c)
     add_h3_test(testVec2d src/apps/testapps/testVec2d.c)
     add_h3_test(testVec3d src/apps/testapps/testVec3d.c)
+    add_h3_test(testH3ToIjk src/apps/testapps/testH3ToIjk.c)
 
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 0)
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 1)

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -42,4 +42,8 @@ void geoBoundaryPrint(const GeoBoundary* b);
 void geoBoundaryPrintln(const GeoBoundary* b);
 int readBoundary(FILE* f, GeoBoundary* b);
 
+void iterateAllIndexesAtRes(int res, void (*callback)(H3Index));
+void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
+                                   int maxBaseCell);
+
 #endif

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -20,6 +20,7 @@
 #include "utility.h"
 #include <assert.h>
 #include <inttypes.h>
+#include <stackAlloc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "geoCoord.h"
@@ -184,7 +185,7 @@ void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
         H3Index bc;
         setH3Index(&bc, 0, i, 0);
         int childrenSz = H3_EXPORT(maxUncompactSize)(&bc, 1, res);
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        STACK_ARRAY_CALLOC(H3Index, children, childrenSz);
         H3_EXPORT(uncompact)(&bc, 1, children, childrenSz, res);
 
         for (int j = 0; j < childrenSz; j++) {
@@ -194,6 +195,5 @@ void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
 
             (*callback)(children[j]);
         }
-        free(children);
     }
 }

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/filters/h3ToIjk.c
+++ b/src/apps/filters/h3ToIjk.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief stdin/stdout filter that converts from H3 indexes to relative IJK
+ * coordinates.
+ *
+ *  usage: `h3ToIjk [origin]`
+ *
+ *  The program reads H3 indexes from stdin and outputs the corresponding
+ *  IJK coordinates to stdout, until EOF is encountered. The H3 indexes
+ *  should be in integer form. `-1 -1 -1` is printed if the IJK coordinates
+ * could not be obtained.
+ *
+ *  `origin` indicates the origin (or anchoring) index for the IJK coordinate
+ * space.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "h3api.h"
+#include "utility.h"
+
+void doCell(H3Index h, H3Index origin) {
+    CoordIJK ijk;
+    if (H3_EXPORT(h3ToIjk)(origin, h, &ijk)) {
+        printf("-1 -1 -1\n");
+    } else {
+        printf("%d %d %d\n", ijk.i, ijk.j, ijk.k);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    // check command line args
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s [origin]\n", argv[0]);
+        exit(1);
+    }
+
+    H3Index origin;
+
+    if (!sscanf(argv[1], "%" PRIx64, &origin))
+        error("origin could not be read");
+
+    if (!H3_EXPORT(h3IsValid)(origin)) error("origin is invalid");
+
+    // process the indexes on stdin
+    char buff[BUFF_SIZE];
+    while (1) {
+        // get an index from stdin
+        if (!fgets(buff, BUFF_SIZE, stdin)) {
+            if (feof(stdin))
+                break;
+            else
+                error("reading H3 index from stdin");
+        }
+
+        H3Index h3 = H3_EXPORT(stringToH3)(buff);
+        doCell(h3, origin);
+    }
+}

--- a/src/apps/filters/h3ToIjk.c
+++ b/src/apps/filters/h3ToIjk.c
@@ -15,28 +15,30 @@
  */
 /** @file
  * @brief stdin/stdout filter that converts from H3 indexes to relative IJK
- * coordinates.
+ * coordinates. This is experimental.
  *
  *  usage: `h3ToIjk [origin]`
  *
  *  The program reads H3 indexes from stdin and outputs the corresponding
  *  IJK coordinates to stdout, until EOF is encountered. The H3 indexes
  *  should be in integer form. `-1 -1 -1` is printed if the IJK coordinates
- * could not be obtained.
+ *  could not be obtained.
  *
  *  `origin` indicates the origin (or anchoring) index for the IJK coordinate
- * space.
+ *  space.
  */
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "coordijk.h"
+#include "h3Index.h"
 #include "h3api.h"
 #include "utility.h"
 
 void doCell(H3Index h, H3Index origin) {
     CoordIJK ijk;
-    if (H3_EXPORT(h3ToIjk)(origin, h, &ijk)) {
+    if (h3ToIjk(origin, h, &ijk)) {
         printf("-1 -1 -1\n");
     } else {
         printf("%d %d %d\n", ijk.i, ijk.j, ijk.k);

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -37,7 +37,7 @@ void h3Distance_identity_assertions(H3Index h3) {
     t_assert(H3_EXPORT(h3Distance)(h3, h3) == 0, "distance to self is 0");
 
     CoordIJK ijk;
-    t_assert(H3_EXPORT(h3ToIjk(h3, h3, &ijk)) == 0, "failed to get ijk");
+    t_assert(h3ToIjk(h3, h3, &ijk) == 0, "failed to get ijk");
     if (r == 0) {
         t_assert(_ijkMatches(&ijk, &UNIT_VECS[0]) == 1, "not at 0,0,0 (res 0)");
     } else if (r == 1) {
@@ -225,9 +225,20 @@ TEST(h3DistanceBaseCells) {
              "distance to neighbor is invalid");
 
     CoordIJK ijk;
-    t_assert(H3_EXPORT(h3ToIjk(pent1, bc1, &ijk)) == 0,
-             "failed to get ijk (4, 15)");
+    t_assert(h3ToIjk(pent1, bc1, &ijk) == 0, "failed to get ijk (4, 15)");
     t_assert(_ijkMatches(&ijk, &UNIT_VECS[2]) == 1, "not at 0,1,0");
+}
+
+TEST(h3DistanceFailed) {
+    H3Index h3 = 0x832830fffffffffL;
+    H3Index edge = H3_EXPORT(getH3UnidirectionalEdge(h3, 0x832834fffffffffL));
+    H3Index h3res2 = 0x822837fffffffffL;
+
+    t_assert(H3_EXPORT(h3Distance)(edge, h3) == -1, "edges cannot be origins");
+    t_assert(H3_EXPORT(h3Distance)(h3, edge) == -1,
+             "edges cannot be destinations");
+    t_assert(H3_EXPORT(h3Distance)(h3, h3res2) == -1,
+             "cannot compare at different resolutions");
 }
 
 END_TESTS();

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -55,7 +55,7 @@ void h3Distance_identity_assertions(H3Index h3) {
 
 void h3Distance_neighbors_assertions(H3Index h3) {
     CoordIJK origin = {0};
-    t_assert(H3_EXPORT(h3ToIjk)(h3, h3, &origin) == 0, "got ijk for origin");
+    t_assert(h3ToIjk(h3, h3, &origin) == 0, "got ijk for origin");
 
     for (int d = 1; d < 7; d++) {
         if (d == 1 && h3IsPentagon(h3)) {
@@ -66,8 +66,7 @@ void h3Distance_neighbors_assertions(H3Index h3) {
         H3Index offset = h3NeighborRotations(h3, d, &rotations);
 
         CoordIJK ijk = {0};
-        t_assert(H3_EXPORT(h3ToIjk)(h3, offset, &ijk) == 0,
-                 "got ijk for destination");
+        t_assert(h3ToIjk(h3, offset, &ijk) == 0, "got ijk for destination");
         CoordIJK invertedIjk = {0};
         _neighbor(&invertedIjk, d);
         for (int i = 0; i < 3; i++) {
@@ -168,18 +167,18 @@ TEST(ijkDistance) {
     CoordIJK ij = {1, 1, 0};
     CoordIJK j2 = {0, 2, 0};
 
-    t_assert(H3_EXPORT(ijkDistance)(&z, &z) == 0, "identity distance 0,0,0");
-    t_assert(H3_EXPORT(ijkDistance)(&i, &i) == 0, "identity distance 1,0,0");
-    t_assert(H3_EXPORT(ijkDistance)(&ik, &ik) == 0, "identity distance 1,0,1");
-    t_assert(H3_EXPORT(ijkDistance)(&ij, &ij) == 0, "identity distance 1,1,0");
-    t_assert(H3_EXPORT(ijkDistance)(&j2, &j2) == 0, "identity distance 0,2,0");
+    t_assert(ijkDistance(&z, &z) == 0, "identity distance 0,0,0");
+    t_assert(ijkDistance(&i, &i) == 0, "identity distance 1,0,0");
+    t_assert(ijkDistance(&ik, &ik) == 0, "identity distance 1,0,1");
+    t_assert(ijkDistance(&ij, &ij) == 0, "identity distance 1,1,0");
+    t_assert(ijkDistance(&j2, &j2) == 0, "identity distance 0,2,0");
 
-    t_assert(H3_EXPORT(ijkDistance)(&z, &i) == 1, "0,0,0 to 1,0,0");
-    t_assert(H3_EXPORT(ijkDistance)(&z, &j2) == 2, "0,0,0 to 0,2,0");
-    t_assert(H3_EXPORT(ijkDistance)(&z, &ik) == 1, "0,0,0 to 1,0,1");
-    t_assert(H3_EXPORT(ijkDistance)(&i, &ik) == 1, "1,0,0 to 1,0,1");
-    t_assert(H3_EXPORT(ijkDistance)(&ik, &j2) == 3, "1,0,1 to 0,2,0");
-    t_assert(H3_EXPORT(ijkDistance)(&ij, &ik) == 2, "1,0,1 to 1,1,0");
+    t_assert(ijkDistance(&z, &i) == 1, "0,0,0 to 1,0,0");
+    t_assert(ijkDistance(&z, &j2) == 2, "0,0,0 to 0,2,0");
+    t_assert(ijkDistance(&z, &ik) == 1, "0,0,0 to 1,0,1");
+    t_assert(ijkDistance(&i, &ik) == 1, "1,0,0 to 1,0,1");
+    t_assert(ijkDistance(&ik, &j2) == 3, "1,0,1 to 0,2,0");
+    t_assert(ijkDistance(&ij, &ik) == 2, "1,0,1 to 1,1,0");
 }
 
 TEST(h3Distance_identity) {
@@ -198,10 +197,11 @@ TEST(h3Distance_kRing) {
     iterateAllIndexesAtRes(0, h3Distance_kRing_assertions);
     iterateAllIndexesAtRes(1, h3Distance_kRing_assertions);
     iterateAllIndexesAtRes(2, h3Distance_kRing_assertions);
-    iterateAllIndexesAtRes(3, h3Distance_kRing_assertions);
-    // Only do these resolutions partially due to how long it would take.
-    iterateAllIndexesAtResPartial(4, h3Distance_kRing_assertions, 20);
-    iterateAllIndexesAtResPartial(5, h3Distance_kRing_assertions, 20);
+    // Don't iterate all of res 3, to save time
+    iterateAllIndexesAtResPartial(3, h3Distance_kRing_assertions, 27);
+    // These would take too long, even at partial execution
+    //    iterateAllIndexesAtResPartial(4, h3Distance_kRing_assertions, 20);
+    //    iterateAllIndexesAtResPartial(5, h3Distance_kRing_assertions, 20);
 }
 
 TEST(h3DistanceBaseCells) {

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -31,6 +31,8 @@
 #include "test.h"
 #include "utility.h"
 
+static const int MAX_DISTANCES[] = {1, 2, 5, 12, 19, 26};
+
 void h3Distance_identity_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);
 
@@ -81,23 +83,11 @@ void h3Distance_neighbors_assertions(H3Index h3) {
 }
 
 void h3Distance_kRing_assertions(H3Index h3) {
-    int maxK = 5;
     int r = H3_GET_RESOLUTION(h3);
-    if (r == 0) {
-        maxK = 1;
-    } else if (r == 1) {
-        maxK = 2;
-    } else if (r == 2) {
-        maxK = 5;
-    } else if (r == 3) {
-        maxK = 12;
-    } else if (r == 4) {
-        maxK = 19;
-    } else if (r == 5) {
-        maxK = 26;
-    } else {
+    if (r > 5) {
         t_assert(false, "wrong res");
     }
+    int maxK = MAX_DISTANCES[r];
 
     int sz = H3_EXPORT(maxKringSize)(maxK);
     STACK_ARRAY_CALLOC(H3Index, neighbors, sz);

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief tests H3 index to IJK+ grid functions.
+ *
+ *  usage: `testH3ToIjk`
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "algos.h"
+#include "baseCells.h"
+#include "constants.h"
+#include "h3Index.h"
+#include "h3api.h"
+#include "test.h"
+#include "utility.h"
+
+void h3Distance_identity_assertions(H3Index h3) {
+    int r = H3_GET_RESOLUTION(h3);
+
+    t_assert(H3_EXPORT(h3Distance)(h3, h3) == 0, "distance to self is 0");
+
+    CoordIJK ijk;
+    t_assert(H3_EXPORT(h3ToIjk(h3, h3, &ijk)) == 0, "failed to get ijk");
+    if (r == 0) {
+        t_assert(_ijkMatches(&ijk, &UNIT_VECS[0]) == 1, "not at 0,0,0 (res 0)");
+    } else if (r == 1) {
+        t_assert(_ijkMatches(&ijk, &UNIT_VECS[H3_GET_INDEX_DIGIT(h3, 1)]) == 1,
+                 "not at expected coordinates (res 1)");
+    } else if (r == 2) {
+        CoordIJK expected = UNIT_VECS[H3_GET_INDEX_DIGIT(h3, 1)];
+        _downAp7r(&expected);
+        _neighbor(&expected, H3_GET_INDEX_DIGIT(h3, 2));
+        t_assert(_ijkMatches(&ijk, &expected) == 1,
+                 "not at expected coordinates (res 2)");
+    } else {
+        t_assert(0, "wrong resolution");
+    }
+}
+
+void h3Distance_neighbors_assertions(H3Index h3) {
+    CoordIJK origin = {0};
+    t_assert(H3_EXPORT(h3ToIjk)(h3, h3, &origin) == 0, "got ijk for origin");
+
+    for (int d = 1; d < 7; d++) {
+        if (d == 1 && h3IsPentagon(h3)) {
+            continue;
+        }
+
+        int rotations = 0;
+        H3Index offset = h3NeighborRotations(h3, d, &rotations);
+
+        CoordIJK ijk = {0};
+        t_assert(H3_EXPORT(h3ToIjk)(h3, offset, &ijk) == 0,
+                 "got ijk for destination");
+        CoordIJK invertedIjk = {0};
+        _neighbor(&invertedIjk, d);
+        for (int i = 0; i < 3; i++) {
+            _ijkRotate60ccw(&invertedIjk);
+        }
+        _ijkAdd(&invertedIjk, &ijk, &ijk);
+        _ijkNormalize(&ijk);
+
+        t_assert(_ijkMatches(&ijk, &origin), "back to origin");
+    }
+}
+
+void h3Distance_kRing_assertions(H3Index h3) {
+    int maxK = 5;
+    int r = H3_GET_RESOLUTION(h3);
+    if (r == 0) {
+        maxK = 1;
+    } else if (r == 1) {
+        maxK = 2;
+    } else if (r == 2) {
+        maxK = 5;
+    } else if (r == 3) {
+        maxK = 12;
+    } else if (r == 4) {
+        maxK = 19;
+    } else if (r == 5) {
+        maxK = 26;
+    } else {
+        t_assert(false, "wrong res");
+    }
+
+    int sz = H3_EXPORT(maxKringSize)(maxK);
+    H3Index *neighbors = calloc(sz, sizeof(H3Index));
+    int *distances = calloc(sz, sizeof(int));
+
+    H3_EXPORT(kRingDistances)(h3, maxK, neighbors, distances);
+
+    for (int i = 0; i < sz; i++) {
+        if (neighbors[i] == 0) {
+            continue;
+        }
+
+        int calculatedDistance = H3_EXPORT(h3Distance)(h3, neighbors[i]);
+
+        // Don't consider indexes where h3Distance reports failure to
+        // generate
+        t_assert(calculatedDistance == distances[i] || calculatedDistance == -1,
+                 "kRingDistances matches h3Distance");
+    }
+
+    free(neighbors);
+    free(distances);
+}
+
+BEGIN_TESTS(h3ToIjk);
+
+TEST(testIndexDistance) {
+    H3Index bc = 0;
+    setH3Index(&bc, 1, 17, 0);
+    H3Index p = 0;
+    setH3Index(&p, 1, 14, 0);
+    H3Index p2;
+    setH3Index(&p2, 1, 14, 2);
+    H3Index p3;
+    setH3Index(&p3, 1, 14, 3);
+    H3Index p4;
+    setH3Index(&p4, 1, 14, 4);
+    H3Index p5;
+    setH3Index(&p5, 1, 14, 5);
+    H3Index p6;
+    setH3Index(&p6, 1, 14, 6);
+
+    t_assert(H3_EXPORT(h3Distance)(bc, p) == 3, "distance onto pentagon");
+    t_assert(H3_EXPORT(h3Distance)(bc, p2) == 2, "distance onto p2");
+    t_assert(H3_EXPORT(h3Distance)(bc, p3) == 3, "distance onto p3");
+    // TODO works correctly but is rejected due to possible pentagon distortion.
+    //    t_assert(H3_EXPORT(h3Distance)(bc, p4) == 3, "distance onto p4");
+    //    t_assert(H3_EXPORT(h3Distance)(bc, p5) == 4, "distance onto p5");
+    t_assert(H3_EXPORT(h3Distance)(bc, p6) == 2, "distance onto p6");
+}
+
+TEST(testIndexDistance2) {
+    H3Index origin = 0x820c4ffffffffffL;
+    // Destination is on the other side of the pentagon
+    H3Index destination = 0x821ce7fffffffffL;
+
+    // TODO doesn't work because of pentagon distortion. Both should be 5.
+    t_assert(H3_EXPORT(h3Distance)(destination, origin) == -1,
+             "distance in res 2 across pentagon");
+    t_assert(H3_EXPORT(h3Distance)(origin, destination) == -1,
+             "distance in res 2 across pentagon (reversed)");
+}
+
+TEST(ijkDistance) {
+    CoordIJK z = {0, 0, 0};
+    CoordIJK i = {1, 0, 0};
+    CoordIJK ik = {1, 0, 1};
+    CoordIJK ij = {1, 1, 0};
+    CoordIJK j2 = {0, 2, 0};
+
+    t_assert(H3_EXPORT(ijkDistance)(&z, &z) == 0, "identity distance 0,0,0");
+    t_assert(H3_EXPORT(ijkDistance)(&i, &i) == 0, "identity distance 1,0,0");
+    t_assert(H3_EXPORT(ijkDistance)(&ik, &ik) == 0, "identity distance 1,0,1");
+    t_assert(H3_EXPORT(ijkDistance)(&ij, &ij) == 0, "identity distance 1,1,0");
+    t_assert(H3_EXPORT(ijkDistance)(&j2, &j2) == 0, "identity distance 0,2,0");
+
+    t_assert(H3_EXPORT(ijkDistance)(&z, &i) == 1, "0,0,0 to 1,0,0");
+    t_assert(H3_EXPORT(ijkDistance)(&z, &j2) == 2, "0,0,0 to 0,2,0");
+    t_assert(H3_EXPORT(ijkDistance)(&z, &ik) == 1, "0,0,0 to 1,0,1");
+    t_assert(H3_EXPORT(ijkDistance)(&i, &ik) == 1, "1,0,0 to 1,0,1");
+    t_assert(H3_EXPORT(ijkDistance)(&ik, &j2) == 3, "1,0,1 to 0,2,0");
+    t_assert(H3_EXPORT(ijkDistance)(&ij, &ik) == 2, "1,0,1 to 1,1,0");
+}
+
+TEST(h3Distance_identity) {
+    iterateAllIndexesAtRes(0, h3Distance_identity_assertions);
+    iterateAllIndexesAtRes(1, h3Distance_identity_assertions);
+    iterateAllIndexesAtRes(2, h3Distance_identity_assertions);
+}
+
+TEST(h3Distance_neighbors) {
+    iterateAllIndexesAtRes(0, h3Distance_neighbors_assertions);
+    iterateAllIndexesAtRes(1, h3Distance_neighbors_assertions);
+    iterateAllIndexesAtRes(2, h3Distance_neighbors_assertions);
+}
+
+TEST(h3Distance_kRing) {
+    iterateAllIndexesAtRes(0, h3Distance_kRing_assertions);
+    iterateAllIndexesAtRes(1, h3Distance_kRing_assertions);
+    iterateAllIndexesAtRes(2, h3Distance_kRing_assertions);
+    iterateAllIndexesAtRes(3, h3Distance_kRing_assertions);
+    // Only do these resolutions partially due to how long it would take.
+    iterateAllIndexesAtResPartial(4, h3Distance_kRing_assertions, 20);
+    iterateAllIndexesAtResPartial(5, h3Distance_kRing_assertions, 20);
+}
+
+TEST(h3DistanceBaseCells) {
+    H3Index bc1 = H3_INIT;
+    setH3Index(&bc1, 0, 15, 0);
+
+    H3Index bc2 = H3_INIT;
+    setH3Index(&bc2, 0, 8, 0);
+
+    H3Index bc3 = H3_INIT;
+    setH3Index(&bc3, 0, 31, 0);
+
+    H3Index pent1 = H3_INIT;
+    setH3Index(&pent1, 0, 4, 0);
+
+    t_assert(H3_EXPORT(h3Distance)(bc1, pent1) == 1,
+             "distance to neighbor is 1 (15, 4)");
+    t_assert(H3_EXPORT(h3Distance)(bc1, bc2) == 1,
+             "distance to neighbor is 1 (15, 8)");
+    t_assert(H3_EXPORT(h3Distance)(bc1, bc3) == 1,
+             "distance to neighbor is 1 (15, 31)");
+    t_assert(H3_EXPORT(h3Distance)(pent1, bc3) == -1,
+             "distance to neighbor is invalid");
+
+    CoordIJK ijk;
+    t_assert(H3_EXPORT(h3ToIjk(pent1, bc1, &ijk)) == 0,
+             "failed to get ijk (4, 15)");
+    t_assert(_ijkMatches(&ijk, &UNIT_VECS[2]) == 1, "not at 0,1,0");
+}
+
+END_TESTS();

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -27,6 +27,7 @@
 #include "constants.h"
 #include "h3Index.h"
 #include "h3api.h"
+#include "stackAlloc.h"
 #include "test.h"
 #include "utility.h"
 
@@ -99,8 +100,8 @@ void h3Distance_kRing_assertions(H3Index h3) {
     }
 
     int sz = H3_EXPORT(maxKringSize)(maxK);
-    H3Index *neighbors = calloc(sz, sizeof(H3Index));
-    int *distances = calloc(sz, sizeof(int));
+    STACK_ARRAY_CALLOC(H3Index, neighbors, sz);
+    STACK_ARRAY_CALLOC(int, distances, sz);
 
     H3_EXPORT(kRingDistances)(h3, maxK, neighbors, distances);
 
@@ -116,9 +117,6 @@ void h3Distance_kRing_assertions(H3Index h3) {
         t_assert(calculatedDistance == distances[i] || calculatedDistance == -1,
                  "kRingDistances matches h3Distance");
     }
-
-    free(neighbors);
-    free(distances);
 }
 
 BEGIN_TESTS(h3ToIjk);

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -19,6 +19,7 @@
  *  usage: `testKRing`
  */
 
+#include <stackAlloc.h>
 #include <stdlib.h>
 #include "algos.h"
 #include "baseCells.h"
@@ -30,13 +31,13 @@ void kRing_equals_kRingInternal_assertions(H3Index h3) {
     for (int k = 0; k < 3; k++) {
         int kSz = H3_EXPORT(maxKringSize)(k);
 
-        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
-        int *distances = calloc(kSz, sizeof(int));
+        STACK_ARRAY_CALLOC(H3Index, neighbors, kSz);
+        STACK_ARRAY_CALLOC(int, distances, kSz);
         H3_EXPORT(kRingDistances)
         (h3, k, neighbors, distances);
 
-        H3Index *internalNeighbors = calloc(kSz, sizeof(H3Index));
-        int *internalDistances = calloc(kSz, sizeof(int));
+        STACK_ARRAY_CALLOC(H3Index, internalNeighbors, kSz);
+        STACK_ARRAY_CALLOC(int, internalDistances, kSz);
         _kRingInternal(h3, k, internalNeighbors, internalDistances, kSz, 0);
 
         int found = 0;
@@ -63,11 +64,6 @@ void kRing_equals_kRingInternal_assertions(H3Index h3) {
                          "produce same output");
             }
         }
-
-        free(neighbors);
-        free(distances);
-        free(internalNeighbors);
-        free(internalDistances);
     }
 }
 

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -52,5 +52,6 @@ int _faceIjkToBaseCellCCWrot60(const FaceIJK* h);
 void _baseCellToFaceIjk(int baseCell, FaceIJK* h);
 bool _baseCellIsCwOffset(int baseCell, int testFace);
 int _getBaseCellNeighbor(int baseCell, Direction dir);
+Direction _getBaseCellDirection(int originBaseCell, int destinationBaseCell);
 
 #endif

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -31,16 +31,8 @@
 #define COORDIJK_H
 
 #include "geoCoord.h"
+#include "h3api.h"
 #include "vec2d.h"
-
-/** @struct CoordIJK
- * @brief IJK hexagon coordinates
- */
-typedef struct {
-    int i;  ///< i component
-    int j;  ///< j component
-    int k;  ///< k component
-} CoordIJK;
 
 /** @brief CoordIJK unit vectors corresponding to the 7 H3 digits.
  */

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -31,8 +31,16 @@
 #define COORDIJK_H
 
 #include "geoCoord.h"
-#include "h3api.h"
 #include "vec2d.h"
+
+/** @struct CoordIJK
+ * @brief IJK hexagon coordinates
+ */
+typedef struct {
+    int i;  ///< i component
+    int j;  ///< j component
+    int k;  ///< k component
+} CoordIJK;
 
 /** @brief CoordIJK unit vectors corresponding to the 7 H3 digits.
  */
@@ -93,5 +101,6 @@ void _ijkRotate60ccw(CoordIJK* ijk);
 void _ijkRotate60cw(CoordIJK* ijk);
 Direction _rotate60ccw(Direction digit);
 Direction _rotate60cw(Direction digit);
+int ijkDistance(const CoordIJK* a, const CoordIJK* b);
 
 #endif

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -157,5 +157,6 @@ Direction _h3LeadingNonZeroDigit(H3Index h);
 H3Index _h3RotatePent60ccw(H3Index h);
 H3Index _h3Rotate60ccw(H3Index h);
 H3Index _h3Rotate60cw(H3Index h);
+int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out);
 
 #endif

--- a/src/h3lib/include/h3api.h
+++ b/src/h3lib/include/h3api.h
@@ -129,15 +129,6 @@ struct LinkedGeoPolygon {
     LinkedGeoPolygon *next;
 };
 
-/** @struct CoordIJK
- * @brief IJK hexagon coordinates
- */
-typedef struct {
-    int i;  ///< i component
-    int j;  ///< j component
-    int k;  ///< k component
-} CoordIJK;
-
 /** @defgroup geoToH3 geoToH3
  * Functions for geoToH3
  * @{
@@ -448,22 +439,6 @@ void H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(H3Index origin,
  */
 /** @brief Returns the GeoBoundary containing the coordinates of the edge */
 void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary *gb);
-/** @} */
-
-/** @defgroup ijkDistance ijkDistance
- * Functions for ijkDistance
- * @{
- */
-/** @brief Returns the distance in cells between the two coordinates */
-int H3_EXPORT(ijkDistance)(const CoordIJK *a, const CoordIJK *b);
-/** @} */
-
-/** @defgroup h3ToIjk h3ToIjk
- * Functions for h3ToIjk
- * @{
- */
-/** @brief Returns planar coordinates for an index */
-int H3_EXPORT(h3ToIjk)(H3Index origin, H3Index h3, CoordIJK *out);
 /** @} */
 
 /** @defgroup h3Distance h3Distance

--- a/src/h3lib/include/h3api.h
+++ b/src/h3lib/include/h3api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,15 @@ struct LinkedGeoPolygon {
     LinkedGeoLoop *last;
     LinkedGeoPolygon *next;
 };
+
+/** @struct CoordIJK
+ * @brief IJK hexagon coordinates
+ */
+typedef struct {
+    int i;  ///< i component
+    int j;  ///< j component
+    int k;  ///< k component
+} CoordIJK;
 
 /** @defgroup geoToH3 geoToH3
  * Functions for geoToH3
@@ -439,6 +448,30 @@ void H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(H3Index origin,
  */
 /** @brief Returns the GeoBoundary containing the coordinates of the edge */
 void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary *gb);
+/** @} */
+
+/** @defgroup ijkDistance ijkDistance
+ * Functions for ijkDistance
+ * @{
+ */
+/** @brief Returns the distance in cells between the two coordinates */
+int H3_EXPORT(ijkDistance)(const CoordIJK *a, const CoordIJK *b);
+/** @} */
+
+/** @defgroup h3ToIjk h3ToIjk
+ * Functions for h3ToIjk
+ * @{
+ */
+/** @brief Returns planar coordinates for an index */
+int H3_EXPORT(h3ToIjk)(H3Index origin, H3Index h3, CoordIJK *out);
+/** @} */
+
+/** @defgroup h3Distance h3Distance
+ * Functions for h3Distance
+ * @{
+ */
+/** @brief Returns grid distance between two indexes */
+int H3_EXPORT(h3Distance)(H3Index origin, H3Index h3);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -22,5 +22,6 @@
 
 // Internal functions
 int _ipow(int base, int exp);
+int _imax(int a, int b);
 
 #endif

--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,12 @@
 #ifndef MATHEXTENSIONS_H
 #define MATHEXTENSIONS_H
 
+/**
+ * MAX returns the maximum of two values.
+ */
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 // Internal functions
 int _ipow(int base, int exp);
-int _imax(int a, int b);
 
 #endif

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -867,3 +867,16 @@ bool _baseCellIsCwOffset(int baseCell, int testFace) {
 int _getBaseCellNeighbor(int baseCell, Direction dir) {
     return baseCellNeighbors[baseCell][dir];
 }
+
+/** @brief Return the direction from the origin base cell to the neighbor.
+ * Returns INVALID_DIGIT if the base cells are not neighbors.
+ */
+Direction _getBaseCellDirection(int originBaseCell, int neighboringBaseCell) {
+    for (Direction dir = CENTER_DIGIT; dir < NUM_DIGITS; dir++) {
+        int testBaseCell = _getBaseCellNeighbor(originBaseCell, dir);
+        if (testBaseCell == neighboringBaseCell) {
+            return dir;
+        }
+    }
+    return INVALID_DIGIT;
+}

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include "constants.h"
 #include "geoCoord.h"
+#include "mathExtensions.h"
 
 /**
  * Sets an IJK coordinate to the specified component values.
@@ -489,4 +490,18 @@ void _downAp3r(CoordIJK* ijk) {
     _ijkAdd(ijk, &kVec, ijk);
 
     _ijkNormalize(ijk);
+}
+
+/**
+ * Finds the distance between the two coordinates. Returns result.
+ *
+ * @param c1 The first set of ijk coordinates.
+ * @param c2 The second set of ijk coordinates.
+ */
+int ijkDistance(const CoordIJK* c1, const CoordIJK* c2) {
+    CoordIJK diff;
+    _ijkSub(c1, c2, &diff);
+    _ijkNormalize(&diff);
+    CoordIJK absDiff = {abs(diff.i), abs(diff.j), abs(diff.k)};
+    return _imax(absDiff.i, _imax(absDiff.j, absDiff.k));
 }

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -503,5 +503,5 @@ int ijkDistance(const CoordIJK* c1, const CoordIJK* c2) {
     _ijkSub(c1, c2, &diff);
     _ijkNormalize(&diff);
     CoordIJK absDiff = {abs(diff.i), abs(diff.j), abs(diff.k)};
-    return _imax(absDiff.i, _imax(absDiff.j, absDiff.k));
+    return MAX(absDiff.i, MAX(absDiff.j, absDiff.k));
 }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -799,33 +799,23 @@ int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
     int baseCell = H3_GET_BASE_CELL(h3);
 
     // Direction from origin base cell to index base cell
-    int dir = 0;
-    int revDir = 0;
+    Direction dir = 0;
+    Direction revDir = 0;
     if (originBaseCell != baseCell) {
-        for (dir = 1; dir < 7; dir++) {
-            int testBaseCell = _getBaseCellNeighbor(originBaseCell, dir);
-            if (testBaseCell == baseCell) {
-                break;
-            }
-        }
-        if (dir == 7) {
+        dir = _getBaseCellDirection(originBaseCell, baseCell);
+        if (dir == INVALID_DIGIT) {
             // Base cells are not neighbors, can't unfold.
             return 2;
         }
-        for (revDir = 1; revDir < 7; revDir++) {
-            int testBaseCell = _getBaseCellNeighbor(baseCell, revDir);
-            if (testBaseCell == originBaseCell) {
-                break;
-            }
-        }
-        assert(revDir != 7);
+        revDir = _getBaseCellDirection(baseCell, originBaseCell);
+        assert(revDir != INVALID_DIGIT);
     }
 
     int originOnPent = _isBaseCellPentagon(originBaseCell);
     int indexOnPent = _isBaseCellPentagon(baseCell);
 
     FaceIJK indexFijk = {0};
-    if (dir != 0) {
+    if (dir != CENTER_DIGIT) {
         // Rotate index into the orientation of the origin base cell.
         // cw because we are undoing the rotation into that base cell.
         int baseCellRotations = baseCellNeighbor60CCWRots[originBaseCell][dir];
@@ -834,7 +824,7 @@ int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
                 h3 = _h3RotatePent60cw(h3);
 
                 revDir = _rotate60cw(revDir);
-                if (revDir == 1) revDir = _rotate60cw(revDir);
+                if (revDir == K_AXES_DIGIT) revDir = _rotate60cw(revDir);
             }
         } else {
             for (int i = 0; i < baseCellRotations; i++) {
@@ -879,7 +869,7 @@ int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
         {false, false, false, true, false, false, false},   // 6
     };
 
-    if (dir != 0) {
+    if (dir != CENTER_DIGIT) {
         assert(baseCell != originBaseCell);
         assert(!(originOnPent && indexOnPent));
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -770,19 +770,18 @@ int isResClassIII(int res) { return res % 2; }
 /**
  * Produces ijk+ coordinates for an index anchored by an origin.
  *
- * The coordinate space used by this function may have a deleted
- * region due to pentagonal distortion.
+ * The coordinate space used by this function may have deleted
+ * regions or warping due to pentagonal distortion.
  *
  * Coordinates are only comparable if they come from the same
- * origin index. Coordinates may not be comparable between versions
- * of the H3 library, including minor/patch versions.
+ * origin index.
  *
  * @param origin An anchoring index for the ijk+ coordinate system.
  * @param index Index to find the coordinates of
  * @param out ijk+ coordinates of the index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(h3ToIjk)(H3Index origin, H3Index h3, CoordIJK* out) {
+int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
     if (H3_GET_MODE(origin) != H3_GET_MODE(h3)) {
         return 1;
     }
@@ -971,6 +970,10 @@ int H3_EXPORT(h3ToIjk)(H3Index origin, H3Index h3, CoordIJK* out) {
 /**
  * Produces the grid distance between the two indexes.
  *
+ * This function may fail to find the distance between two indexes, for
+ * example if they are very far apart. It may also fail when finding
+ * distances for indexes on opposite sides of a pentagon.
+ *
  * @param origin Index to find the distance from.
  * @param index Index to find the distance to.
  * @return The distance, or a negative number if the library could not
@@ -978,13 +981,13 @@ int H3_EXPORT(h3ToIjk)(H3Index origin, H3Index h3, CoordIJK* out) {
  */
 int H3_EXPORT(h3Distance)(H3Index origin, H3Index h3) {
     CoordIJK originIjk, h3Ijk;
-    if (H3_EXPORT(h3ToIjk)(origin, origin, &originIjk)) {
+    if (h3ToIjk(origin, origin, &originIjk)) {
         // This should never happen
         return -1;
     }
-    if (H3_EXPORT(h3ToIjk)(origin, h3, &h3Ijk)) {
+    if (h3ToIjk(origin, h3, &h3Ijk)) {
         return -1;
     }
 
-    return H3_EXPORT(ijkDistance)(&originIjk, &h3Ijk);
+    return ijkDistance(&originIjk, &h3Ijk);
 }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -782,7 +782,10 @@ int isResClassIII(int res) { return res % 2; }
  * @return 0 on success, or another value on failure.
  */
 int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
-    if (H3_GET_MODE(origin) != H3_GET_MODE(h3)) {
+    if (H3_GET_MODE(origin) != H3_HEXAGON_MODE ||
+        H3_GET_MODE(h3) != H3_HEXAGON_MODE) {
+        // Only hexagon mode is relevant, since we can't
+        // encode directionality in CoordIJK.
         return 1;
     }
 
@@ -982,7 +985,8 @@ int h3ToIjk(H3Index origin, H3Index h3, CoordIJK* out) {
 int H3_EXPORT(h3Distance)(H3Index origin, H3Index h3) {
     CoordIJK originIjk, h3Ijk;
     if (h3ToIjk(origin, origin, &originIjk)) {
-        // This should never happen
+        // Only possible if origin is invalid, for example if it's a
+        // unidirectional edge.
         return -1;
     }
     if (h3ToIjk(origin, h3, &h3Ijk)) {

--- a/src/h3lib/lib/mathExtensions.c
+++ b/src/h3lib/lib/mathExtensions.c
@@ -37,3 +37,14 @@ int _ipow(int base, int exp) {
 
     return result;
 }
+
+/**
+ * _imax returns the maximum of two integers.
+ */
+int _imax(int a, int b) {
+    if (a > b) {
+        return a;
+    } else {
+        return b;
+    }
+}

--- a/src/h3lib/lib/mathExtensions.c
+++ b/src/h3lib/lib/mathExtensions.c
@@ -37,14 +37,3 @@ int _ipow(int base, int exp) {
 
     return result;
 }
-
-/**
- * _imax returns the maximum of two integers.
- */
-int _imax(int a, int b) {
-    if (a > b) {
-        return a;
-    } else {
-        return b;
-    }
-}


### PR DESCRIPTION
Experimental.

Adds an h3ToIjk function which produces users consumable IJK+ coordinates. An "origin" for the coordinate system must be specified, and coordinates are only comparable if they were obtained from the same origin. This is limited to obtaining coordinates for indexes which are on the same base cell or neighboring base cells. Pentagons have more restrictions about crossing the pentagonal distortion. The intention is in the future this could be improved to handle pentagon distortion better, which may make current coordinates invalid. Coordinates should not be persisted or passed between library versions.

Pentagon cases were mostly restricted by experimentally disabling a number of cases.

With IJK+ coordinates, it's possible to determine the grid distance of cells, with the same limitations of h3ToIjk. This is done under the assumption that the distances that are of interest are below the granularity of a base cell (at that resolution, haversine may be a better approach.)

Along with this change, CoordIJK is moved to the public API.

edit: this would be version 3.1.0.