### PR TITLE
Feature: clear unused memory for pentagon children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Added
 - Added Direction enum, replacing int and defined constants (#77)
+- Ensured unused memory is cleared for pentagon children.
 
 ## [3.0.7] - 2018-06-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Added
 - Added Direction enum, replacing int and defined constants (#77)
-- Ensured unused memory is cleared for pentagon children.
+### Fixed
+- Ensured unused memory is cleared for pentagon children. (#84)
 
 ## [3.0.7] - 2018-06-08
 ### Added

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -125,12 +125,12 @@ TEST(pentagonChildren) {
     H3Index pentagon;
     setH3Index(&pentagon, 1, 4, 0);
 
-    const int expectedCount = 6;
-    const int paddedCount = H3_EXPORT(maxH3ToChildrenSize)(pentagon, 2);
+    const int expectedCount = (5 * 7) + 6;
+    const int paddedCount = H3_EXPORT(maxH3ToChildrenSize)(pentagon, 3);
 
     H3Index* children = calloc(paddedCount, sizeof(H3Index));
-    H3_EXPORT(h3ToChildren)(sfHex8, 9, children);
-    H3_EXPORT(h3ToChildren)(pentagon, 2, children);
+    H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
+    H3_EXPORT(h3ToChildren)(pentagon, 3, children);
 
     verifyCountAndUniqueness(children, paddedCount, expectedCount);
     free(children);

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -121,4 +121,19 @@ TEST(childResTooHigh) {
     free(children);
 }
 
+TEST(pentagonChildren) {
+    H3Index pentagon;
+    setH3Index(&pentagon, 1, 4, 0);
+
+    const int expectedCount = 6;
+    const int paddedCount = H3_EXPORT(maxH3ToChildrenSize)(pentagon, 2);
+
+    H3Index* children = calloc(paddedCount, sizeof(H3Index));
+    H3_EXPORT(h3ToChildren)(sfHex8, 9, children);
+    H3_EXPORT(h3ToChildren)(pentagon, 2, children);
+
+    verifyCountAndUniqueness(children, paddedCount, expectedCount);
+    free(children);
+}
+
 END_TESTS();

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -195,7 +195,7 @@ void H3_EXPORT(h3ToChildren)(H3Index h, int childRes, H3Index* children) {
         if (!isAPentagon || i != K_AXES_DIGIT) {
             H3_EXPORT(h3ToChildren)(makeDirectChild(h, i), childRes, children);
         } else {
-            *children = 0;
+            *children = H3_INVALID_INDEX;
         }
         children += bufferChildStep;
     }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -192,12 +192,16 @@ void H3_EXPORT(h3ToChildren)(H3Index h, int childRes, H3Index* children) {
     int bufferChildStep = (bufferSize / 7);
     int isAPentagon = H3_EXPORT(h3IsPentagon)(h);
     for (int i = 0; i < 7; i++) {
-        if (!isAPentagon || i != K_AXES_DIGIT) {
-            H3_EXPORT(h3ToChildren)(makeDirectChild(h, i), childRes, children);
+        if (isAPentagon && i == K_AXES_DIGIT) {
+            H3Index* nextChild = children + bufferChildStep;
+            while (children < nextChild) {
+                *children = H3_INVALID_INDEX;
+                children++;
+            }
         } else {
-            *children = H3_INVALID_INDEX;
+            H3_EXPORT(h3ToChildren)(makeDirectChild(h, i), childRes, children);
+            children += bufferChildStep;
         }
-        children += bufferChildStep;
     }
 }
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -194,6 +194,8 @@ void H3_EXPORT(h3ToChildren)(H3Index h, int childRes, H3Index* children) {
     for (int i = 0; i < 7; i++) {
         if (!isAPentagon || i != K_AXES_DIGIT) {
             H3_EXPORT(h3ToChildren)(makeDirectChild(h, i), childRes, children);
+        } else {
+            *children = 0;
         }
         children += bufferChildStep;
     }


### PR DESCRIPTION
This is a fantastic library!

I've encountered an inconsistency between `h3ToChildren` and `kRing`: The later sets memory to zero for pentagons. This left me confused when using `h3ToChildren` on pentagons which in my case returned valid indices (left over in memory from other calls) for the children that are skipped.

This pull request zeroes out memory for the unused slots.

Alternatively, the difference should at least be documented to let us know to use calloc.