### PR TITLE
Add erlang binding

### DIFF
--- a/docs/community/bindings.md
+++ b/docs/community/bindings.md
@@ -2,6 +2,10 @@
 
 As a C library, bindings can be made to call H3 functions from different programming languages. This page lists different bindings currently available. Contributions to this list are welcome, please feel free to open a [pull request](https://github.com/uber/h3/tree/master/docs/community/bindings.md).
 
+## Erlang
+
+- [helium/erlang-h3](https://github.com/helium/erlang-h3)
+
 ## Java
 
 - [uber/h3-java](https://github.com/uber/h3-java)


### PR DESCRIPTION
Adds an erlang-h3 binding. 

The remainder bindings, docs and travis are in the works but this is a functioning binding. 

Thanks for h3, it's really cool!