### PR TITLE
Add Libraries Using H3 page, link geojson2h3

### DIFF
--- a/docs/community/libraries.md
+++ b/docs/community/libraries.md
@@ -1,0 +1,7 @@
+# Libraries Using H3
+
+The following libraries use H3 via one of its bindings. Contributions to this list are welcome, please feel free to open a [pull request](https://github.com/uber/h3/tree/master/docs/community/libraries.md).
+
+## JavaScript
+
+- [uber/geojson2H3](https://github.com/uber/geojson2H3) - Conversion utilities between H3 indexes and GeoJSON

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -36,6 +36,7 @@ import api_regions from '../../docs/api/regions.md';
 import api_uniedge from '../../docs/api/uniedge.md';
 
 import community_bindings from '../../docs/community/bindings.md';
+import community_libraries from '../../docs/community/libraries.md';
 
 export default [{
     name: 'Documentation',
@@ -112,7 +113,7 @@ export default [{
                 markdown: api_hierarchy
             },
             {
-                name: 'regions',
+                name: 'Regions',
                 markdown: api_regions
             },
             {
@@ -130,6 +131,10 @@ export default [{
             {
                 name: 'Bindings',
                 markdown: community_bindings
+            },
+            {
+                name: 'Libraries Using H3',
+                markdown: community_libraries
             }
         ]
     }]


### PR DESCRIPTION
Adds [uber/geojson2H3](https://github.com/uber/geojson2H3) to the new Libraries page. This assumes that I don't need to do anything additional to add the new page to the nav bar.