### PR TITLE
Optimize sincos implementation

### DIFF
--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -25,7 +25,14 @@
  */
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
-// Internal functions
+/**
+ * @internal
+ */
 int _ipow(int base, int exp);
+
+/**
+ * @internal
+ */
+void _sincos(double degree, double* sin, double* cos);
 
 #endif

--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -26,6 +26,17 @@
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 /**
+ * MIN returns the minimum of two values.
+ */
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/**
+ * CLAMP returns the value closest to x within the range bounded by
+ * [a, b].
+ */
+#define CLAMP(x, a, b) (((x) > (b)) ? b : MAX(x, a))
+
+/**
  * @internal
  */
 int _ipow(int base, int exp);

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include "coordijk.h"
 #include "geoCoord.h"
 #include "h3Index.h"
+#include "mathExtensions.h"
 #include "vec3d.h"
 
 /** square root of 7 */
@@ -425,8 +426,11 @@ void _geoToHex2d(const GeoCoord* g, int res, int* face, Vec2d* v) {
     // we now have (r, theta) in hex2d with theta ccw from x-axes
 
     // convert to local x,y
-    v->x = r * cos(theta);
-    v->y = r * sin(theta);
+    double sinTheta;
+    double cosTheta;
+    _sincos(theta, &sinTheta, &cosTheta);
+    v->x = r * cosTheta;
+    v->y = r * sinTheta;
 }
 
 /**

--- a/src/h3lib/lib/geoCoord.c
+++ b/src/h3lib/lib/geoCoord.c
@@ -131,9 +131,6 @@ double constrainLng(double lng) {
     return lng;
 }
 
-#define CLAMP(x, lower, upper) \
-    ((x < lower) ? lower : ((x > upper) ? upper : lower))
-
 /**
  * Find the great circle distance in radians between two spherical coordinates.
  *

--- a/src/h3lib/lib/geoCoord.c
+++ b/src/h3lib/lib/geoCoord.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include "constants.h"
 #include "h3api.h"
+#include "mathExtensions.h"
 
 /**
  * Normalizes radians to a value between 0.0 and two PI.
@@ -130,6 +131,9 @@ double constrainLng(double lng) {
     return lng;
 }
 
+#define CLAMP(x, lower, upper) \
+    ((x < lower) ? lower : ((x > upper) ? upper : lower))
+
 /**
  * Find the great circle distance in radians between two spherical coordinates.
  *
@@ -151,13 +155,19 @@ double _geoDistRads(const GeoCoord* p1, const GeoCoord* p2) {
         bigC = fabs(lon2 - lon1);
     }
 
-    double b = M_PI_2 - p1->lat;
-    double a = M_PI_2 - p2->lat;
-
     // use law of cosines to find c
-    double cosc = cos(a) * cos(b) + sin(a) * sin(b) * cos(bigC);
-    if (cosc > 1.0L) cosc = 1.0L;
-    if (cosc < -1.0L) cosc = -1.0L;
+    const double b = M_PI_2 - p1->lat;
+    const double a = M_PI_2 - p2->lat;
+    double sina;
+    double cosa;
+    _sincos(a, &sina, &cosa);
+    double sinb;
+    double cosb;
+    _sincos(b, &sinb, &cosb);
+    double sinBigC;
+    double cosBigC;
+    _sincos(bigC, &sinBigC, &cosBigC);
+    double cosc = CLAMP(cosa * cosb + sina * sinb * cosBigC, -1, 1);
 
     return acos(cosc);
 }

--- a/src/h3lib/lib/mathExtensions.c
+++ b/src/h3lib/lib/mathExtensions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,12 @@
 
 #include "mathExtensions.h"
 
+#include <assert.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 /**
  * _ipow does integer exponentiation efficiently. Taken from StackOverflow.
  *
@@ -36,4 +42,104 @@ int _ipow(int base, int exp) {
     }
 
     return result;
+}
+
+#define S0 1.58962301576546568060E-10
+#define S1 -2.50507477628578072866E-8
+#define S2 2.75573136213857245213E-6
+#define S3 -1.98412698295895385996E-4
+#define S4 8.33333333332211858878E-3
+#define S5 -1.66666666666666307295E-1
+
+#define C0 -1.13585365213876817300E-11
+#define C1 2.08757008419747316778E-9
+#define C2 -2.75573141792967388112E-7
+#define C3 2.48015872888517045348E-5
+#define C4 -1.38888888888730564116E-3
+#define C5 4.16666666666665929218E-2
+
+#define PI4A 7.85398125648498535156E-1
+#define PI4B 3.77489470793079817668E-8
+#define PI4C 2.69515142907905952645E-15
+#define M4PI 1.273239544735162542821171882678754627704620361328125  // 4/pi
+
+// Based on Go implementation, which is based on Cephes library implementation.
+// See here for details:
+// https://github.com/golang/go/blob/master/src/math/sin.go.
+void _sincos(double x, double* sin, double* cos) {
+    assert(sin != NULL);
+    assert(cos != NULL);
+
+    if (x == 0) {
+        *sin = x;
+        *cos = 1;
+        return;
+    }
+
+    if (isnan(x) || isinf(x)) {
+        *sin = NAN;
+        *cos = NAN;
+        return;
+    }
+
+    bool sinSign = false;
+    bool cosSign = false;
+    if (x < 0) {
+        x = -x;
+        sinSign = true;
+    }
+
+    // Integer part of x/(pi/4), as integer for tests on the phase angle
+    int64_t j = x * M4PI;
+    double y = j;
+
+    // Map zeros to origin.
+    if ((j & 1) == 1) {
+        j++;
+        y++;
+    }
+
+    // Octant modulo 2*pi radians.
+    j &= 7;
+
+    // Reflect in x axis.
+    if (j > 3) {
+        j -= 4;
+        sinSign = !sinSign;
+        cosSign = !cosSign;
+    }
+
+    if (j > 1) {
+        cosSign = !cosSign;
+    }
+
+// Extended precision modular arithmetic.
+#define Z (((x - y * PI4A) - y * PI4B) - (y * PI4C))
+#define ZZ ((Z) * (Z))
+
+    double cosValue =
+        1.0 - 0.5 * ZZ +
+        ZZ * ZZ *
+            ((((((C0 * ZZ) + C1) * ZZ + C2) * ZZ + C3) * ZZ + C4) * ZZ + C5);
+    double sinValue =
+        Z +
+        Z * ZZ *
+            ((((((S0 * ZZ) + S1) * ZZ + S2) * ZZ + S3) * ZZ + S4) * ZZ + S5);
+#undef Z
+#undef ZZ
+
+    if (j == 1 || j == 2) {
+        double tmp = sinValue;
+        sinValue = cosValue;
+        cosValue = tmp;
+    }
+    if (cosSign) {
+        cosValue = -cosValue;
+    }
+    if (sinSign) {
+        sinValue = -sinValue;
+    }
+
+    *sin = sinValue;
+    *cos = cosValue;
 }

--- a/src/h3lib/lib/vec3d.c
+++ b/src/h3lib/lib/vec3d.c
@@ -18,7 +18,10 @@
  */
 
 #include "vec3d.h"
+
 #include <math.h>
+
+#include "mathExtensions.h"
 
 /**
  * Square of a number
@@ -47,9 +50,13 @@ double _pointSquareDist(const Vec3d* v1, const Vec3d* v2) {
  * @param v The 3D coordinate of the point.
  */
 void _geoToVec3d(const GeoCoord* geo, Vec3d* v) {
-    double r = cos(geo->lat);
+    double r;
+    double x;
+    double y;
 
-    v->z = sin(geo->lat);
-    v->x = cos(geo->lon) * r;
-    v->y = sin(geo->lon) * r;
+    _sincos(geo->lat, &v->z, &r);
+    _sincos(geo->lon, &y, &x);
+
+    v->x = x * r;
+    v->y = y * r;
 }


### PR DESCRIPTION
Output from master `make bench_benchmarkPolyfill`:

```
$ make bench_benchmarkPolyfill
...
	-- polyfillSF: 1.164000 milliseconds per iteration (500 iterations)
	-- polyfillAlameda: 1.986000 milliseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 87.400000 milliseconds per iteration (10 iterations)
...
```

After this change:

```
$ make bench_benchmarkPolyfill
...
	-- polyfillSF: 0.008000 milliseconds per iteration (500 iterations)
	-- polyfillAlameda: 0.010000 milliseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 0.000000 milliseconds per iteration (10 iterations)
...
```