### PR TITLE
Make polygon functions accept either Geofences or LinkedGeoLoops

### DIFF
--- a/src/apps/benchmarks/benchmarkPolygon.c
+++ b/src/apps/benchmarks/benchmarkPolygon.c
@@ -135,11 +135,11 @@ largeGeofence.numVerts = 90;
 largeGeofence.verts = largeVerts;
 bboxFromGeofence(&largeGeofence, &largeBBox);
 
-BENCHMARK(loopContainsPointSmall, 100000,
-          { loopContainsPoint(&smallGeofence, &smallBBox, &coord); });
+BENCHMARK(geofenceContainsPointSmall, 100000,
+          { geofenceContainsPoint(&smallGeofence, &smallBBox, &coord); });
 
-BENCHMARK(loopContainsPointLarge, 100000,
-          { loopContainsPoint(&largeGeofence, &largeBBox, &coord); });
+BENCHMARK(geofenceContainsPointLarge, 100000,
+          { geofenceContainsPoint(&largeGeofence, &largeBBox, &coord); });
 
 BENCHMARK(bboxFromGeofenceSmall, 100000,
           { bboxFromGeofence(&smallGeofence, &smallBBox); });

--- a/src/apps/benchmarks/benchmarkPolygon.c
+++ b/src/apps/benchmarks/benchmarkPolygon.c
@@ -135,11 +135,11 @@ largeGeofence.numVerts = 90;
 largeGeofence.verts = largeVerts;
 bboxFromGeofence(&largeGeofence, &largeBBox);
 
-BENCHMARK(geofenceContainsPointSmall, 100000,
-          { geofenceContainsPoint(&smallGeofence, &smallBBox, &coord); });
+BENCHMARK(pointInsideGeofenceSmall, 100000,
+          { pointInsideGeofence(&smallGeofence, &smallBBox, &coord); });
 
-BENCHMARK(geofenceContainsPointLarge, 100000,
-          { geofenceContainsPoint(&largeGeofence, &largeBBox, &coord); });
+BENCHMARK(pointInsideGeofenceLarge, 100000,
+          { pointInsideGeofence(&largeGeofence, &largeBBox, &coord); });
 
 BENCHMARK(bboxFromGeofenceSmall, 100000,
           { bboxFromGeofence(&smallGeofence, &smallBBox); });

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -22,14 +22,11 @@
 #include "polygon.h"
 #include "test.h"
 
-void assertBBox(GeoCoord* verts, const BBox* expected, const GeoCoord* inside,
-                const GeoCoord* outside) {
+void assertBBox(const Geofence* geofence, const BBox* expected,
+                const GeoCoord* inside, const GeoCoord* outside) {
     BBox result;
-    Geofence geofence;
-    geofence.verts = verts;
-    geofence.numVerts = 4;
 
-    bboxFromGeofence(&geofence, &result);
+    bboxFromGeofence(geofence, &result);
 
     t_assert(bboxEquals(&result, expected), "Got expected bbox");
     t_assert(bboxContains(&result, inside), "Contains expected inside point");
@@ -40,92 +37,89 @@ void assertBBox(GeoCoord* verts, const BBox* expected, const GeoCoord* inside,
 BEGIN_TESTS(BBox);
 
 TEST(posLatPosLon) {
-    const GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {1.1, 0.7, 0.7, 0.2};
     const GeoCoord inside = {0.9, 0.4};
     const GeoCoord outside = {0.0, 0.0};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(negLatPosLon) {
-    const GeoCoord verts[] = {
-        {-0.3, 0.6}, {-0.4, 0.9}, {-0.2, 0.8}, {-0.1, 0.6}};
+    GeoCoord verts[] = {{-0.3, 0.6}, {-0.4, 0.9}, {-0.2, 0.8}, {-0.1, 0.6}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {-0.1, -0.4, 0.9, 0.6};
     const GeoCoord inside = {-0.3, 0.8};
     const GeoCoord outside = {0.0, 0.0};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(posLatNegLon) {
-    const GeoCoord verts[] = {
-        {0.7, -1.4}, {0.8, -0.9}, {1.0, -0.8}, {1.1, -1.3}};
+    GeoCoord verts[] = {{0.7, -1.4}, {0.8, -0.9}, {1.0, -0.8}, {1.1, -1.3}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {1.1, 0.7, -0.8, -1.4};
     const GeoCoord inside = {0.9, -1.0};
     const GeoCoord outside = {0.0, 0.0};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(negLatNegLon) {
-    const GeoCoord verts[] = {
-        {-0.4, -1.4}, {-0.3, -1.1}, {-0.1, -1.2}, {-0.2, -1.4}};
+    GeoCoord verts[] = {{-0.4, -1.4}, {-0.3, -1.1}, {-0.1, -1.2}, {-0.2, -1.4}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {-0.1, -0.4, -1.1, -1.4};
     const GeoCoord inside = {-0.3, -1.2};
     const GeoCoord outside = {0.0, 0.0};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(aroundZeroZero) {
-    const GeoCoord verts[] = {
-        {0.4, -0.4}, {0.4, 0.4}, {-0.4, 0.4}, {-0.4, -0.4}};
+    GeoCoord verts[] = {{0.4, -0.4}, {0.4, 0.4}, {-0.4, 0.4}, {-0.4, -0.4}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {0.4, -0.4, 0.4, -0.4};
     const GeoCoord inside = {-0.1, -0.1};
     const GeoCoord outside = {1.0, -1.0};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(transmeridian) {
-    const GeoCoord verts[] = {{0.4, M_PI - 0.1},
-                              {0.4, -M_PI + 0.1},
-                              {-0.4, -M_PI + 0.1},
-                              {-0.4, M_PI - 0.1}};
+    GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                        {0.4, -M_PI + 0.1},
+                        {-0.4, -M_PI + 0.1},
+                        {-0.4, M_PI - 0.1}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {0.4, -0.4, -M_PI + 0.1, M_PI - 0.1};
     const GeoCoord inside = {-0.1, M_PI};
     const GeoCoord outside = {1.0, M_PI - 0.5};
-    assertBBox(verts, &expected, &inside, &outside);
-
-    BBox result;
-    Geofence geofence;
-    geofence.verts = verts;
-    geofence.numVerts = 4;
-
-    bboxFromGeofence(&geofence, &result);
+    assertBBox(&geofence, &expected, &inside, &outside);
 
     const GeoCoord westOutside = {0.1, M_PI - 0.5};
-    t_assert(!bboxContains(&result, &westOutside),
+    t_assert(!bboxContains(&expected, &westOutside),
              "Does not contain expected west outside point");
     const GeoCoord eastOutside = {0.1, -M_PI + 0.5};
-    t_assert(!bboxContains(&result, &eastOutside),
+    t_assert(!bboxContains(&expected, &eastOutside),
              "Does not contain expected east outside point");
 }
 
 TEST(edgeOnNorthPole) {
-    const GeoCoord verts[] = {
+    GeoCoord verts[] = {
         {M_PI_2 - 0.1, 0.1}, {M_PI_2 - 0.1, 0.8}, {M_PI_2, 0.8}, {M_PI_2, 0.1}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {M_PI_2, M_PI_2 - 0.1, 0.8, 0.1};
     const GeoCoord inside = {M_PI_2 - 0.01, 0.4};
     const GeoCoord outside = {M_PI_2, 0.9};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(edgeOnSouthPole) {
-    const GeoCoord verts[] = {{-M_PI_2 + 0.1, 0.1},
-                              {-M_PI_2 + 0.1, 0.8},
-                              {-M_PI_2, 0.8},
-                              {-M_PI_2, 0.1}};
+    GeoCoord verts[] = {{-M_PI_2 + 0.1, 0.1},
+                        {-M_PI_2 + 0.1, 0.8},
+                        {-M_PI_2, 0.8},
+                        {-M_PI_2, 0.1}};
+    const Geofence geofence = {.numVerts = 4, .verts = verts};
     const BBox expected = {-M_PI_2 + 0.1, -M_PI_2, 0.8, 0.1};
     const GeoCoord inside = {-M_PI_2 + 0.01, 0.4};
     const GeoCoord outside = {-M_PI_2, 0.9};
-    assertBBox(verts, &expected, &inside, &outside);
+    assertBBox(&geofence, &expected, &inside, &outside);
 }
 
 TEST(containsEdges) {

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -22,10 +22,14 @@
 #include "polygon.h"
 #include "test.h"
 
-void assertBBox(const GeoCoord* verts, const BBox* expected,
-                const GeoCoord* inside, const GeoCoord* outside) {
+void assertBBox(GeoCoord* verts, const BBox* expected, const GeoCoord* inside,
+                const GeoCoord* outside) {
     BBox result;
-    bboxFromVertices(verts, 4, &result);
+    Geofence geofence;
+    geofence.verts = verts;
+    geofence.numVerts = 4;
+
+    bboxFromGeofence(&geofence, &result);
 
     t_assert(bboxEquals(&result, expected), "Got expected bbox");
     t_assert(bboxContains(&result, inside), "Contains expected inside point");
@@ -90,7 +94,11 @@ TEST(transmeridian) {
     assertBBox(verts, &expected, &inside, &outside);
 
     BBox result;
-    bboxFromVertices(verts, 4, &result);
+    Geofence geofence;
+    geofence.verts = verts;
+    geofence.numVerts = 4;
+
+    bboxFromGeofence(&geofence, &result);
 
     const GeoCoord westOutside = {0.1, M_PI - 0.5};
     t_assert(!bboxContains(&result, &westOutside),

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -233,6 +233,8 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
     bboxFromLinkedGeoLoop(&loop, &result);
 
     t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+
+    destroyLinkedGeoLoop(&loop);
 }
 
 END_TESTS();

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -142,10 +142,8 @@ TEST(bboxFromGeofence) {
 }
 
 TEST(bboxFromGeofenceNoVertices) {
-    GeoCoord verts[] = {};
-
     Geofence geofence;
-    geofence.verts = verts;
+    geofence.verts = NULL;
     geofence.numVerts = 0;
 
     const BBox expected = {0.0, 0.0, 0.0, 0.0};
@@ -258,10 +256,8 @@ TEST(loopIsEmptyLinkedLoop) {
 }
 
 TEST(loopIsEmptyLinkedLoopGeofence) {
-    GeoCoord noVerts[] = {};
-
     Geofence geofence;
-    geofence.verts = noVerts;
+    geofence.verts = NULL;
     geofence.numVerts = 0;
 
     IterableGeoLoop loop;

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -96,15 +96,6 @@ TEST(geofenceContainsPointTransmeridian) {
              "does not contain outside point to the east of the antimeridian");
 }
 
-TEST(noVertices) {
-    const BBox expected = {0.0, 0.0, 0.0, 0.0};
-
-    BBox result;
-    bboxFromVertices(NULL, 0, &result);
-
-    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-}
-
 TEST(bboxFromGeofence) {
     GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
 
@@ -116,6 +107,21 @@ TEST(bboxFromGeofence) {
 
     BBox result;
     bboxFromGeofence(&geofence, &result);
+    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+}
+
+TEST(bboxFromGeofenceNoVertices) {
+    GeoCoord verts[] = {};
+
+    Geofence geofence;
+    geofence.verts = verts;
+    geofence.numVerts = 0;
+
+    const BBox expected = {0.0, 0.0, 0.0, 0.0};
+
+    BBox result;
+    bboxFromGeofence(&geofence, &result);
+
     t_assert(bboxEquals(&result, &expected), "Got expected bbox");
 }
 

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -59,21 +59,21 @@ transMeridianGeofence.verts = transMeridianVerts;
 transMeridianHoleGeofence.numVerts = 4;
 transMeridianHoleGeofence.verts = transMeridianHoleVerts;
 
-TEST(loopContainsPoint) {
+TEST(geofenceContainsPoint) {
     GeoCoord somewhere = {1, 2};
 
     BBox bbox;
     bboxFromGeofence(&sfGeofence, &bbox);
 
-    t_assert(loopContainsPoint(&sfGeofence, &bbox, &sfVerts[0]) == false,
+    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &sfVerts[0]) == false,
              "contains exact");
-    t_assert(loopContainsPoint(&sfGeofence, &bbox, &sfVerts[4]) == true,
+    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &sfVerts[4]) == true,
              "contains exact4");
-    t_assert(loopContainsPoint(&sfGeofence, &bbox, &somewhere) == false,
+    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &somewhere) == false,
              "contains somewhere else");
 }
 
-TEST(loopContainsPointTransmeridian) {
+TEST(geofenceContainsPointTransmeridian) {
     GeoCoord eastPoint = {0.001, -M_PI + 0.001};
     GeoCoord eastPointOutside = {0.001, -M_PI + 0.1};
     GeoCoord westPoint = {0.001, M_PI - 0.001};
@@ -82,17 +82,17 @@ TEST(loopContainsPointTransmeridian) {
     BBox bbox;
     bboxFromGeofence(&transMeridianGeofence, &bbox);
 
-    t_assert(
-        loopContainsPoint(&transMeridianGeofence, &bbox, &westPoint) == true,
-        "contains point to the west of the antimeridian");
-    t_assert(
-        loopContainsPoint(&transMeridianGeofence, &bbox, &eastPoint) == true,
-        "contains point to the east of the antimeridian");
-    t_assert(loopContainsPoint(&transMeridianGeofence, &bbox,
-                               &westPointOutside) == false,
+    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox, &westPoint) ==
+                 true,
+             "contains point to the west of the antimeridian");
+    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox, &eastPoint) ==
+                 true,
+             "contains point to the east of the antimeridian");
+    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox,
+                                   &westPointOutside) == false,
              "does not contain outside point to the west of the antimeridian");
-    t_assert(loopContainsPoint(&transMeridianGeofence, &bbox,
-                               &eastPointOutside) == false,
+    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox,
+                                   &eastPointOutside) == false,
              "does not contain outside point to the east of the antimeridian");
 }
 

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -68,21 +68,21 @@ transMeridianGeofence.verts = transMeridianVerts;
 transMeridianHoleGeofence.numVerts = 4;
 transMeridianHoleGeofence.verts = transMeridianHoleVerts;
 
-TEST(geofenceContainsPoint) {
+TEST(pointInsideGeofence) {
     GeoCoord somewhere = {1, 2};
 
     BBox bbox;
     bboxFromGeofence(&sfGeofence, &bbox);
 
-    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &sfVerts[0]) == false,
+    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[0]) == false,
              "contains exact");
-    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &sfVerts[4]) == true,
+    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[4]) == true,
              "contains exact4");
-    t_assert(geofenceContainsPoint(&sfGeofence, &bbox, &somewhere) == false,
+    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &somewhere) == false,
              "contains somewhere else");
 }
 
-TEST(geofenceContainsPointTransmeridian) {
+TEST(pointInsideGeofenceTransmeridian) {
     GeoCoord eastPoint = {0.001, -M_PI + 0.001};
     GeoCoord eastPointOutside = {0.001, -M_PI + 0.1};
     GeoCoord westPoint = {0.001, M_PI - 0.001};
@@ -91,21 +91,21 @@ TEST(geofenceContainsPointTransmeridian) {
     BBox bbox;
     bboxFromGeofence(&transMeridianGeofence, &bbox);
 
-    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox, &westPoint) ==
-                 true,
-             "contains point to the west of the antimeridian");
-    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox, &eastPoint) ==
-                 true,
-             "contains point to the east of the antimeridian");
-    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox,
-                                   &westPointOutside) == false,
+    t_assert(
+        pointInsideGeofence(&transMeridianGeofence, &bbox, &westPoint) == true,
+        "contains point to the west of the antimeridian");
+    t_assert(
+        pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPoint) == true,
+        "contains point to the east of the antimeridian");
+    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox,
+                                 &westPointOutside) == false,
              "does not contain outside point to the west of the antimeridian");
-    t_assert(geofenceContainsPoint(&transMeridianGeofence, &bbox,
-                                   &eastPointOutside) == false,
+    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox,
+                                 &eastPointOutside) == false,
              "does not contain outside point to the east of the antimeridian");
 }
 
-TEST(linkedGeoLoopContainsPoint) {
+TEST(pointInsideLinkedGeoLoop) {
     GeoCoord somewhere = {1, 2};
     GeoCoord inside = {0.659, -2.136};
 
@@ -119,9 +119,9 @@ TEST(linkedGeoLoopContainsPoint) {
     BBox bbox;
     bboxFromLinkedGeoLoop(&loop, &bbox);
 
-    t_assert(linkedGeoLoopContainsPoint(&loop, &bbox, &inside) == true,
+    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &inside) == true,
              "contains exact4");
-    t_assert(linkedGeoLoopContainsPoint(&loop, &bbox, &somewhere) == false,
+    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &somewhere) == false,
              "contains somewhere else");
 
     destroyLinkedGeoLoop(&loop);
@@ -233,51 +233,6 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
     bboxFromLinkedGeoLoop(&loop, &result);
 
     t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-}
-
-TEST(loopIsEmptyLinkedLoop) {
-    LinkedGeoLoop linkedGeoLoop;
-    initLinkedLoop(&linkedGeoLoop);
-
-    IterableGeoLoop loop;
-    loop.linkedGeoLoop = &linkedGeoLoop;
-    loop.type = TYPE_LINKED_GEO_LOOP;
-
-    t_assert(loopIsEmpty(&loop) == true, "LinkedGeoLoop is empty");
-
-    const GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    for (int i = 0; i < 4; i++) {
-        addLinkedCoord(&linkedGeoLoop, &verts[i]);
-    }
-
-    t_assert(loopIsEmpty(&loop) == false, "LinkedGeoLoop is not empty");
-
-    destroyLinkedGeoLoop(&linkedGeoLoop);
-}
-
-TEST(loopIsEmptyLinkedLoopGeofence) {
-    Geofence geofence;
-    geofence.verts = NULL;
-    geofence.numVerts = 0;
-
-    IterableGeoLoop loop;
-    loop.geofence = &geofence;
-    loop.type = TYPE_GEOFENCE;
-
-    t_assert(loopIsEmpty(&loop) == true, "Geofence is empty");
-
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    geofence.verts = verts;
-    geofence.numVerts = 4;
-
-    t_assert(loopIsEmpty(&loop) == false, "Geofence is not empty");
-}
-
-TEST(loopIsEmptyUnknown) {
-    IterableGeoLoop loop;
-    loop.type = 42;
-
-    t_assert(loopIsEmpty(&loop) == true, "Unknown loop type is empty");
 }
 
 END_TESTS();

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -46,7 +46,7 @@ GeoCoord transMeridianHoleVerts[] = {{0.005, -M_PI + 0.005},
                                      {-0.005, -M_PI + 0.005}};
 Geofence transMeridianHoleGeofence;
 
-void destroyLinkedGeoLoop(LinkedGeoLoop* loop) {
+static void destroyLinkedGeoLoop(LinkedGeoLoop* loop) {
     for (LinkedGeoCoord *currentCoord = loop->first, *nextCoord;
          currentCoord != NULL; currentCoord = nextCoord) {
         nextCoord = currentCoord->next;

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -105,6 +105,28 @@ TEST(geofenceContainsPointTransmeridian) {
              "does not contain outside point to the east of the antimeridian");
 }
 
+TEST(linkedGeoLoopContainsPoint) {
+    GeoCoord somewhere = {1, 2};
+    GeoCoord inside = {0.659, -2.136};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 6; i++) {
+        addLinkedCoord(&loop, &sfVerts[i]);
+    }
+
+    BBox bbox;
+    bboxFromLinkedGeoLoop(&loop, &bbox);
+
+    t_assert(linkedGeoLoopContainsPoint(&loop, &bbox, &inside) == true,
+             "contains exact4");
+    t_assert(linkedGeoLoopContainsPoint(&loop, &bbox, &somewhere) == false,
+             "contains somewhere else");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
 TEST(bboxFromGeofence) {
     GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
 

--- a/src/h3lib/include/linkedGeo.h
+++ b/src/h3lib/include/linkedGeo.h
@@ -25,6 +25,7 @@
 #include "h3api.h"
 
 void initLinkedPolygon(LinkedGeoPolygon* polygon);
+void initLinkedLoop(LinkedGeoLoop* loop);
 LinkedGeoPolygon* addLinkedPolygon(LinkedGeoPolygon* polygon);
 LinkedGeoLoop* addLinkedLoop(LinkedGeoPolygon* polygon);
 LinkedGeoCoord* addLinkedCoord(LinkedGeoLoop* loop, const GeoCoord* vertex);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -24,6 +24,27 @@
 #include "bbox.h"
 #include "geoCoord.h"
 #include "h3api.h"
+#include "linkedGeo.h"
+
+/** @struct IterableGeoLoop
+ *  @brief  Struct supporting polymorphic loop iteration
+ */
+typedef struct {
+    union {
+        const Geofence* geofence;            ///< optional Geofence
+        const LinkedGeoLoop* linkedGeoLoop;  ///< optional LinkedGeoLoop
+    };
+    union {
+        int index;                     ///< iteration var for Geofence
+        LinkedGeoCoord* currentCoord;  ///< iteration var for LinkedGeoLoop
+    };
+    int type;  ///< flag for type held by struct
+} IterableGeoLoop;
+
+/** Flag for Geofence type in IterableGeoLoop */
+#define TYPE_GEOFENCE 1
+/** Flag for LinkedGeoLoop type in IterableGeoLoop */
+#define TYPE_LINKED_GEO_LOOP 2
 
 void bboxFromVertices(const GeoCoord* verts, int numVerts, BBox* bbox);
 void bboxFromGeofence(const Geofence* geofence, BBox* bbox);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -28,8 +28,8 @@
 void bboxFromVertices(const GeoCoord* verts, int numVerts, BBox* bbox);
 void bboxFromGeofence(const Geofence* geofence, BBox* bbox);
 void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes);
-bool loopContainsPoint(const Geofence* geofence, const BBox* bbox,
-                       const GeoCoord* coord);
+bool geofenceContainsPoint(const Geofence* geofence, const BBox* bbox,
+                           const GeoCoord* coord);
 bool polygonContainsPoint(const GeoPolygon* geoPolygon, const BBox* bboxes,
                           const GeoCoord* coord);
 

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -34,10 +34,6 @@ typedef struct {
         const Geofence* geofence;            ///< optional Geofence
         const LinkedGeoLoop* linkedGeoLoop;  ///< optional LinkedGeoLoop
     };
-    union {
-        int index;                     ///< iteration var for Geofence
-        LinkedGeoCoord* currentCoord;  ///< iteration var for LinkedGeoLoop
-    };
     int type;  ///< flag for type held by struct
 } IterableGeoLoop;
 
@@ -45,6 +41,16 @@ typedef struct {
 #define TYPE_GEOFENCE 1
 /** Flag for LinkedGeoLoop type in IterableGeoLoop */
 #define TYPE_LINKED_GEO_LOOP 2
+
+#define INIT_ITERATION int loopIndex = -1
+
+#define ITERATE(loop, coord, next)                                             \
+    if (loop->type == TYPE_GEOFENCE) {                                         \
+        if (++loopIndex >= loop->geofence->numVerts) break;                    \
+        coord = loop->geofence->verts[loopIndex];                              \
+        next =                                                                 \
+            loop->geofence->verts[(loopIndex + 1) % loop->geofence->numVerts]; \
+    }
 
 void bboxFromVertices(const GeoCoord* verts, int numVerts, BBox* bbox);
 void bboxFromGeofence(const Geofence* geofence, BBox* bbox);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -50,9 +50,8 @@ typedef struct {
         coord = loop->geofence->verts[loopIndex];                              \
         next =                                                                 \
             loop->geofence->verts[(loopIndex + 1) % loop->geofence->numVerts]; \
-    }
+    }  // TODO: TYPE_LINKED_GEO_LOOP
 
-void bboxFromVertices(const GeoCoord* verts, int numVerts, BBox* bbox);
 void bboxFromGeofence(const Geofence* geofence, BBox* bbox);
 void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes);
 bool geofenceContainsPoint(const Geofence* geofence, const BBox* bbox,

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -46,7 +46,7 @@ typedef struct {
 #define INIT_ITERATION                   \
     int loopIndex = -1;                  \
     LinkedGeoCoord* currentCoord = NULL; \
-    LinkedGeoCoord* nextCoord = NULL;
+    LinkedGeoCoord* nextCoord = NULL
 
 /** Macro: Increment polymorphic loop iteration, or break if done.
  *  Uses if/else rather than switch to support break

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file polygon.c
+ * @brief Polygon algorithms
+ */
+
+#include "polygon.h"
+#include <float.h>
+#include <math.h>
+#include <stdbool.h>
+#include "bbox.h"
+#include "constants.h"
+#include "geoCoord.h"
+#include "h3api.h"
+
+#ifndef TYPE
+#error "TYPE must be defined before including this header"
+#endif
+
+#ifndef IS_EMPTY
+#error "IS_EMPTY must be defined before including this header"
+#endif
+
+#ifndef INIT_ITERATION
+#error "INIT_ITERATION must be defined before including this header"
+#endif
+
+#ifndef ITERATE
+#error "ITERATE must be defined before including this header"
+#endif
+
+#define LOOP_ALGO_XTJOIN(a, b) a##b
+#define LOOP_ALGO_TJOIN(a, b) LOOP_ALGO_XTJOIN(a, b)
+#define GENERIC_LOOP_ALGO(func) LOOP_ALGO_TJOIN(func, TYPE)
+
+/**
+ * pointInside is the core loop of the point-in-poly algorithm
+ * @param loop  The loop to check
+ * @param bbox  The bbox for the loop being tested
+ * @param coord The coordinate to check
+ * @return      Whether the point is contained
+ */
+bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
+                        const GeoCoord* coord) {
+    // fail fast if we're outside the bounding box
+    if (!bboxContains(bbox, coord)) {
+        return false;
+    }
+    bool isTransmeridian = bboxIsTransmeridian(bbox);
+    bool contains = false;
+
+    double lat = coord->lat;
+    double lng = NORMALIZE_LNG(coord->lon, isTransmeridian);
+
+    GeoCoord a;
+    GeoCoord b;
+
+    INIT_ITERATION;
+
+    while (true) {
+        ITERATE(loop, a, b);
+
+        // Ray casting algo requires the second point to always be higher
+        // than the first, so swap if needed
+        if (a.lat > b.lat) {
+            GeoCoord tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        // If we're totally above or below the latitude ranges, the test
+        // ray cannot intersect the line segment, so let's move on
+        if (lat < a.lat || lat > b.lat) {
+            continue;
+        }
+
+        double aLng = NORMALIZE_LNG(a.lon, isTransmeridian);
+        double bLng = NORMALIZE_LNG(b.lon, isTransmeridian);
+
+        // Rays are cast in the longitudinal direction, in case a point
+        // exactly matches, to decide tiebreakers, bias westerly
+        if (aLng == lng || bLng == lng) {
+            lng -= DBL_EPSILON;
+        }
+
+        // For the latitude of the point, compute the longitude of the
+        // point that lies on the line segment defined by a and b
+        // This is done by computing the percent above a the lat is,
+        // and traversing the same percent in the longitudinal direction
+        // of a to b
+        double ratio = (lat - a.lat) / (b.lat - a.lat);
+        double testLng =
+            NORMALIZE_LNG(aLng + (bLng - aLng) * ratio, isTransmeridian);
+
+        // Intersection of the ray
+        if (testLng > lng) {
+            contains = !contains;
+        }
+    }
+
+    return contains;
+}
+
+
+/**
+ * Create a bounding box from a simple polygon loop.
+ * Known limitations:
+ * - Does not support polygons with two adjacent points > 180 degrees of
+ *   longitude apart. These will be interpreted as crossing the antimeridian.
+ * - Does not currently support polygons containing a pole.
+ * @param loop     Loop of coordinates
+ * @param bbox     Output bbox
+ */
+void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
+    // Early exit if there are no vertices
+    if (IS_EMPTY(loop)) {
+        bbox->north = 0;
+        bbox->south = 0;
+        bbox->east = 0;
+        bbox->west = 0;
+        return;
+    }
+    double lat;
+    double lon;
+
+    bbox->south = DBL_MAX;
+    bbox->west = DBL_MAX;
+    bbox->north = -1.0 * DBL_MAX;
+    bbox->east = -1.0 * DBL_MAX;
+    bool isTransmeridian = false;
+
+    GeoCoord coord;
+    GeoCoord next;
+
+    INIT_ITERATION;
+
+    while (true) {
+        ITERATE(loop, coord, next);
+
+        lat = coord.lat;
+        lon = coord.lon;
+        if (lat < bbox->south) bbox->south = lat;
+        if (lon < bbox->west) bbox->west = lon;
+        if (lat > bbox->north) bbox->north = lat;
+        if (lon > bbox->east) bbox->east = lon;
+        // check for arcs > 180 degrees longitude, flagging as transmeridian
+        if (fabs(lon - next.lon) > M_PI) {
+            isTransmeridian = true;
+        }
+    }
+    // Swap east and west if transmeridian
+    if (isTransmeridian) {
+        double tmp = bbox->east;
+        bbox->east = bbox->west;
+        bbox->west = tmp;
+    }
+}

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** @file polygon.c
- * @brief Polygon algorithms
+/** @file
+ * @brief Include file for poylgon algorithms. This includes the core
+ *        logic for algorithms acting over loops of coordinates,
+ *        allowing them to be reused for both Geofence and
+ *        LinkegGeoLoop structures. This file is intended to be
+ *        included inline in a file that defines the type-specific
+ *        macros required for iteration.
  */
 
 #include "polygon.h"

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -706,7 +706,7 @@ void H3_EXPORT(polyfill)(const GeoPolygon* geoPolygon, int res, H3Index* out) {
         hexCenter.lat = constrainLat(hexCenter.lat);
         hexCenter.lon = constrainLng(hexCenter.lon);
         // And remove from list if not
-        if (!polygonContainsPoint(geoPolygon, bboxes, &hexCenter)) {
+        if (!pointInsidePolygon(geoPolygon, bboxes, &hexCenter)) {
             out[i] = H3_INVALID_INDEX;
         }
     }

--- a/src/h3lib/lib/polygon.c
+++ b/src/h3lib/lib/polygon.c
@@ -26,13 +26,7 @@
 #include "geoCoord.h"
 #include "h3api.h"
 
-// Define macros used in polygon algos for Geofence
-#define TYPE Geofence
-#define INIT_ITERATION INIT_ITERATION_GEOFENCE
-#define ITERATE ITERATE_GEOFENCE
-#define IS_EMPTY IS_EMPTY_GEOFENCE
-
-// Functions created in include file:
+// Functions created via the include file:
 
 /**
  * Take a given Geofence data structure and check if it
@@ -51,6 +45,30 @@
  * @param geofence Input Geofence
  * @param bbox     Output bbox
  */
+
+/**
+ * Take a given LinkedGeoLoop data structure and check if it
+ * contains a given geo coordinate.
+ * @name pointInsideLinkedGeoLoop
+ *
+ * @param loop          The linked loop
+ * @param bbox          The bbox for the loop
+ * @param coord         The coordinate to check
+ * @return              Whether the point is contained
+ */
+
+/**
+ * Create a bounding box from a LinkedGeoLoop
+ * @name bboxFromLinkedGeoLoop
+ * @param geofence Input Geofence
+ * @param bbox     Output bbox
+ */
+
+// Define macros used in polygon algos for Geofence
+#define TYPE Geofence
+#define INIT_ITERATION INIT_ITERATION_GEOFENCE
+#define ITERATE ITERATE_GEOFENCE
+#define IS_EMPTY IS_EMPTY_GEOFENCE
 
 #include "polygonAlgos.h"
 
@@ -106,26 +124,6 @@ bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
 #define INIT_ITERATION INIT_ITERATION_LINKED_LOOP
 #define ITERATE ITERATE_LINKED_LOOP
 #define IS_EMPTY IS_EMPTY_LINKED_LOOP
-
-// Functions created in include file:
-
-/**
- * Take a given LinkedGeoLoop data structure and check if it
- * contains a given geo coordinate.
- * @name pointInsideLinkedGeoLoop
- *
- * @param loop          The linked loop
- * @param bbox          The bbox for the loop
- * @param coord         The coordinate to check
- * @return              Whether the point is contained
- */
-
-/**
- * Create a bounding box from a LinkedGeoLoop
- * @name bboxFromLinkedGeoLoop
- * @param geofence Input Geofence
- * @param bbox     Output bbox
- */
 
 #include "polygonAlgos.h"
 


### PR DESCRIPTION
Adds support for `LinkedGeoLoop` input to `loopContainsPoint` and `bboxFromLoop`.

I considered several options on this:
- Function pointers (passing in `void* loop, void* iter, (*iterate)(...)`)
- Using union type and a polymorphic `iterate` function
- Current option, union type with iteration macro
- Moving the function bodies into macros and creating two functions from the macros

* Function pointers worked, but was > 2x slower than master, and I couldn't figure out ways around the compiler warnings when casting from `void*`
* Union types plus `iterate` function was cleaner but still > 2x slower
* The current union + macro version was faster than the other options, and only put "utility" code into the macro, rather than the core algo logic

I didn't try the full macro version, because it didn't seem like the perf benefit would be worth the additional difficulties in maintenance.

Benchmarks:

**Master**
```
Built target benchmarkPolygon
	-- loopContainsPointSmall: 0.000020 milliseconds per iteration (100000 iterations)
	-- loopContainsPointLarge: 0.000170 milliseconds per iteration (100000 iterations)
	-- bboxFromGeofenceSmall: 0.000020 milliseconds per iteration (100000 iterations)
	-- bboxFromGeofenceLarge: 0.000260 milliseconds per iteration (100000 iterations)
Built target benchmarkPolyfill
	-- polyfillSF: 1.574000 milliseconds per iteration (500 iterations)
	-- polyfillAlameda: 2.840000 milliseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 119.800000 milliseconds per iteration (10 iterations)
```

**Current**
```
Built target benchmarkPolygon
	-- geofenceContainsPointSmall: 0.000050 milliseconds per iteration (100000 iterations)
	-- geofenceContainsPointLarge: 0.000410 milliseconds per iteration (100000 iterations)
	-- bboxFromGeofenceSmall: 0.000030 milliseconds per iteration (100000 iterations)
	-- bboxFromGeofenceLarge: 0.000440 milliseconds per iteration (100000 iterations)
Built target benchmarkPolyfill
	-- polyfillSF: 1.610000 milliseconds per iteration (500 iterations)
	-- polyfillAlameda: 3.048000 milliseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 123.200000 milliseconds per iteration (10 iterations)
```