### PR TITLE
Improve tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,10 @@ if(BUILD_SHARED_LIBS)
     set_target_properties(h3 PROPERTIES SOVERSION ${H3_SOVERSION})
 endif()
 
+if(MSVC)
+    target_compile_definitions(h3 PUBLIC inline=__inline)
+endif()
+
 target_compile_definitions(h3 PUBLIC H3_PREFIX=${H3_PREFIX})
 if(have_alloca)
     target_compile_definitions(h3 PUBLIC H3_HAVE_ALLOCA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,10 +191,6 @@ if(BUILD_SHARED_LIBS)
     set_target_properties(h3 PROPERTIES SOVERSION ${H3_SOVERSION})
 endif()
 
-if(MSVC)
-    target_compile_definitions(h3 PUBLIC inline=__inline)
-endif()
-
 target_compile_definitions(h3 PUBLIC H3_PREFIX=${H3_PREFIX})
 if(have_alloca)
     target_compile_definitions(h3 PUBLIC H3_HAVE_ALLOCA)

--- a/src/apps/applib/include/test.h
+++ b/src/apps/applib/include/test.h
@@ -34,19 +34,10 @@ extern int globalTestCount;
             exit(1);                                                        \
         }                                                                   \
         globalTestCount++;                                                  \
-        printf(".\n");                                                      \
+        printf(".");                                                        \
     } while (0)
 
-static inline void t_assertBoundary(H3Index h3, const GeoBoundary* b1) {
-    // Generate cell boundary for the h3 index
-    GeoBoundary b2;
-    H3_EXPORT(h3ToGeoBoundary)(h3, &b2);
-    t_assert(b1->numVerts == b2.numVerts, "expected cell boundary count");
-    for (int v = 0; v < b1->numVerts; v++) {
-        t_assert(geoAlmostEqual(&b1->verts[v], &b2.verts[v]),
-                 "got expected vertex");
-    }
-}
+void t_assertBoundary(H3Index h3, const GeoBoundary* b1);
 
 #define SUITE(NAME)                                         \
     static void runTests(void);                             \

--- a/src/apps/applib/include/test.h
+++ b/src/apps/applib/include/test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,16 +25,19 @@
 #include "h3api.h"
 
 extern int globalTestCount;
+extern const char* currentSuiteName;
+extern const char* currentTestName;
 
-#define t_assert(condition, msg)                                            \
-    do {                                                                    \
-        if (!(condition)) {                                                 \
-            fprintf(stderr, "t_assert failed at %s:%d, %s, %s\n", __FILE__, \
-                    __LINE__, #condition, msg);                             \
-            exit(1);                                                        \
-        }                                                                   \
-        globalTestCount++;                                                  \
-        printf(".");                                                        \
+#define t_assert(condition, msg)                                           \
+    do {                                                                   \
+        if (!(condition)) {                                                \
+            fprintf(stderr, "%s.%s: t_assert failed at %s:%d, %s, %s\n",   \
+                    currentSuiteName, currentTestName, __FILE__, __LINE__, \
+                    #condition, msg);                                      \
+            exit(1);                                                       \
+        }                                                                  \
+        globalTestCount++;                                                 \
+        printf(".");                                                       \
     } while (0)
 
 void t_assertBoundary(H3Index h3, const GeoBoundary* b1);
@@ -42,12 +45,12 @@ void t_assertBoundary(H3Index h3, const GeoBoundary* b1);
 #define SUITE(NAME)                                         \
     static void runTests(void);                             \
     int main(void) {                                        \
+        currentSuiteName = #NAME;                           \
         printf("TEST %s\n", #NAME);                         \
         runTests();                                         \
         printf("\nDONE: %d assertions\n", globalTestCount); \
         return 0;                                           \
     }                                                       \
     void runTests(void)
-#define TEST(NAME)
-
+#define TEST(NAME) currentTestName = #NAME;
 #endif

--- a/src/apps/applib/lib/test.c
+++ b/src/apps/applib/lib/test.c
@@ -24,3 +24,14 @@
 // Assert
 
 int globalTestCount = 0;
+
+void t_assertBoundary(H3Index h3, const GeoBoundary* b1) {
+    // Generate cell boundary for the h3 index
+    GeoBoundary b2;
+    H3_EXPORT(h3ToGeoBoundary)(h3, &b2);
+    t_assert(b1->numVerts == b2.numVerts, "expected cell boundary count");
+    for (int v = 0; v < b1->numVerts; v++) {
+        t_assert(geoAlmostEqual(&b1->verts[v], &b2.verts[v]),
+                 "got expected vertex");
+    }
+}

--- a/src/apps/applib/lib/test.c
+++ b/src/apps/applib/lib/test.c
@@ -24,26 +24,3 @@
 // Assert
 
 int globalTestCount = 0;
-void t_assert(int value, const char* msg) {
-    if (!value) {
-        printf("%s\n", msg);
-    }
-    assert(value);
-    globalTestCount++;
-    printf(".");
-}
-
-void t_assertBoundary(H3Index h3, const GeoBoundary* b1) {
-    // generate cell boundary for the h3 index
-    GeoBoundary b2;
-    H3_EXPORT(h3ToGeoBoundary)(h3, &b2);
-
-    t_assert(b1->numVerts == b2.numVerts, "expected cell boundary count");
-
-    for (int v = 0; v < b1->numVerts; v++) {
-        t_assert(geoAlmostEqual(&b1->verts[v], &b2.verts[v]),
-                 "got expected vertex");
-    }
-}
-
-int testCount() { return globalTestCount; }

--- a/src/apps/applib/lib/test.c
+++ b/src/apps/applib/lib/test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 // Assert
 
 int globalTestCount = 0;
+const char* currentSuiteName = "";
+const char* currentTestName = "";
 
 void t_assertBoundary(H3Index h3, const GeoBoundary* b1) {
     // Generate cell boundary for the h3 index

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -34,187 +34,189 @@ void assertBBox(const Geofence* geofence, const BBox* expected,
              "Does not contain expected outside point");
 }
 
-BEGIN_TESTS(BBox);
+SUITE(BBox) {
+    TEST(posLatPosLon) {
+        GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {1.1, 0.7, 0.7, 0.2};
+        const GeoCoord inside = {0.9, 0.4};
+        const GeoCoord outside = {0.0, 0.0};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(posLatPosLon) {
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {1.1, 0.7, 0.7, 0.2};
-    const GeoCoord inside = {0.9, 0.4};
-    const GeoCoord outside = {0.0, 0.0};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(negLatPosLon) {
+        GeoCoord verts[] = {{-0.3, 0.6}, {-0.4, 0.9}, {-0.2, 0.8}, {-0.1, 0.6}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {-0.1, -0.4, 0.9, 0.6};
+        const GeoCoord inside = {-0.3, 0.8};
+        const GeoCoord outside = {0.0, 0.0};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(negLatPosLon) {
-    GeoCoord verts[] = {{-0.3, 0.6}, {-0.4, 0.9}, {-0.2, 0.8}, {-0.1, 0.6}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {-0.1, -0.4, 0.9, 0.6};
-    const GeoCoord inside = {-0.3, 0.8};
-    const GeoCoord outside = {0.0, 0.0};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(posLatNegLon) {
+        GeoCoord verts[] = {{0.7, -1.4}, {0.8, -0.9}, {1.0, -0.8}, {1.1, -1.3}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {1.1, 0.7, -0.8, -1.4};
+        const GeoCoord inside = {0.9, -1.0};
+        const GeoCoord outside = {0.0, 0.0};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(posLatNegLon) {
-    GeoCoord verts[] = {{0.7, -1.4}, {0.8, -0.9}, {1.0, -0.8}, {1.1, -1.3}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {1.1, 0.7, -0.8, -1.4};
-    const GeoCoord inside = {0.9, -1.0};
-    const GeoCoord outside = {0.0, 0.0};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(negLatNegLon) {
+        GeoCoord verts[] = {
+            {-0.4, -1.4}, {-0.3, -1.1}, {-0.1, -1.2}, {-0.2, -1.4}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {-0.1, -0.4, -1.1, -1.4};
+        const GeoCoord inside = {-0.3, -1.2};
+        const GeoCoord outside = {0.0, 0.0};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(negLatNegLon) {
-    GeoCoord verts[] = {{-0.4, -1.4}, {-0.3, -1.1}, {-0.1, -1.2}, {-0.2, -1.4}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {-0.1, -0.4, -1.1, -1.4};
-    const GeoCoord inside = {-0.3, -1.2};
-    const GeoCoord outside = {0.0, 0.0};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(aroundZeroZero) {
+        GeoCoord verts[] = {{0.4, -0.4}, {0.4, 0.4}, {-0.4, 0.4}, {-0.4, -0.4}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {0.4, -0.4, 0.4, -0.4};
+        const GeoCoord inside = {-0.1, -0.1};
+        const GeoCoord outside = {1.0, -1.0};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(aroundZeroZero) {
-    GeoCoord verts[] = {{0.4, -0.4}, {0.4, 0.4}, {-0.4, 0.4}, {-0.4, -0.4}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {0.4, -0.4, 0.4, -0.4};
-    const GeoCoord inside = {-0.1, -0.1};
-    const GeoCoord outside = {1.0, -1.0};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(transmeridian) {
+        GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                            {0.4, -M_PI + 0.1},
+                            {-0.4, -M_PI + 0.1},
+                            {-0.4, M_PI - 0.1}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {0.4, -0.4, -M_PI + 0.1, M_PI - 0.1};
+        const GeoCoord insideOnMeridian = {-0.1, M_PI};
+        const GeoCoord outside = {1.0, M_PI - 0.5};
+        assertBBox(&geofence, &expected, &insideOnMeridian, &outside);
 
-TEST(transmeridian) {
-    GeoCoord verts[] = {{0.4, M_PI - 0.1},
-                        {0.4, -M_PI + 0.1},
-                        {-0.4, -M_PI + 0.1},
-                        {-0.4, M_PI - 0.1}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {0.4, -0.4, -M_PI + 0.1, M_PI - 0.1};
-    const GeoCoord insideOnMeridian = {-0.1, M_PI};
-    const GeoCoord outside = {1.0, M_PI - 0.5};
-    assertBBox(&geofence, &expected, &insideOnMeridian, &outside);
+        const GeoCoord westInside = {0.1, M_PI - 0.05};
+        t_assert(bboxContains(&expected, &westInside),
+                 "Contains expected west inside point");
+        const GeoCoord eastInside = {0.1, -M_PI + 0.05};
+        t_assert(bboxContains(&expected, &eastInside),
+                 "Contains expected east outside point");
 
-    const GeoCoord westInside = {0.1, M_PI - 0.05};
-    t_assert(bboxContains(&expected, &westInside),
-             "Contains expected west inside point");
-    const GeoCoord eastInside = {0.1, -M_PI + 0.05};
-    t_assert(bboxContains(&expected, &eastInside),
-             "Contains expected east outside point");
+        const GeoCoord westOutside = {0.1, M_PI - 0.5};
+        t_assert(!bboxContains(&expected, &westOutside),
+                 "Does not contain expected west outside point");
+        const GeoCoord eastOutside = {0.1, -M_PI + 0.5};
+        t_assert(!bboxContains(&expected, &eastOutside),
+                 "Does not contain expected east outside point");
+    }
 
-    const GeoCoord westOutside = {0.1, M_PI - 0.5};
-    t_assert(!bboxContains(&expected, &westOutside),
-             "Does not contain expected west outside point");
-    const GeoCoord eastOutside = {0.1, -M_PI + 0.5};
-    t_assert(!bboxContains(&expected, &eastOutside),
-             "Does not contain expected east outside point");
-}
+    TEST(edgeOnNorthPole) {
+        GeoCoord verts[] = {{M_PI_2 - 0.1, 0.1},
+                            {M_PI_2 - 0.1, 0.8},
+                            {M_PI_2, 0.8},
+                            {M_PI_2, 0.1}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {M_PI_2, M_PI_2 - 0.1, 0.8, 0.1};
+        const GeoCoord inside = {M_PI_2 - 0.01, 0.4};
+        const GeoCoord outside = {M_PI_2, 0.9};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(edgeOnNorthPole) {
-    GeoCoord verts[] = {
-        {M_PI_2 - 0.1, 0.1}, {M_PI_2 - 0.1, 0.8}, {M_PI_2, 0.8}, {M_PI_2, 0.1}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {M_PI_2, M_PI_2 - 0.1, 0.8, 0.1};
-    const GeoCoord inside = {M_PI_2 - 0.01, 0.4};
-    const GeoCoord outside = {M_PI_2, 0.9};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(edgeOnSouthPole) {
+        GeoCoord verts[] = {{-M_PI_2 + 0.1, 0.1},
+                            {-M_PI_2 + 0.1, 0.8},
+                            {-M_PI_2, 0.8},
+                            {-M_PI_2, 0.1}};
+        const Geofence geofence = {.numVerts = 4, .verts = verts};
+        const BBox expected = {-M_PI_2 + 0.1, -M_PI_2, 0.8, 0.1};
+        const GeoCoord inside = {-M_PI_2 + 0.01, 0.4};
+        const GeoCoord outside = {-M_PI_2, 0.9};
+        assertBBox(&geofence, &expected, &inside, &outside);
+    }
 
-TEST(edgeOnSouthPole) {
-    GeoCoord verts[] = {{-M_PI_2 + 0.1, 0.1},
-                        {-M_PI_2 + 0.1, 0.8},
-                        {-M_PI_2, 0.8},
-                        {-M_PI_2, 0.1}};
-    const Geofence geofence = {.numVerts = 4, .verts = verts};
-    const BBox expected = {-M_PI_2 + 0.1, -M_PI_2, 0.8, 0.1};
-    const GeoCoord inside = {-M_PI_2 + 0.01, 0.4};
-    const GeoCoord outside = {-M_PI_2, 0.9};
-    assertBBox(&geofence, &expected, &inside, &outside);
-}
+    TEST(containsEdges) {
+        const BBox bbox = {0.1, -0.1, 0.2, -0.2};
+        GeoCoord points[] = {
+            {0.1, 0.2},  {0.1, 0.0},  {0.1, -0.2},  {0.0, 0.2},
+            {-0.1, 0.2}, {-0.1, 0.0}, {-0.1, -0.2}, {0.0, -0.2},
+        };
+        const int numPoints = 8;
 
-TEST(containsEdges) {
-    const BBox bbox = {0.1, -0.1, 0.2, -0.2};
-    GeoCoord points[] = {
-        {0.1, 0.2},  {0.1, 0.0},  {0.1, -0.2},  {0.0, 0.2},
-        {-0.1, 0.2}, {-0.1, 0.0}, {-0.1, -0.2}, {0.0, -0.2},
-    };
-    const int numPoints = 8;
+        for (int i = 0; i < numPoints; i++) {
+            t_assert(bboxContains(&bbox, &points[i]), "Contains edge point");
+        }
+    }
 
-    for (int i = 0; i < numPoints; i++) {
-        t_assert(bboxContains(&bbox, &points[i]), "Contains edge point");
+    TEST(containsEdgesTransmeridian) {
+        const BBox bbox = {0.1, -0.1, -M_PI + 0.2, M_PI - 0.2};
+        GeoCoord points[] = {
+            {0.1, -M_PI + 0.2}, {0.1, M_PI},         {0.1, M_PI - 0.2},
+            {0.0, -M_PI + 0.2}, {-0.1, -M_PI + 0.2}, {-0.1, M_PI},
+            {-0.1, M_PI - 0.2}, {0.0, M_PI - 0.2},
+        };
+        const int numPoints = 8;
+
+        for (int i = 0; i < numPoints; i++) {
+            t_assert(bboxContains(&bbox, &points[i]),
+                     "Contains transmeridian edge point");
+        }
+    }
+
+    TEST(bboxCenterBasicQuandrants) {
+        GeoCoord center;
+
+        BBox bbox1 = {1.0, 0.8, 1.0, 0.8};
+        GeoCoord expected1 = {0.9, 0.9};
+        bboxCenter(&bbox1, &center);
+        t_assert(geoAlmostEqual(&center, &expected1), "pos/pos as expected");
+
+        BBox bbox2 = {-0.8, -1.0, 1.0, 0.8};
+        GeoCoord expected2 = {-0.9, 0.9};
+        bboxCenter(&bbox2, &center);
+        t_assert(geoAlmostEqual(&center, &expected2), "neg/pos as expected");
+
+        BBox bbox3 = {1.0, 0.8, -0.8, -1.0};
+        GeoCoord expected3 = {0.9, -0.9};
+        bboxCenter(&bbox3, &center);
+        t_assert(geoAlmostEqual(&center, &expected3), "pos/neg as expected");
+
+        BBox bbox4 = {-0.8, -1.0, -0.8, -1.0};
+        GeoCoord expected4 = {-0.9, -0.9};
+        bboxCenter(&bbox4, &center);
+        t_assert(geoAlmostEqual(&center, &expected4), "neg/neg as expected");
+
+        BBox bbox5 = {0.8, -0.8, 1.0, -1.0};
+        GeoCoord expected5 = {0.0, 0.0};
+        bboxCenter(&bbox5, &center);
+        t_assert(geoAlmostEqual(&center, &expected5),
+                 "around origin as expected");
+    }
+
+    TEST(bboxCenterTransmeridian) {
+        GeoCoord center;
+
+        BBox bbox1 = {1.0, 0.8, -M_PI + 0.3, M_PI - 0.1};
+        GeoCoord expected1 = {0.9, -M_PI + 0.1};
+        bboxCenter(&bbox1, &center);
+
+        t_assert(geoAlmostEqual(&center, &expected1), "skew east as expected");
+
+        BBox bbox2 = {1.0, 0.8, -M_PI + 0.1, M_PI - 0.3};
+        GeoCoord expected2 = {0.9, M_PI - 0.1};
+        bboxCenter(&bbox2, &center);
+        t_assert(geoAlmostEqual(&center, &expected2), "skew west as expected");
+
+        BBox bbox3 = {1.0, 0.8, -M_PI + 0.1, M_PI - 0.1};
+        GeoCoord expected3 = {0.9, M_PI};
+        bboxCenter(&bbox3, &center);
+        t_assert(geoAlmostEqual(&center, &expected3),
+                 "on antimeridian as expected");
+    }
+
+    TEST(bboxIsTransmeridian) {
+        BBox bboxNormal = {1.0, 0.8, 1.0, 0.8};
+        t_assert(!bboxIsTransmeridian(&bboxNormal),
+                 "Normal bbox not transmeridian");
+
+        BBox bboxTransmeridian = {1.0, 0.8, -M_PI + 0.3, M_PI - 0.1};
+        t_assert(bboxIsTransmeridian(&bboxTransmeridian),
+                 "Transmeridian bbox is transmeridian");
     }
 }
-
-TEST(containsEdgesTransmeridian) {
-    const BBox bbox = {0.1, -0.1, -M_PI + 0.2, M_PI - 0.2};
-    GeoCoord points[] = {
-        {0.1, -M_PI + 0.2}, {0.1, M_PI},         {0.1, M_PI - 0.2},
-        {0.0, -M_PI + 0.2}, {-0.1, -M_PI + 0.2}, {-0.1, M_PI},
-        {-0.1, M_PI - 0.2}, {0.0, M_PI - 0.2},
-    };
-    const int numPoints = 8;
-
-    for (int i = 0; i < numPoints; i++) {
-        t_assert(bboxContains(&bbox, &points[i]),
-                 "Contains transmeridian edge point");
-    }
-}
-
-TEST(bboxCenterBasicQuandrants) {
-    GeoCoord center;
-
-    BBox bbox1 = {1.0, 0.8, 1.0, 0.8};
-    GeoCoord expected1 = {0.9, 0.9};
-    bboxCenter(&bbox1, &center);
-    t_assert(geoAlmostEqual(&center, &expected1), "pos/pos as expected");
-
-    BBox bbox2 = {-0.8, -1.0, 1.0, 0.8};
-    GeoCoord expected2 = {-0.9, 0.9};
-    bboxCenter(&bbox2, &center);
-    t_assert(geoAlmostEqual(&center, &expected2), "neg/pos as expected");
-
-    BBox bbox3 = {1.0, 0.8, -0.8, -1.0};
-    GeoCoord expected3 = {0.9, -0.9};
-    bboxCenter(&bbox3, &center);
-    t_assert(geoAlmostEqual(&center, &expected3), "pos/neg as expected");
-
-    BBox bbox4 = {-0.8, -1.0, -0.8, -1.0};
-    GeoCoord expected4 = {-0.9, -0.9};
-    bboxCenter(&bbox4, &center);
-    t_assert(geoAlmostEqual(&center, &expected4), "neg/neg as expected");
-
-    BBox bbox5 = {0.8, -0.8, 1.0, -1.0};
-    GeoCoord expected5 = {0.0, 0.0};
-    bboxCenter(&bbox5, &center);
-    t_assert(geoAlmostEqual(&center, &expected5), "around origin as expected");
-}
-
-TEST(bboxCenterTransmeridian) {
-    GeoCoord center;
-
-    BBox bbox1 = {1.0, 0.8, -M_PI + 0.3, M_PI - 0.1};
-    GeoCoord expected1 = {0.9, -M_PI + 0.1};
-    bboxCenter(&bbox1, &center);
-
-    t_assert(geoAlmostEqual(&center, &expected1), "skew east as expected");
-
-    BBox bbox2 = {1.0, 0.8, -M_PI + 0.1, M_PI - 0.3};
-    GeoCoord expected2 = {0.9, M_PI - 0.1};
-    bboxCenter(&bbox2, &center);
-    t_assert(geoAlmostEqual(&center, &expected2), "skew west as expected");
-
-    BBox bbox3 = {1.0, 0.8, -M_PI + 0.1, M_PI - 0.1};
-    GeoCoord expected3 = {0.9, M_PI};
-    bboxCenter(&bbox3, &center);
-    t_assert(geoAlmostEqual(&center, &expected3),
-             "on antimeridian as expected");
-}
-
-TEST(bboxIsTransmeridian) {
-    BBox bboxNormal = {1.0, 0.8, 1.0, 0.8};
-    t_assert(!bboxIsTransmeridian(&bboxNormal),
-             "Normal bbox not transmeridian");
-
-    BBox bboxTransmeridian = {1.0, 0.8, -M_PI + 0.3, M_PI - 0.1};
-    t_assert(bboxIsTransmeridian(&bboxTransmeridian),
-             "Transmeridian bbox is transmeridian");
-}
-
-END_TESTS();

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -24,213 +24,214 @@ H3Index sunnyvale = 0x89283470c27ffff;
 H3Index uncompactable[] = {0x89283470803ffff, 0x8928347081bffff,
                            0x8928347080bffff};
 
-BEGIN_TESTS(compact);
+SUITE(compact) {
+    TEST(roundtrip) {
+        int k = 9;
+        int hexCount = H3_EXPORT(maxKringSize)(k);
+        int expectedCompactCount = 73;
 
-TEST(roundtrip) {
-    int k = 9;
-    int hexCount = H3_EXPORT(maxKringSize)(k);
-    int expectedCompactCount = 73;
+        // Generate a set of hexagons to compact
+        H3Index* sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
+        H3_EXPORT(kRing)(sunnyvale, k, sunnyvaleExpanded);
 
-    // Generate a set of hexagons to compact
-    H3Index* sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
-    H3_EXPORT(kRing)(sunnyvale, k, sunnyvaleExpanded);
+        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        int err = H3_EXPORT(compact)(sunnyvaleExpanded, compressed, hexCount);
+        t_assert(err == 0, "no error on compact");
 
-    H3Index* compressed = calloc(hexCount, sizeof(H3Index));
-    int err = H3_EXPORT(compact)(sunnyvaleExpanded, compressed, hexCount);
-    t_assert(err == 0, "no error on compact");
-
-    int count = 0;
-    for (int i = 0; i < hexCount; i++) {
-        if (compressed[i] != 0) {
-            count++;
+        int count = 0;
+        for (int i = 0; i < hexCount; i++) {
+            if (compressed[i] != 0) {
+                count++;
+            }
         }
-    }
-    t_assert(count == expectedCompactCount, "got expected compacted count");
+        t_assert(count == expectedCompactCount, "got expected compacted count");
 
-    H3Index* decompressed = calloc(
-        H3_EXPORT(maxUncompactSize)(compressed, count, 9), sizeof(H3Index));
-    int err2 =
-        H3_EXPORT(uncompact)(compressed, count, decompressed, hexCount, 9);
-    t_assert(err2 == 0, "no error on uncompact");
+        H3Index* decompressed = calloc(
+            H3_EXPORT(maxUncompactSize)(compressed, count, 9), sizeof(H3Index));
+        int err2 =
+            H3_EXPORT(uncompact)(compressed, count, decompressed, hexCount, 9);
+        t_assert(err2 == 0, "no error on uncompact");
 
-    int count2 = 0;
-    for (int i = 0; i < hexCount; i++) {
-        if (decompressed[i] != 0) {
-            count2++;
+        int count2 = 0;
+        for (int i = 0; i < hexCount; i++) {
+            if (decompressed[i] != 0) {
+                count2++;
+            }
         }
-    }
-    t_assert(count2 == hexCount, "got expected uncompacted count");
+        t_assert(count2 == hexCount, "got expected uncompacted count");
 
-    free(compressed);
-    free(decompressed);
-    free(sunnyvaleExpanded);
-}
-
-TEST(res0) {
-    int hexCount = NUM_BASE_CELLS;
-
-    H3Index* res0Hexes = calloc(hexCount, sizeof(H3Index));
-    for (int i = 0; i < hexCount; i++) {
-        setH3Index(&res0Hexes[i], 0, i, 0);
-    }
-    H3Index* compressed = calloc(hexCount, sizeof(H3Index));
-    int err = H3_EXPORT(compact)(res0Hexes, compressed, hexCount);
-    t_assert(err == 0, "no error on compact");
-
-    for (int i = 0; i < hexCount; i++) {
-        // At resolution 0, it will be an exact copy.
-        // The test is further optimizing that it will be in order (which isn't
-        // guaranteed.)
-        t_assert(compressed[i] == res0Hexes[i],
-                 "got expected compressed result");
+        free(compressed);
+        free(decompressed);
+        free(sunnyvaleExpanded);
     }
 
-    H3Index* decompressed = calloc(
-        H3_EXPORT(maxUncompactSize)(compressed, hexCount, 0), sizeof(H3Index));
-    int err2 =
-        H3_EXPORT(uncompact)(compressed, hexCount, decompressed, hexCount, 0);
-    t_assert(err2 == 0, "no error on uncompact");
+    TEST(res0) {
+        int hexCount = NUM_BASE_CELLS;
 
-    int count2 = 0;
-    for (int i = 0; i < hexCount; i++) {
-        if (decompressed[i] != 0) {
-            count2++;
+        H3Index* res0Hexes = calloc(hexCount, sizeof(H3Index));
+        for (int i = 0; i < hexCount; i++) {
+            setH3Index(&res0Hexes[i], 0, i, 0);
         }
-    }
-    t_assert(count2 == hexCount, "got expected uncompacted count");
+        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        int err = H3_EXPORT(compact)(res0Hexes, compressed, hexCount);
+        t_assert(err == 0, "no error on compact");
 
-    free(res0Hexes);
-    free(compressed);
-    free(decompressed);
-}
-
-TEST(uncompactable) {
-    int hexCount = 3;
-    int expectedCompactCount = 3;
-
-    H3Index* compressed = calloc(hexCount, sizeof(H3Index));
-    int err = H3_EXPORT(compact)(uncompactable, compressed, hexCount);
-    t_assert(err == 0, "no error on compact");
-
-    int count = 0;
-    for (int i = 0; i < hexCount; i++) {
-        if (compressed[i] != 0) {
-            count++;
+        for (int i = 0; i < hexCount; i++) {
+            // At resolution 0, it will be an exact copy.
+            // The test is further optimizing that it will be in order (which
+            // isn't guaranteed.)
+            t_assert(compressed[i] == res0Hexes[i],
+                     "got expected compressed result");
         }
-    }
-    t_assert(count == expectedCompactCount, "got expected compacted count");
 
-    H3Index* decompressed = calloc(
-        H3_EXPORT(maxUncompactSize)(compressed, count, 9), sizeof(H3Index));
-    int err2 =
-        H3_EXPORT(uncompact)(compressed, count, decompressed, hexCount, 9);
-    t_assert(err2 == 0, "no error on uncompact");
+        H3Index* decompressed =
+            calloc(H3_EXPORT(maxUncompactSize)(compressed, hexCount, 0),
+                   sizeof(H3Index));
+        int err2 = H3_EXPORT(uncompact)(compressed, hexCount, decompressed,
+                                        hexCount, 0);
+        t_assert(err2 == 0, "no error on uncompact");
 
-    int count2 = 0;
-    for (int i = 0; i < hexCount; i++) {
-        if (decompressed[i] != 0) {
-            count2++;
+        int count2 = 0;
+        for (int i = 0; i < hexCount; i++) {
+            if (decompressed[i] != 0) {
+                count2++;
+            }
         }
-    }
-    t_assert(count2 == hexCount, "got expected uncompacted count");
+        t_assert(count2 == hexCount, "got expected uncompacted count");
 
-    free(compressed);
-    free(decompressed);
-}
-
-TEST(compact_duplicate) {
-    int numHex = 10;
-    H3Index someHexagons[10] = {0};
-    for (int i = 0; i < numHex; i++) {
-        setH3Index(&someHexagons[i], 5, 0, 2);
-    }
-    H3Index compressed[10];
-
-    t_assert(H3_EXPORT(compact)(someHexagons, compressed, numHex) != 0,
-             "compact fails on duplicate input");
-}
-
-TEST(uncompact_wrongRes) {
-    int numHex = 3;
-    H3Index someHexagons[] = {0, 0, 0};
-    for (int i = 0; i < numHex; i++) {
-        setH3Index(&someHexagons[i], 5, i, 0);
+        free(res0Hexes);
+        free(compressed);
+        free(decompressed);
     }
 
-    int sizeResult = H3_EXPORT(maxUncompactSize)(someHexagons, numHex, 4);
-    t_assert(sizeResult < 0,
-             "maxUncompactSize fails when given illogical resolutions");
-    sizeResult = H3_EXPORT(maxUncompactSize)(someHexagons, numHex, -1);
-    t_assert(sizeResult < 0,
-             "maxUncompactSize fails when given illegal resolutions");
+    TEST(uncompactable) {
+        int hexCount = 3;
+        int expectedCompactCount = 3;
 
-    H3Index uncompressed[] = {0, 0, 0};
-    int uncompactResult =
-        H3_EXPORT(uncompact)(someHexagons, numHex, uncompressed, numHex, 0);
-    t_assert(uncompactResult != 0,
-             "uncompact fails when given illogical resolutions");
-    uncompactResult =
-        H3_EXPORT(uncompact)(someHexagons, numHex, uncompressed, numHex, 6);
-    t_assert(uncompactResult != 0,
-             "uncompact fails when given too little buffer");
-    uncompactResult =
-        H3_EXPORT(uncompact)(someHexagons, numHex, uncompressed, numHex - 1, 5);
-    t_assert(uncompactResult != 0,
-             "uncompact fails when given too little buffer (same resolution)");
-}
+        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        int err = H3_EXPORT(compact)(uncompactable, compressed, hexCount);
+        t_assert(err == 0, "no error on compact");
 
-TEST(someHexagon) {
-    H3Index origin;
-    setH3Index(&origin, 1, 5, 0);
-
-    int childrenSz = H3_EXPORT(maxUncompactSize)(&origin, 1, 2);
-    H3Index* children = calloc(childrenSz, sizeof(H3Index));
-    int uncompactResult =
-        H3_EXPORT(uncompact)(&origin, 1, children, childrenSz, 2);
-    t_assert(uncompactResult == 0, "uncompact origin succeeds");
-
-    H3Index* result = calloc(childrenSz, sizeof(H3Index));
-    int compactResult = H3_EXPORT(compact)(children, result, childrenSz);
-    t_assert(compactResult == 0, "compact origin succeeds");
-
-    int found = 0;
-    for (int i = 0; i < childrenSz; i++) {
-        if (result[i] != 0) {
-            found++;
-            t_assert(result[i] == origin, "compacted to correct origin");
+        int count = 0;
+        for (int i = 0; i < hexCount; i++) {
+            if (compressed[i] != 0) {
+                count++;
+            }
         }
-    }
-    t_assert(found == 1, "compacted to a single hexagon");
+        t_assert(count == expectedCompactCount, "got expected compacted count");
 
-    free(children);
-    free(result);
-}
+        H3Index* decompressed = calloc(
+            H3_EXPORT(maxUncompactSize)(compressed, count, 9), sizeof(H3Index));
+        int err2 =
+            H3_EXPORT(uncompact)(compressed, count, decompressed, hexCount, 9);
+        t_assert(err2 == 0, "no error on uncompact");
 
-TEST(pentagon) {
-    H3Index pentagon;
-    setH3Index(&pentagon, 1, 4, 0);
-
-    int childrenSz = H3_EXPORT(maxUncompactSize)(&pentagon, 1, 2);
-    H3Index* children = calloc(childrenSz, sizeof(H3Index));
-    int uncompactResult =
-        H3_EXPORT(uncompact)(&pentagon, 1, children, childrenSz, 2);
-    t_assert(uncompactResult == 0, "uncompact pentagon succeeds");
-
-    H3Index* result = calloc(childrenSz, sizeof(H3Index));
-    int compactResult = H3_EXPORT(compact)(children, result, childrenSz);
-    t_assert(compactResult == 0, "compact pentagon succeeds");
-
-    int found = 0;
-    for (int i = 0; i < childrenSz; i++) {
-        if (result[i] != 0) {
-            found++;
-            t_assert(result[i] == pentagon, "compacted to correct pentagon");
+        int count2 = 0;
+        for (int i = 0; i < hexCount; i++) {
+            if (decompressed[i] != 0) {
+                count2++;
+            }
         }
+        t_assert(count2 == hexCount, "got expected uncompacted count");
+
+        free(compressed);
+        free(decompressed);
     }
-    t_assert(found == 1, "compacted to a single pentagon");
 
-    free(children);
-    free(result);
+    TEST(compact_duplicate) {
+        int numHex = 10;
+        H3Index someHexagons[10] = {0};
+        for (int i = 0; i < numHex; i++) {
+            setH3Index(&someHexagons[i], 5, 0, 2);
+        }
+        H3Index compressed[10];
+
+        t_assert(H3_EXPORT(compact)(someHexagons, compressed, numHex) != 0,
+                 "compact fails on duplicate input");
+    }
+
+    TEST(uncompact_wrongRes) {
+        int numHex = 3;
+        H3Index someHexagons[] = {0, 0, 0};
+        for (int i = 0; i < numHex; i++) {
+            setH3Index(&someHexagons[i], 5, i, 0);
+        }
+
+        int sizeResult = H3_EXPORT(maxUncompactSize)(someHexagons, numHex, 4);
+        t_assert(sizeResult < 0,
+                 "maxUncompactSize fails when given illogical resolutions");
+        sizeResult = H3_EXPORT(maxUncompactSize)(someHexagons, numHex, -1);
+        t_assert(sizeResult < 0,
+                 "maxUncompactSize fails when given illegal resolutions");
+
+        H3Index uncompressed[] = {0, 0, 0};
+        int uncompactResult =
+            H3_EXPORT(uncompact)(someHexagons, numHex, uncompressed, numHex, 0);
+        t_assert(uncompactResult != 0,
+                 "uncompact fails when given illogical resolutions");
+        uncompactResult =
+            H3_EXPORT(uncompact)(someHexagons, numHex, uncompressed, numHex, 6);
+        t_assert(uncompactResult != 0,
+                 "uncompact fails when given too little buffer");
+        uncompactResult = H3_EXPORT(uncompact)(someHexagons, numHex,
+                                               uncompressed, numHex - 1, 5);
+        t_assert(
+            uncompactResult != 0,
+            "uncompact fails when given too little buffer (same resolution)");
+    }
+
+    TEST(someHexagon) {
+        H3Index origin;
+        setH3Index(&origin, 1, 5, 0);
+
+        int childrenSz = H3_EXPORT(maxUncompactSize)(&origin, 1, 2);
+        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        int uncompactResult =
+            H3_EXPORT(uncompact)(&origin, 1, children, childrenSz, 2);
+        t_assert(uncompactResult == 0, "uncompact origin succeeds");
+
+        H3Index* result = calloc(childrenSz, sizeof(H3Index));
+        int compactResult = H3_EXPORT(compact)(children, result, childrenSz);
+        t_assert(compactResult == 0, "compact origin succeeds");
+
+        int found = 0;
+        for (int i = 0; i < childrenSz; i++) {
+            if (result[i] != 0) {
+                found++;
+                t_assert(result[i] == origin, "compacted to correct origin");
+            }
+        }
+        t_assert(found == 1, "compacted to a single hexagon");
+
+        free(children);
+        free(result);
+    }
+
+    TEST(pentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 1, 4, 0);
+
+        int childrenSz = H3_EXPORT(maxUncompactSize)(&pentagon, 1, 2);
+        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        int uncompactResult =
+            H3_EXPORT(uncompact)(&pentagon, 1, children, childrenSz, 2);
+        t_assert(uncompactResult == 0, "uncompact pentagon succeeds");
+
+        H3Index* result = calloc(childrenSz, sizeof(H3Index));
+        int compactResult = H3_EXPORT(compact)(children, result, childrenSz);
+        t_assert(compactResult == 0, "compact pentagon succeeds");
+
+        int found = 0;
+        for (int i = 0; i < childrenSz; i++) {
+            if (result[i] != 0) {
+                found++;
+                t_assert(result[i] == pentagon,
+                         "compacted to correct pentagon");
+            }
+        }
+        t_assert(found == 1, "compacted to a single pentagon");
+
+        free(children);
+        free(result);
+    }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testGeoCoord.c
+++ b/src/apps/testapps/testGeoCoord.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testGeoCoord.c
+++ b/src/apps/testapps/testGeoCoord.c
@@ -42,149 +42,149 @@ void testDecreasingFunction(double (*function)(int), const char* message) {
     }
 }
 
-BEGIN_TESTS(geoCoord);
+SUITE(geoCoord) {
+    TEST(radsToDegs) {
+        double originalRads = 1;
+        double degs = H3_EXPORT(radsToDegs)(originalRads);
+        double rads = H3_EXPORT(degsToRads)(degs);
+        t_assert(fabs(rads - originalRads) < EPSILON_RAD,
+                 "radsToDegs/degsToRads invertible");
+    }
 
-TEST(radsToDegs) {
-    double originalRads = 1;
-    double degs = H3_EXPORT(radsToDegs)(originalRads);
-    double rads = H3_EXPORT(degsToRads)(degs);
-    t_assert(fabs(rads - originalRads) < EPSILON_RAD,
-             "radsToDegs/degsToRads invertible");
-}
+    TEST(_geoDistRads) {
+        GeoCoord p1;
+        setGeoDegs(&p1, 10, 10);
+        GeoCoord p2;
+        setGeoDegs(&p2, 0, 10);
 
-TEST(_geoDistRads) {
-    GeoCoord p1;
-    setGeoDegs(&p1, 10, 10);
-    GeoCoord p2;
-    setGeoDegs(&p2, 0, 10);
+        // TODO: Epsilon is relatively large
+        t_assert(_geoDistRads(&p1, &p1) < EPSILON_RAD * 1000,
+                 "0 distance as expected");
+        t_assert(fabs(_geoDistRads(&p1, &p2) - H3_EXPORT(degsToRads)(10)) <
+                     EPSILON_RAD * 1000,
+                 "distance along longitude as expected");
+    }
 
-    // TODO: Epsilon is relatively large
-    t_assert(_geoDistRads(&p1, &p1) < EPSILON_RAD * 1000,
-             "0 distance as expected");
-    t_assert(fabs(_geoDistRads(&p1, &p2) - H3_EXPORT(degsToRads)(10)) <
-                 EPSILON_RAD * 1000,
-             "distance along longitude as expected");
-}
+    TEST(constrainLatLng) {
+        t_assert(constrainLat(0) == 0, "lat 0");
+        t_assert(constrainLat(1) == 1, "lat 1");
+        t_assert(constrainLat(M_PI_2) == M_PI_2, "lat pi/2");
+        t_assert(constrainLat(M_PI) == 0, "lat pi");
+        t_assert(constrainLat(M_PI + 1) == 1, "lat pi+1");
+        t_assert(constrainLat(2 * M_PI + 1) == 1, "lat 2pi+1");
 
-TEST(constrainLatLng) {
-    t_assert(constrainLat(0) == 0, "lat 0");
-    t_assert(constrainLat(1) == 1, "lat 1");
-    t_assert(constrainLat(M_PI_2) == M_PI_2, "lat pi/2");
-    t_assert(constrainLat(M_PI) == 0, "lat pi");
-    t_assert(constrainLat(M_PI + 1) == 1, "lat pi+1");
-    t_assert(constrainLat(2 * M_PI + 1) == 1, "lat 2pi+1");
+        t_assert(constrainLng(0) == 0, "lng 0");
+        t_assert(constrainLng(1) == 1, "lng 1");
+        t_assert(constrainLng(M_PI) == M_PI, "lng pi");
+        t_assert(constrainLng(2 * M_PI) == 0, "lng 2pi");
+        t_assert(constrainLng(3 * M_PI) == M_PI, "lng 2pi");
+        t_assert(constrainLng(4 * M_PI) == 0, "lng 4pi");
+    }
 
-    t_assert(constrainLng(0) == 0, "lng 0");
-    t_assert(constrainLng(1) == 1, "lng 1");
-    t_assert(constrainLng(M_PI) == M_PI, "lng pi");
-    t_assert(constrainLng(2 * M_PI) == 0, "lng 2pi");
-    t_assert(constrainLng(3 * M_PI) == M_PI, "lng 2pi");
-    t_assert(constrainLng(4 * M_PI) == 0, "lng 4pi");
-}
+    TEST(_geoAzDistanceRads_noop) {
+        GeoCoord start = {15, 10};
+        GeoCoord out;
+        GeoCoord expected = {15, 10};
 
-TEST(_geoAzDistanceRads_noop) {
-    GeoCoord start = {15, 10};
-    GeoCoord out;
-    GeoCoord expected = {15, 10};
+        _geoAzDistanceRads(&start, 0, 0, &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "0 distance produces same point");
+    }
 
-    _geoAzDistanceRads(&start, 0, 0, &out);
-    t_assert(geoAlmostEqual(&expected, &out), "0 distance produces same point");
-}
+    TEST(_geoAzDistanceRads_dueNorthSouth) {
+        GeoCoord start;
+        GeoCoord out;
+        GeoCoord expected;
 
-TEST(_geoAzDistanceRads_dueNorthSouth) {
-    GeoCoord start;
-    GeoCoord out;
-    GeoCoord expected;
+        // Due north to north pole
+        setGeoDegs(&start, 45, 1);
+        setGeoDegs(&expected, 90, 0);
+        _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(45), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "due north to north pole produces north pole");
 
-    // Due north to north pole
-    setGeoDegs(&start, 45, 1);
-    setGeoDegs(&expected, 90, 0);
-    _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(45), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "due north to north pole produces north pole");
+        // Due north to south pole, which doesn't get wrapped correctly
+        setGeoDegs(&start, 45, 1);
+        setGeoDegs(&expected, 270, 1);
+        _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(45 + 180), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "due north to south pole produces south pole");
 
-    // Due north to south pole, which doesn't get wrapped correctly
-    setGeoDegs(&start, 45, 1);
-    setGeoDegs(&expected, 270, 1);
-    _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(45 + 180), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "due north to south pole produces south pole");
+        // Due south to south pole
+        setGeoDegs(&start, -45, 2);
+        setGeoDegs(&expected, -90, 0);
+        _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(180),
+                           H3_EXPORT(degsToRads)(45), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "due south to south pole produces south pole");
 
-    // Due south to south pole
-    setGeoDegs(&start, -45, 2);
-    setGeoDegs(&expected, -90, 0);
-    _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(180),
-                       H3_EXPORT(degsToRads)(45), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "due south to south pole produces south pole");
+        // Due north to non-pole
+        setGeoDegs(&start, -45, 10);
+        setGeoDegs(&expected, -10, 10);
+        _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(35), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "due north produces expected result");
+    }
 
-    // Due north to non-pole
-    setGeoDegs(&start, -45, 10);
-    setGeoDegs(&expected, -10, 10);
-    _geoAzDistanceRads(&start, 0, H3_EXPORT(degsToRads)(35), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "due north produces expected result");
-}
+    TEST(_geoAzDistanceRads_poleToPole) {
+        GeoCoord start;
+        GeoCoord out;
+        GeoCoord expected;
 
-TEST(_geoAzDistanceRads_poleToPole) {
-    GeoCoord start;
-    GeoCoord out;
-    GeoCoord expected;
+        // Azimuth doesn't really matter in this case. Any azimuth from the
+        // north pole is south, any azimuth from the south pole is north.
 
-    // Azimuth doesn't really matter in this case. Any azimuth from the north
-    // pole is south, any azimuth from the south pole is north.
+        setGeoDegs(&start, 90, 0);
+        setGeoDegs(&expected, -90, 0);
+        _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(12),
+                           H3_EXPORT(degsToRads)(180), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "some direction to south pole produces south pole");
 
-    setGeoDegs(&start, 90, 0);
-    setGeoDegs(&expected, -90, 0);
-    _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(12),
-                       H3_EXPORT(degsToRads)(180), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "some direction to south pole produces south pole");
+        setGeoDegs(&start, -90, 0);
+        setGeoDegs(&expected, 90, 0);
+        _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(34),
+                           H3_EXPORT(degsToRads)(180), &out);
+        t_assert(geoAlmostEqual(&expected, &out),
+                 "some direction to north pole produces north pole");
+    }
 
-    setGeoDegs(&start, -90, 0);
-    setGeoDegs(&expected, 90, 0);
-    _geoAzDistanceRads(&start, H3_EXPORT(degsToRads)(34),
-                       H3_EXPORT(degsToRads)(180), &out);
-    t_assert(geoAlmostEqual(&expected, &out),
-             "some direction to north pole produces north pole");
-}
+    TEST(_geoAzDistanceRads_invertible) {
+        GeoCoord start;
+        setGeoDegs(&start, 15, 10);
+        GeoCoord out;
 
-TEST(_geoAzDistanceRads_invertible) {
-    GeoCoord start;
-    setGeoDegs(&start, 15, 10);
-    GeoCoord out;
+        double azimuth = H3_EXPORT(degsToRads)(20);
+        double degrees180 = H3_EXPORT(degsToRads)(180);
+        double distance = H3_EXPORT(degsToRads)(15);
 
-    double azimuth = H3_EXPORT(degsToRads)(20);
-    double degrees180 = H3_EXPORT(degsToRads)(180);
-    double distance = H3_EXPORT(degsToRads)(15);
+        _geoAzDistanceRads(&start, azimuth, distance, &out);
+        t_assert(fabs(_geoDistRads(&start, &out) - distance) < EPSILON_RAD,
+                 "moved distance is as expected");
 
-    _geoAzDistanceRads(&start, azimuth, distance, &out);
-    t_assert(fabs(_geoDistRads(&start, &out) - distance) < EPSILON_RAD,
-             "moved distance is as expected");
+        GeoCoord start2 = out;
+        _geoAzDistanceRads(&start2, azimuth + degrees180, distance, &out);
+        // TODO: Epsilon is relatively large
+        t_assert(_geoDistRads(&start, &out) < 0.01, "moved back to origin");
+    }
 
-    GeoCoord start2 = out;
-    _geoAzDistanceRads(&start2, azimuth + degrees180, distance, &out);
-    // TODO: Epsilon is relatively large
-    t_assert(_geoDistRads(&start, &out) < 0.01, "moved back to origin");
-}
+    TEST(doubleConstants) {
+        // Simple checks for ordering of values
+        testDecreasingFunction(H3_EXPORT(hexAreaKm2), "hexAreaKm2 ordering");
+        testDecreasingFunction(H3_EXPORT(hexAreaM2), "hexAreaM2 ordering");
+        testDecreasingFunction(H3_EXPORT(edgeLengthKm),
+                               "edgeLengthKm ordering");
+        testDecreasingFunction(H3_EXPORT(edgeLengthM), "edgeLengthM ordering");
+    }
 
-TEST(doubleConstants) {
-    // Simple checks for ordering of values
-    testDecreasingFunction(H3_EXPORT(hexAreaKm2), "hexAreaKm2 ordering");
-    testDecreasingFunction(H3_EXPORT(hexAreaM2), "hexAreaM2 ordering");
-    testDecreasingFunction(H3_EXPORT(edgeLengthKm), "edgeLengthKm ordering");
-    testDecreasingFunction(H3_EXPORT(edgeLengthM), "edgeLengthM ordering");
-}
-
-TEST(intConstants) {
-    // Simple checks for ordering of values
-    int64_t last = 0;
-    int64_t next;
-    for (int i = 0; i <= MAX_H3_RES; i++) {
-        next = H3_EXPORT(numHexagons)(i);
-        t_assert(next > last, "numHexagons ordering");
-        last = next;
+    TEST(intConstants) {
+        // Simple checks for ordering of values
+        int64_t last = 0;
+        int64_t next;
+        for (int i = 0; i <= MAX_H3_RES; i++) {
+            next = H3_EXPORT(numHexagons)(i);
+            t_assert(next > last, "numHexagons ordering");
+            last = next;
+        }
     }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testGeoToH3.c
+++ b/src/apps/testapps/testGeoToH3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testGeoToH3.c
+++ b/src/apps/testapps/testGeoToH3.c
@@ -31,7 +31,7 @@
 #include "test.h"
 #include "utility.h"
 
-static inline void assertExpected(H3Index h1, const GeoCoord* g1) {
+static void assertExpected(H3Index h1, const GeoCoord* g1) {
     // convert lat/lon to H3 and verify
     int res = H3_EXPORT(h3GetResolution)(h1);
     H3Index h2 = H3_EXPORT(geoToH3)(g1, res);

--- a/src/apps/testapps/testGeoToH3.c
+++ b/src/apps/testapps/testGeoToH3.c
@@ -31,7 +31,7 @@
 #include "test.h"
 #include "utility.h"
 
-void assertExpected(H3Index h1, const GeoCoord* g1) {
+static inline void assertExpected(H3Index h1, const GeoCoord* g1) {
     // convert lat/lon to H3 and verify
     int res = H3_EXPORT(h3GetResolution)(h1);
     H3Index h2 = H3_EXPORT(geoToH3)(g1, res);

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -25,58 +25,57 @@
 #include "test.h"
 #include "utility.h"
 
-BEGIN_TESTS(h3Api);
+SUITE(h3Api) {
+    TEST(geoToH3_res) {
+        GeoCoord anywhere = {0, 0};
 
-TEST(geoToH3_res) {
-    GeoCoord anywhere = {0, 0};
+        t_assert(H3_EXPORT(geoToH3)(&anywhere, -1) == 0,
+                 "resolution below 0 is invalid");
+        t_assert(H3_EXPORT(geoToH3)(&anywhere, 16) == 0,
+                 "resolution above 15 is invalid");
+    }
 
-    t_assert(H3_EXPORT(geoToH3)(&anywhere, -1) == 0,
-             "resolution below 0 is invalid");
-    t_assert(H3_EXPORT(geoToH3)(&anywhere, 16) == 0,
-             "resolution above 15 is invalid");
-}
+    TEST(geoToH3_coord) {
+        GeoCoord invalidLat = {NAN, 0};
+        GeoCoord invalidLon = {0, NAN};
+        GeoCoord invalidLatLon = {INFINITY, -INFINITY};
 
-TEST(geoToH3_coord) {
-    GeoCoord invalidLat = {NAN, 0};
-    GeoCoord invalidLon = {0, NAN};
-    GeoCoord invalidLatLon = {INFINITY, -INFINITY};
+        t_assert(H3_EXPORT(geoToH3)(&invalidLat, 1) == 0,
+                 "invalid latitude is rejected");
+        t_assert(H3_EXPORT(geoToH3)(&invalidLon, 1) == 0,
+                 "invalid longitude is rejected");
+        t_assert(H3_EXPORT(geoToH3)(&invalidLatLon, 1) == 0,
+                 "coordinates with infinity are rejected");
+    }
 
-    t_assert(H3_EXPORT(geoToH3)(&invalidLat, 1) == 0,
-             "invalid latitude is rejected");
-    t_assert(H3_EXPORT(geoToH3)(&invalidLon, 1) == 0,
-             "invalid longitude is rejected");
-    t_assert(H3_EXPORT(geoToH3)(&invalidLatLon, 1) == 0,
-             "coordinates with infinity are rejected");
-}
+    TEST(h3ToGeoBoundary_classIIIEdgeVertex) {
+        // Bug test for https://github.com/uber/h3/issues/45
+        char* hexes[] = {
+            "894cc5349b7ffff", "894cc534d97ffff", "894cc53682bffff",
+            "894cc536b17ffff", "894cc53688bffff", "894cead92cbffff",
+            "894cc536537ffff", "894cc5acbabffff", "894cc536597ffff"};
+        int numHexes = sizeof(hexes) / sizeof(hexes[0]);
+        H3Index h3;
+        GeoBoundary b;
+        for (int i = 0; i < numHexes; i++) {
+            h3 = H3_EXPORT(stringToH3)(hexes[i]);
+            H3_EXPORT(h3ToGeoBoundary)(h3, &b);
+            t_assert(b.numVerts == 7, "got expected vertex count");
+        }
+    }
 
-TEST(h3ToGeoBoundary_classIIIEdgeVertex) {
-    // Bug test for https://github.com/uber/h3/issues/45
-    char* hexes[] = {"894cc5349b7ffff", "894cc534d97ffff", "894cc53682bffff",
-                     "894cc536b17ffff", "894cc53688bffff", "894cead92cbffff",
-                     "894cc536537ffff", "894cc5acbabffff", "894cc536597ffff"};
-    int numHexes = sizeof(hexes) / sizeof(hexes[0]);
-    H3Index h3;
-    GeoBoundary b;
-    for (int i = 0; i < numHexes; i++) {
-        h3 = H3_EXPORT(stringToH3)(hexes[i]);
-        H3_EXPORT(h3ToGeoBoundary)(h3, &b);
-        t_assert(b.numVerts == 7, "got expected vertex count");
+    TEST(h3ToGeoBoundary_classIIIEdgeVertex_exact) {
+        // Bug test for https://github.com/uber/h3/issues/45
+        H3Index h3 = H3_EXPORT(stringToH3)("894cc536537ffff");
+        GeoBoundary boundary;
+        boundary.numVerts = 7;
+        setGeoDegs(&boundary.verts[0], 18.043333154, -66.27836523500002);
+        setGeoDegs(&boundary.verts[1], 18.042238363, -66.27929062800001);
+        setGeoDegs(&boundary.verts[2], 18.040818259, -66.27854193899998);
+        setGeoDegs(&boundary.verts[3], 18.040492975, -66.27686786700002);
+        setGeoDegs(&boundary.verts[4], 18.041040385, -66.27640518300001);
+        setGeoDegs(&boundary.verts[5], 18.041757122, -66.27596711500001);
+        setGeoDegs(&boundary.verts[6], 18.043007860, -66.27669118199998);
+        t_assertBoundary(h3, &boundary);
     }
 }
-
-TEST(h3ToGeoBoundary_classIIIEdgeVertex_exact) {
-    // Bug test for https://github.com/uber/h3/issues/45
-    H3Index h3 = H3_EXPORT(stringToH3)("894cc536537ffff");
-    GeoBoundary boundary;
-    boundary.numVerts = 7;
-    setGeoDegs(&boundary.verts[0], 18.043333154, -66.27836523500002);
-    setGeoDegs(&boundary.verts[1], 18.042238363, -66.27929062800001);
-    setGeoDegs(&boundary.verts[2], 18.040818259, -66.27854193899998);
-    setGeoDegs(&boundary.verts[3], 18.040492975, -66.27686786700002);
-    setGeoDegs(&boundary.verts[4], 18.041040385, -66.27640518300001);
-    setGeoDegs(&boundary.verts[5], 18.041757122, -66.27596711500001);
-    setGeoDegs(&boundary.verts[6], 18.043007860, -66.27669118199998);
-    t_assertBoundary(h3, &boundary);
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -27,146 +27,147 @@
 #include "test.h"
 #include "utility.h"
 
-BEGIN_TESTS(h3Index);
+SUITE(h3Index) {
+    TEST(geoToH3ExtremeCoordinates) {
+        // Check that none of these cause crashes.
+        GeoCoord g = {0, 1E45};
+        H3_EXPORT(geoToH3)(&g, 14);
 
-TEST(geoToH3ExtremeCoordinates) {
-    // Check that none of these cause crashes.
-    GeoCoord g = {0, 1E45};
-    H3_EXPORT(geoToH3)(&g, 14);
+        GeoCoord g2 = {1E46, 1E45};
+        H3_EXPORT(geoToH3)(&g2, 15);
 
-    GeoCoord g2 = {1E46, 1E45};
-    H3_EXPORT(geoToH3)(&g2, 15);
-
-    GeoCoord g4;
-    setGeoDegs(&g4, 2, -3E39);
-    H3_EXPORT(geoToH3)(&g4, 0);
-}
-
-TEST(faceIjkToH3ExtremeCoordinates) {
-    FaceIJK fijk0I = {0, {3, 0, 0}};
-    t_assert(_faceIjkToH3(&fijk0I, 0) == 0, "i out of bounds at res 0");
-    FaceIJK fijk0J = {1, {0, 4, 0}};
-    t_assert(_faceIjkToH3(&fijk0J, 0) == 0, "j out of bounds at res 0");
-    FaceIJK fijk0K = {2, {2, 0, 5}};
-    t_assert(_faceIjkToH3(&fijk0K, 0) == 0, "k out of bounds at res 0");
-
-    FaceIJK fijk1I = {3, {6, 0, 0}};
-    t_assert(_faceIjkToH3(&fijk1I, 1) == 0, "i out of bounds at res 1");
-    FaceIJK fijk1J = {4, {0, 7, 1}};
-    t_assert(_faceIjkToH3(&fijk1J, 1) == 0, "j out of bounds at res 1");
-    FaceIJK fijk1K = {5, {2, 0, 8}};
-    t_assert(_faceIjkToH3(&fijk1K, 1) == 0, "k out of bounds at res 1");
-
-    FaceIJK fijk2I = {6, {18, 0, 0}};
-    t_assert(_faceIjkToH3(&fijk2I, 2) == 0, "i out of bounds at res 2");
-    FaceIJK fijk2J = {7, {0, 19, 1}};
-    t_assert(_faceIjkToH3(&fijk2J, 2) == 0, "j out of bounds at res 2");
-    FaceIJK fijk2K = {8, {2, 0, 20}};
-    t_assert(_faceIjkToH3(&fijk2K, 2) == 0, "k out of bounds at res 2");
-}
-
-TEST(h3IsValidAtResolution) {
-    for (int i = 0; i <= MAX_H3_RES; i++) {
-        GeoCoord geoCoord = {0, 0};
-        H3Index h3 = H3_EXPORT(geoToH3)(&geoCoord, i);
-        char failureMessage[BUFF_SIZE];
-        sprintf(failureMessage, "h3IsValid failed on resolution %d", i);
-        t_assert(H3_EXPORT(h3IsValid)(h3), failureMessage);
+        GeoCoord g4;
+        setGeoDegs(&g4, 2, -3E39);
+        H3_EXPORT(geoToH3)(&g4, 0);
     }
-}
 
-TEST(h3IsValidDigits) {
-    GeoCoord geoCoord = {0, 0};
-    H3Index h3 = H3_EXPORT(geoToH3)(&geoCoord, 1);
-    // Set a bit for an unused digit to something else.
-    h3 ^= 1;
-    t_assert(!H3_EXPORT(h3IsValid)(h3),
-             "h3IsValid failed on invalid unused digits");
-}
+    TEST(faceIjkToH3ExtremeCoordinates) {
+        FaceIJK fijk0I = {0, {3, 0, 0}};
+        t_assert(_faceIjkToH3(&fijk0I, 0) == 0, "i out of bounds at res 0");
+        FaceIJK fijk0J = {1, {0, 4, 0}};
+        t_assert(_faceIjkToH3(&fijk0J, 0) == 0, "j out of bounds at res 0");
+        FaceIJK fijk0K = {2, {2, 0, 5}};
+        t_assert(_faceIjkToH3(&fijk0K, 0) == 0, "k out of bounds at res 0");
 
-TEST(h3IsValidBaseCell) {
-    for (int i = 0; i < NUM_BASE_CELLS; i++) {
+        FaceIJK fijk1I = {3, {6, 0, 0}};
+        t_assert(_faceIjkToH3(&fijk1I, 1) == 0, "i out of bounds at res 1");
+        FaceIJK fijk1J = {4, {0, 7, 1}};
+        t_assert(_faceIjkToH3(&fijk1J, 1) == 0, "j out of bounds at res 1");
+        FaceIJK fijk1K = {5, {2, 0, 8}};
+        t_assert(_faceIjkToH3(&fijk1K, 1) == 0, "k out of bounds at res 1");
+
+        FaceIJK fijk2I = {6, {18, 0, 0}};
+        t_assert(_faceIjkToH3(&fijk2I, 2) == 0, "i out of bounds at res 2");
+        FaceIJK fijk2J = {7, {0, 19, 1}};
+        t_assert(_faceIjkToH3(&fijk2J, 2) == 0, "j out of bounds at res 2");
+        FaceIJK fijk2K = {8, {2, 0, 20}};
+        t_assert(_faceIjkToH3(&fijk2K, 2) == 0, "k out of bounds at res 2");
+    }
+
+    TEST(h3IsValidAtResolution) {
+        for (int i = 0; i <= MAX_H3_RES; i++) {
+            GeoCoord geoCoord = {0, 0};
+            H3Index h3 = H3_EXPORT(geoToH3)(&geoCoord, i);
+            char failureMessage[BUFF_SIZE];
+            sprintf(failureMessage, "h3IsValid failed on resolution %d", i);
+            t_assert(H3_EXPORT(h3IsValid)(h3), failureMessage);
+        }
+    }
+
+    TEST(h3IsValidDigits) {
+        GeoCoord geoCoord = {0, 0};
+        H3Index h3 = H3_EXPORT(geoToH3)(&geoCoord, 1);
+        // Set a bit for an unused digit to something else.
+        h3 ^= 1;
+        t_assert(!H3_EXPORT(h3IsValid)(h3),
+                 "h3IsValid failed on invalid unused digits");
+    }
+
+    TEST(h3IsValidBaseCell) {
+        for (int i = 0; i < NUM_BASE_CELLS; i++) {
+            H3Index h = H3_INIT;
+            H3_SET_MODE(h, H3_HEXAGON_MODE);
+            H3_SET_BASE_CELL(h, i);
+            char failureMessage[BUFF_SIZE];
+            sprintf(failureMessage, "h3IsValid failed on base cell %d", i);
+            t_assert(H3_EXPORT(h3IsValid)(h), failureMessage);
+
+            t_assert(H3_EXPORT(h3GetBaseCell)(h) == i,
+                     "failed to recover base cell");
+        }
+    }
+
+    TEST(h3IsValidBaseCellInvalid) {
+        H3Index hWrongBaseCell = H3_INIT;
+        H3_SET_MODE(hWrongBaseCell, H3_HEXAGON_MODE);
+        H3_SET_BASE_CELL(hWrongBaseCell, NUM_BASE_CELLS);
+        t_assert(!H3_EXPORT(h3IsValid)(hWrongBaseCell),
+                 "h3IsValid failed on invalid base cell");
+    }
+
+    TEST(h3IsValidWithMode) {
+        for (int i = 0; i <= 0xf; i++) {
+            H3Index h = H3_INIT;
+            H3_SET_MODE(h, i);
+            char failureMessage[BUFF_SIZE];
+            sprintf(failureMessage, "h3IsValid failed on mode %d", i);
+            t_assert(!H3_EXPORT(h3IsValid)(h) || i == 1, failureMessage);
+        }
+    }
+
+    TEST(h3BadDigitInvalid) {
         H3Index h = H3_INIT;
         H3_SET_MODE(h, H3_HEXAGON_MODE);
-        H3_SET_BASE_CELL(h, i);
-        char failureMessage[BUFF_SIZE];
-        sprintf(failureMessage, "h3IsValid failed on base cell %d", i);
-        t_assert(H3_EXPORT(h3IsValid)(h), failureMessage);
+        H3_SET_RESOLUTION(h, 1);
+        t_assert(!H3_EXPORT(h3IsValid)(h),
+                 "h3IsValid failed on too large digit");
+    }
 
-        t_assert(H3_EXPORT(h3GetBaseCell)(h) == i,
-                 "failed to recover base cell");
+    TEST(h3ToString) {
+        const size_t bufSz = 17;
+        char buf[17] = {0};
+        H3_EXPORT(h3ToString)(0x1234, buf, bufSz - 1);
+        // Buffer should be unmodified because the size was too small
+        t_assert(buf[0] == 0, "h3ToString failed on buffer too small");
+        H3_EXPORT(h3ToString)(0xcafe, buf, bufSz);
+        t_assert(strcmp(buf, "cafe") == 0,
+                 "h3ToString failed to produce base 16 results");
+        H3_EXPORT(h3ToString)(0xffffffffffffffff, buf, bufSz);
+        t_assert(strcmp(buf, "ffffffffffffffff") == 0,
+                 "h3ToString failed on large input");
+        t_assert(buf[bufSz - 1] == 0, "didn't null terminate");
+    }
+
+    TEST(stringToH3) {
+        t_assert(H3_EXPORT(stringToH3)("") == 0, "got an index from nothing");
+        t_assert(H3_EXPORT(stringToH3)("**") == 0, "got an index from junk");
+        t_assert(
+            H3_EXPORT(stringToH3)("ffffffffffffffff") == 0xffffffffffffffff,
+            "failed on large input");
+    }
+
+    TEST(setH3Index) {
+        H3Index h;
+        setH3Index(&h, 5, 12, 1);
+        t_assert(H3_GET_RESOLUTION(h) == 5, "resolution as expected");
+        t_assert(H3_GET_BASE_CELL(h) == 12, "base cell as expected");
+        t_assert(H3_GET_MODE(h) == H3_HEXAGON_MODE, "mode as expected");
+        for (int i = 1; i <= 5; i++) {
+            t_assert(H3_GET_INDEX_DIGIT(h, i) == 1, "digit as expected");
+        }
+        for (int i = 6; i <= MAX_H3_RES; i++) {
+            t_assert(H3_GET_INDEX_DIGIT(h, i) == 7,
+                     "blanked digit as expected");
+        }
+        t_assert(h == 0x85184927fffffffL, "index matches expected");
+    }
+
+    TEST(h3IsResClassIII) {
+        GeoCoord coord = {0, 0};
+        for (int i = 0; i <= MAX_H3_RES; i++) {
+            H3Index h = H3_EXPORT(geoToH3)(&coord, i);
+            t_assert(H3_EXPORT(h3IsResClassIII)(h) == isResClassIII(i),
+                     "matches existing definition");
+        }
     }
 }
-
-TEST(h3IsValidBaseCellInvalid) {
-    H3Index hWrongBaseCell = H3_INIT;
-    H3_SET_MODE(hWrongBaseCell, H3_HEXAGON_MODE);
-    H3_SET_BASE_CELL(hWrongBaseCell, NUM_BASE_CELLS);
-    t_assert(!H3_EXPORT(h3IsValid)(hWrongBaseCell),
-             "h3IsValid failed on invalid base cell");
-}
-
-TEST(h3IsValidWithMode) {
-    for (int i = 0; i <= 0xf; i++) {
-        H3Index h = H3_INIT;
-        H3_SET_MODE(h, i);
-        char failureMessage[BUFF_SIZE];
-        sprintf(failureMessage, "h3IsValid failed on mode %d", i);
-        t_assert(!H3_EXPORT(h3IsValid)(h) || i == 1, failureMessage);
-    }
-}
-
-TEST(h3BadDigitInvalid) {
-    H3Index h = H3_INIT;
-    H3_SET_MODE(h, H3_HEXAGON_MODE);
-    H3_SET_RESOLUTION(h, 1);
-    t_assert(!H3_EXPORT(h3IsValid)(h), "h3IsValid failed on too large digit");
-}
-
-TEST(h3ToString) {
-    const size_t bufSz = 17;
-    char buf[17] = {0};
-    H3_EXPORT(h3ToString)(0x1234, buf, bufSz - 1);
-    // Buffer should be unmodified because the size was too small
-    t_assert(buf[0] == 0, "h3ToString failed on buffer too small");
-    H3_EXPORT(h3ToString)(0xcafe, buf, bufSz);
-    t_assert(strcmp(buf, "cafe") == 0,
-             "h3ToString failed to produce base 16 results");
-    H3_EXPORT(h3ToString)(0xffffffffffffffff, buf, bufSz);
-    t_assert(strcmp(buf, "ffffffffffffffff") == 0,
-             "h3ToString failed on large input");
-    t_assert(buf[bufSz - 1] == 0, "didn't null terminate");
-}
-
-TEST(stringToH3) {
-    t_assert(H3_EXPORT(stringToH3)("") == 0, "got an index from nothing");
-    t_assert(H3_EXPORT(stringToH3)("**") == 0, "got an index from junk");
-    t_assert(H3_EXPORT(stringToH3)("ffffffffffffffff") == 0xffffffffffffffff,
-             "failed on large input");
-}
-
-TEST(setH3Index) {
-    H3Index h;
-    setH3Index(&h, 5, 12, 1);
-    t_assert(H3_GET_RESOLUTION(h) == 5, "resolution as expected");
-    t_assert(H3_GET_BASE_CELL(h) == 12, "base cell as expected");
-    t_assert(H3_GET_MODE(h) == H3_HEXAGON_MODE, "mode as expected");
-    for (int i = 1; i <= 5; i++) {
-        t_assert(H3_GET_INDEX_DIGIT(h, i) == 1, "digit as expected");
-    }
-    for (int i = 6; i <= MAX_H3_RES; i++) {
-        t_assert(H3_GET_INDEX_DIGIT(h, i) == 7, "blanked digit as expected");
-    }
-    t_assert(h == 0x85184927fffffffL, "index matches expected");
-}
-
-TEST(h3IsResClassIII) {
-    GeoCoord coord = {0, 0};
-    for (int i = 0; i <= MAX_H3_RES; i++) {
-        H3Index h = H3_EXPORT(geoToH3)(&coord, i);
-        t_assert(H3_EXPORT(h3IsResClassIII)(h) == isResClassIII(i),
-                 "matches existing definition");
-    }
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3SetToLinkedGeo.c
+++ b/src/apps/testapps/testH3SetToLinkedGeo.c
@@ -19,251 +19,259 @@
 #include "test.h"
 #include "utility.h"
 
-BEGIN_TESTS(h3SetToLinkedGeo);
+SUITE(h3SetToLinkedGeo) {
+    TEST(empty) {
+        LinkedGeoPolygon polygon;
 
-TEST(empty) {
-    LinkedGeoPolygon polygon;
+        H3_EXPORT(h3SetToLinkedGeo)(NULL, 0, &polygon);
 
-    H3_EXPORT(h3SetToLinkedGeo)(NULL, 0, &polygon);
+        t_assert(countLinkedLoops(&polygon) == 0, "No loops added to polygon");
 
-    t_assert(countLinkedLoops(&polygon) == 0, "No loops added to polygon");
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
 
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    TEST(singleHex) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x890dab6220bffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 6,
+                 "6 coords added to loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(contiguous2) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x8928308291bffff, 0x89283082957ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 10,
+                 "All coords added to loop except 2 shared");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    // TODO: This test asserts incorrect behavior - we should be creating
+    // multiple polygons, each with their own single loop. Update when the
+    // algorithm is corrected.
+    TEST(nonContiguous2) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x8928308291bffff, 0x89283082943ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "2 polygons added");
+        t_assert(countLinkedLoops(&polygon) == 1,
+                 "1 loop on the first polygon");
+        t_assert(countLinkedCoords(polygon.first) == 6,
+                 "All coords for one hex added to first loop");
+        t_assert(countLinkedLoops(polygon.next) == 1,
+                 "Loop count on second polygon correct");
+        t_assert(countLinkedCoords(polygon.next->first) == 6,
+                 "All coords for one hex added to second polygon");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(contiguous3) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x8928308288bffff, 0x892830828d7ffff,
+                         0x8928308289bffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 12,
+                 "All coords added to loop except 6 shared");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(hole) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x892830828c7ffff, 0x892830828d7ffff,
+                         0x8928308289bffff, 0x89283082813ffff,
+                         0x8928308288fffff, 0x89283082883ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 2, "2 loops added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 6 * 3,
+                 "All outer coords added to first loop");
+        t_assert(countLinkedCoords(polygon.first->next) == 6,
+                 "All inner coords added to second loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(pentagon) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x851c0003fffffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 10,
+                 "10 coords (distorted pentagon) added to loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(2Ring) {
+        LinkedGeoPolygon polygon;
+        // 2-ring, in order returned by k-ring algo
+        H3Index set[] = {
+            0x8930062838bffff, 0x8930062838fffff, 0x89300628383ffff,
+            0x8930062839bffff, 0x893006283d7ffff, 0x893006283c7ffff,
+            0x89300628313ffff, 0x89300628317ffff, 0x893006283bbffff,
+            0x89300628387ffff, 0x89300628397ffff, 0x89300628393ffff,
+            0x89300628067ffff, 0x8930062806fffff, 0x893006283d3ffff,
+            0x893006283c3ffff, 0x893006283cfffff, 0x8930062831bffff,
+            0x89300628303ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == (6 * (2 * 2 + 1)),
+                 "Expected number of coords added to loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(2RingUnordered) {
+        LinkedGeoPolygon polygon;
+        // 2-ring in random order
+        H3Index set[] = {
+            0x89300628393ffff, 0x89300628383ffff, 0x89300628397ffff,
+            0x89300628067ffff, 0x89300628387ffff, 0x893006283bbffff,
+            0x89300628313ffff, 0x893006283cfffff, 0x89300628303ffff,
+            0x89300628317ffff, 0x8930062839bffff, 0x8930062838bffff,
+            0x8930062806fffff, 0x8930062838fffff, 0x893006283d3ffff,
+            0x893006283c3ffff, 0x8930062831bffff, 0x893006283d7ffff,
+            0x893006283c7ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == (6 * (2 * 2 + 1)),
+                 "Expected number of coords added to loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(nestedDonut) {
+        LinkedGeoPolygon polygon;
+        // hollow 1-ring + hollow 3-ring around the same hex
+        H3Index set[] = {
+            0x89283082813ffff, 0x8928308281bffff, 0x8928308280bffff,
+            0x8928308280fffff, 0x89283082807ffff, 0x89283082817ffff,
+            0x8928308289bffff, 0x892830828d7ffff, 0x892830828c3ffff,
+            0x892830828cbffff, 0x89283082853ffff, 0x89283082843ffff,
+            0x8928308284fffff, 0x8928308287bffff, 0x89283082863ffff,
+            0x89283082867ffff, 0x8928308282bffff, 0x89283082823ffff,
+            0x89283082837ffff, 0x892830828afffff, 0x892830828a3ffff,
+            0x892830828b3ffff, 0x89283082887ffff, 0x89283082883ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        // Note that the polygon order here is arbitrary, making this test
+        // somewhat brittle, but it's difficult to assert correctness otherwise
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 2,
+                 "Loop count on first polygon correct");
+        t_assert(countLinkedCoords(polygon.first) == 42,
+                 "Got expected big outer loop");
+        t_assert(countLinkedCoords(polygon.first->next) == 30,
+                 "Got expected big inner loop");
+        t_assert(countLinkedLoops(polygon.next) == 2,
+                 "Loop count on second polygon correct");
+        t_assert(countLinkedCoords(polygon.next->first) == 18,
+                 "Got expected outer loop");
+        t_assert(countLinkedCoords(polygon.next->first->next) == 6,
+                 "Got expected inner loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(nestedDonutTransmeridian) {
+        LinkedGeoPolygon polygon;
+        // hollow 1-ring + hollow 3-ring around the hex at (0, -180)
+        H3Index set[] = {
+            0x897eb5722c7ffff, 0x897eb5722cfffff, 0x897eb572257ffff,
+            0x897eb57220bffff, 0x897eb572203ffff, 0x897eb572213ffff,
+            0x897eb57266fffff, 0x897eb5722d3ffff, 0x897eb5722dbffff,
+            0x897eb573537ffff, 0x897eb573527ffff, 0x897eb57225bffff,
+            0x897eb57224bffff, 0x897eb57224fffff, 0x897eb57227bffff,
+            0x897eb572263ffff, 0x897eb572277ffff, 0x897eb57223bffff,
+            0x897eb572233ffff, 0x897eb5722abffff, 0x897eb5722bbffff,
+            0x897eb572287ffff, 0x897eb572283ffff, 0x897eb57229bffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        // Note that the polygon order here is arbitrary, making this test
+        // somewhat brittle, but it's difficult to assert correctness otherwise
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 2,
+                 "Loop count on first polygon correct");
+        t_assert(countLinkedCoords(polygon.first) == 18,
+                 "Got expected outer loop");
+        t_assert(countLinkedCoords(polygon.first->next) == 6,
+                 "Got expected inner loop");
+        t_assert(countLinkedLoops(polygon.next) == 2,
+                 "Loop count on second polygon correct");
+        t_assert(countLinkedCoords(polygon.next->first) == 42,
+                 "Got expected big outer loop");
+        t_assert(countLinkedCoords(polygon.next->first->next) == 30,
+                 "Got expected big inner loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(contiguous2distorted) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x894cc5365afffff, 0x894cc536537ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
+        t_assert(countLinkedCoords(polygon.first) == 12,
+                 "All coords added to loop except 2 shared");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(negativeHashedCoordinates) {
+        LinkedGeoPolygon polygon;
+        H3Index set[] = {0x88ad36c547fffff, 0x88ad36c467fffff};
+        int numHexes = ARRAY_SIZE(set);
+        H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "2 polygons added");
+        t_assert(countLinkedLoops(&polygon) == 1,
+                 "1 loop on the first polygon");
+        t_assert(countLinkedCoords(polygon.first) == 6,
+                 "All coords for one hex added to first loop");
+        t_assert(countLinkedLoops(polygon.next) == 1,
+                 "Loop count on second polygon correct");
+        t_assert(countLinkedCoords(polygon.next->first) == 6,
+                 "All coords for one hex added to second polygon");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
 }
-
-TEST(singleHex) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x890dab6220bffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 6, "6 coords added to loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(contiguous2) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x8928308291bffff, 0x89283082957ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 10,
-             "All coords added to loop except 2 shared");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-// TODO: This test asserts incorrect behavior - we should be creating multiple
-// polygons, each with their own single loop. Update when the algorithm is
-// corrected.
-TEST(nonContiguous2) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x8928308291bffff, 0x89283082943ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "2 polygons added");
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop on the first polygon");
-    t_assert(countLinkedCoords(polygon.first) == 6,
-             "All coords for one hex added to first loop");
-    t_assert(countLinkedLoops(polygon.next) == 1,
-             "Loop count on second polygon correct");
-    t_assert(countLinkedCoords(polygon.next->first) == 6,
-             "All coords for one hex added to second polygon");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(contiguous3) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x8928308288bffff, 0x892830828d7ffff, 0x8928308289bffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 12,
-             "All coords added to loop except 6 shared");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(hole) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x892830828c7ffff, 0x892830828d7ffff, 0x8928308289bffff,
-                     0x89283082813ffff, 0x8928308288fffff, 0x89283082883ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 2, "2 loops added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 6 * 3,
-             "All outer coords added to first loop");
-    t_assert(countLinkedCoords(polygon.first->next) == 6,
-             "All inner coords added to second loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(pentagon) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x851c0003fffffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 10,
-             "10 coords (distorted pentagon) added to loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(2Ring) {
-    LinkedGeoPolygon polygon;
-    // 2-ring, in order returned by k-ring algo
-    H3Index set[] = {0x8930062838bffff, 0x8930062838fffff, 0x89300628383ffff,
-                     0x8930062839bffff, 0x893006283d7ffff, 0x893006283c7ffff,
-                     0x89300628313ffff, 0x89300628317ffff, 0x893006283bbffff,
-                     0x89300628387ffff, 0x89300628397ffff, 0x89300628393ffff,
-                     0x89300628067ffff, 0x8930062806fffff, 0x893006283d3ffff,
-                     0x893006283c3ffff, 0x893006283cfffff, 0x8930062831bffff,
-                     0x89300628303ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == (6 * (2 * 2 + 1)),
-             "Expected number of coords added to loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(2RingUnordered) {
-    LinkedGeoPolygon polygon;
-    // 2-ring in random order
-    H3Index set[] = {0x89300628393ffff, 0x89300628383ffff, 0x89300628397ffff,
-                     0x89300628067ffff, 0x89300628387ffff, 0x893006283bbffff,
-                     0x89300628313ffff, 0x893006283cfffff, 0x89300628303ffff,
-                     0x89300628317ffff, 0x8930062839bffff, 0x8930062838bffff,
-                     0x8930062806fffff, 0x8930062838fffff, 0x893006283d3ffff,
-                     0x893006283c3ffff, 0x8930062831bffff, 0x893006283d7ffff,
-                     0x893006283c7ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == (6 * (2 * 2 + 1)),
-             "Expected number of coords added to loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(nestedDonut) {
-    LinkedGeoPolygon polygon;
-    // hollow 1-ring + hollow 3-ring around the same hex
-    H3Index set[] = {0x89283082813ffff, 0x8928308281bffff, 0x8928308280bffff,
-                     0x8928308280fffff, 0x89283082807ffff, 0x89283082817ffff,
-                     0x8928308289bffff, 0x892830828d7ffff, 0x892830828c3ffff,
-                     0x892830828cbffff, 0x89283082853ffff, 0x89283082843ffff,
-                     0x8928308284fffff, 0x8928308287bffff, 0x89283082863ffff,
-                     0x89283082867ffff, 0x8928308282bffff, 0x89283082823ffff,
-                     0x89283082837ffff, 0x892830828afffff, 0x892830828a3ffff,
-                     0x892830828b3ffff, 0x89283082887ffff, 0x89283082883ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    // Note that the polygon order here is arbitrary, making this test
-    // somewhat brittle, but it's difficult to assert correctness otherwise
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 2,
-             "Loop count on first polygon correct");
-    t_assert(countLinkedCoords(polygon.first) == 42,
-             "Got expected big outer loop");
-    t_assert(countLinkedCoords(polygon.first->next) == 30,
-             "Got expected big inner loop");
-    t_assert(countLinkedLoops(polygon.next) == 2,
-             "Loop count on second polygon correct");
-    t_assert(countLinkedCoords(polygon.next->first) == 18,
-             "Got expected outer loop");
-    t_assert(countLinkedCoords(polygon.next->first->next) == 6,
-             "Got expected inner loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(nestedDonutTransmeridian) {
-    LinkedGeoPolygon polygon;
-    // hollow 1-ring + hollow 3-ring around the hex at (0, -180)
-    H3Index set[] = {0x897eb5722c7ffff, 0x897eb5722cfffff, 0x897eb572257ffff,
-                     0x897eb57220bffff, 0x897eb572203ffff, 0x897eb572213ffff,
-                     0x897eb57266fffff, 0x897eb5722d3ffff, 0x897eb5722dbffff,
-                     0x897eb573537ffff, 0x897eb573527ffff, 0x897eb57225bffff,
-                     0x897eb57224bffff, 0x897eb57224fffff, 0x897eb57227bffff,
-                     0x897eb572263ffff, 0x897eb572277ffff, 0x897eb57223bffff,
-                     0x897eb572233ffff, 0x897eb5722abffff, 0x897eb5722bbffff,
-                     0x897eb572287ffff, 0x897eb572283ffff, 0x897eb57229bffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    // Note that the polygon order here is arbitrary, making this test
-    // somewhat brittle, but it's difficult to assert correctness otherwise
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 2,
-             "Loop count on first polygon correct");
-    t_assert(countLinkedCoords(polygon.first) == 18, "Got expected outer loop");
-    t_assert(countLinkedCoords(polygon.first->next) == 6,
-             "Got expected inner loop");
-    t_assert(countLinkedLoops(polygon.next) == 2,
-             "Loop count on second polygon correct");
-    t_assert(countLinkedCoords(polygon.next->first) == 42,
-             "Got expected big outer loop");
-    t_assert(countLinkedCoords(polygon.next->first->next) == 30,
-             "Got expected big inner loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(contiguous2distorted) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x894cc5365afffff, 0x894cc536537ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop added to polygon");
-    t_assert(countLinkedCoords(polygon.first) == 12,
-             "All coords added to loop except 2 shared");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(negativeHashedCoordinates) {
-    LinkedGeoPolygon polygon;
-    H3Index set[] = {0x88ad36c547fffff, 0x88ad36c467fffff};
-    int numHexes = ARRAY_SIZE(set);
-    H3_EXPORT(h3SetToLinkedGeo)(set, numHexes, &polygon);
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "2 polygons added");
-    t_assert(countLinkedLoops(&polygon) == 1, "1 loop on the first polygon");
-    t_assert(countLinkedCoords(polygon.first) == 6,
-             "All coords for one hex added to first loop");
-    t_assert(countLinkedLoops(polygon.next) == 1,
-             "Loop count on second polygon correct");
-    t_assert(countLinkedCoords(polygon.next->first) == 6,
-             "All coords for one hex added to second polygon");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3SetToVertexGraph.c
+++ b/src/apps/testapps/testH3SetToVertexGraph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3SetToVertexGraph.c
+++ b/src/apps/testapps/testH3SetToVertexGraph.c
@@ -19,85 +19,86 @@
 #include "test.h"
 #include "utility.h"
 
-BEGIN_TESTS(h3SetToVertexGraph);
+SUITE(h3SetToVertexGraph) {
+    TEST(empty) {
+        VertexGraph graph;
 
-TEST(empty) {
-    VertexGraph graph;
+        h3SetToVertexGraph(NULL, 0, &graph);
 
-    h3SetToVertexGraph(NULL, 0, &graph);
+        t_assert(graph.size == 0, "No edges added to graph");
 
-    t_assert(graph.size == 0, "No edges added to graph");
+        destroyVertexGraph(&graph);
+    }
 
-    destroyVertexGraph(&graph);
+    TEST(singleHex) {
+        VertexGraph graph;
+        H3Index set[] = {0x890dab6220bffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == 6, "All edges of one hex added to graph");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(nonContiguous2) {
+        VertexGraph graph;
+        H3Index set[] = {0x8928308291bffff, 0x89283082943ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == 12,
+                 "All edges of two non-contiguous hexes added to graph");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(contiguous2) {
+        VertexGraph graph;
+        H3Index set[] = {0x8928308291bffff, 0x89283082957ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == 10, "All edges except 2 shared added to graph");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(contiguous2distorted) {
+        VertexGraph graph;
+        H3Index set[] = {0x894cc5365afffff, 0x894cc536537ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == 12, "All edges except 2 shared added to graph");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(contiguous3) {
+        VertexGraph graph;
+        H3Index set[] = {0x8928308288bffff, 0x892830828d7ffff,
+                         0x8928308289bffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == 3 * 4,
+                 "All edges except 6 shared added to graph");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(hole) {
+        VertexGraph graph;
+        H3Index set[] = {0x892830828c7ffff, 0x892830828d7ffff,
+                         0x8928308289bffff, 0x89283082813ffff,
+                         0x8928308288fffff, 0x89283082883ffff};
+        int numHexes = ARRAY_SIZE(set);
+
+        h3SetToVertexGraph(set, numHexes, &graph);
+        t_assert(graph.size == (6 * 3) + 6,
+                 "All outer edges and inner hole edges added to graph");
+
+        destroyVertexGraph(&graph);
+    }
 }
-
-TEST(singleHex) {
-    VertexGraph graph;
-    H3Index set[] = {0x890dab6220bffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == 6, "All edges of one hex added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(nonContiguous2) {
-    VertexGraph graph;
-    H3Index set[] = {0x8928308291bffff, 0x89283082943ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == 12,
-             "All edges of two non-contiguous hexes added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(contiguous2) {
-    VertexGraph graph;
-    H3Index set[] = {0x8928308291bffff, 0x89283082957ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == 10, "All edges except 2 shared added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(contiguous2distorted) {
-    VertexGraph graph;
-    H3Index set[] = {0x894cc5365afffff, 0x894cc536537ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == 12, "All edges except 2 shared added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(contiguous3) {
-    VertexGraph graph;
-    H3Index set[] = {0x8928308288bffff, 0x892830828d7ffff, 0x8928308289bffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == 3 * 4, "All edges except 6 shared added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(hole) {
-    VertexGraph graph;
-    H3Index set[] = {0x892830828c7ffff, 0x892830828d7ffff, 0x8928308289bffff,
-                     0x89283082813ffff, 0x8928308288fffff, 0x89283082883ffff};
-    int numHexes = ARRAY_SIZE(set);
-
-    h3SetToVertexGraph(set, numHexes, &graph);
-    t_assert(graph.size == (6 * 3) + 6,
-             "All outer edges and inner hole edges added to graph");
-
-    destroyVertexGraph(&graph);
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -20,8 +20,8 @@
 
 #define PADDED_COUNT 10
 
-void verifyCountAndUniqueness(H3Index* children, int paddedCount,
-                              int expectedCount) {
+static inline void verifyCountAndUniqueness(H3Index* children, int paddedCount,
+                                            int expectedCount) {
     int numFound = 0;
     for (int i = 0; i < paddedCount; i++) {
         H3Index currIndex = children[i];
@@ -41,99 +41,97 @@ void verifyCountAndUniqueness(H3Index* children, int paddedCount,
     t_assert(numFound == expectedCount, "got expected number of children");
 }
 
-BEGIN_TESTS(h3ToChildren);
+SUITE(h3ToChildren) {
+    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+    H3Index sfHex8 = H3_EXPORT(geoToH3)(&sf, 8);
 
-GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
-H3Index sfHex8 = H3_EXPORT(geoToH3)(&sf, 8);
+    TEST(oneResStep) {
+        const int expectedCount = 7;
+        const int paddedCount = 10;
 
-TEST(oneResStep) {
-    const int expectedCount = 7;
-    const int paddedCount = 10;
+        H3Index sfHex9s[PADDED_COUNT] = {0};
+        H3_EXPORT(h3ToChildren)(sfHex8, 9, sfHex9s);
 
-    H3Index sfHex9s[PADDED_COUNT] = {0};
-    H3_EXPORT(h3ToChildren)(sfHex8, 9, sfHex9s);
+        GeoCoord center;
+        H3_EXPORT(h3ToGeo)(sfHex8, &center);
+        H3Index sfHex9_0 = H3_EXPORT(geoToH3)(&center, 9);
 
-    GeoCoord center;
-    H3_EXPORT(h3ToGeo)(sfHex8, &center);
-    H3Index sfHex9_0 = H3_EXPORT(geoToH3)(&center, 9);
+        int numFound = 0;
 
-    int numFound = 0;
-
-    // Find the center
-    for (int i = 0; i < paddedCount; i++) {
-        if (sfHex9_0 == sfHex9s[i]) {
-            numFound++;
-        }
-    }
-    t_assert(numFound == 1, "found the center hex");
-
-    // Get the neighbor hexagons by averaging the center point and outer points
-    // then query for those independently
-
-    GeoBoundary outside;
-    H3_EXPORT(h3ToGeoBoundary)(sfHex8, &outside);
-    for (int i = 0; i < outside.numVerts; i++) {
-        GeoCoord avg = {0};
-        avg.lat = (outside.verts[i].lat + center.lat) / 2;
-        avg.lon = (outside.verts[i].lon + center.lon) / 2;
-        H3Index avgHex9 = H3_EXPORT(geoToH3)(&avg, 9);
-        for (int j = 0; j < expectedCount; j++) {
-            if (avgHex9 == sfHex9s[j]) {
+        // Find the center
+        for (int i = 0; i < paddedCount; i++) {
+            if (sfHex9_0 == sfHex9s[i]) {
                 numFound++;
             }
         }
+        t_assert(numFound == 1, "found the center hex");
+
+        // Get the neighbor hexagons by averaging the center point and outer
+        // points then query for those independently
+
+        GeoBoundary outside;
+        H3_EXPORT(h3ToGeoBoundary)(sfHex8, &outside);
+        for (int i = 0; i < outside.numVerts; i++) {
+            GeoCoord avg = {0};
+            avg.lat = (outside.verts[i].lat + center.lat) / 2;
+            avg.lon = (outside.verts[i].lon + center.lon) / 2;
+            H3Index avgHex9 = H3_EXPORT(geoToH3)(&avg, 9);
+            for (int j = 0; j < expectedCount; j++) {
+                if (avgHex9 == sfHex9s[j]) {
+                    numFound++;
+                }
+            }
+        }
+
+        t_assert(numFound == expectedCount, "found all expected children");
     }
 
-    t_assert(numFound == expectedCount, "found all expected children");
+    TEST(multipleResSteps) {
+        // Lots of children. Will just confirm number and uniqueness
+        const int expectedCount = 49;
+        const int paddedCount = 60;
+
+        H3Index* children = calloc(paddedCount, sizeof(H3Index));
+        H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
+
+        verifyCountAndUniqueness(children, paddedCount, expectedCount);
+        free(children);
+    }
+
+    TEST(sameRes) {
+        const int expectedCount = 1;
+        const int paddedCount = 7;
+
+        H3Index* children = calloc(paddedCount, sizeof(H3Index));
+        H3_EXPORT(h3ToChildren)(sfHex8, 8, children);
+
+        verifyCountAndUniqueness(children, paddedCount, expectedCount);
+        free(children);
+    }
+
+    TEST(childResTooHigh) {
+        const int expectedCount = 0;
+        const int paddedCount = 7;
+
+        H3Index* children = calloc(paddedCount, sizeof(H3Index));
+        H3_EXPORT(h3ToChildren)(sfHex8, 7, children);
+
+        verifyCountAndUniqueness(children, paddedCount, expectedCount);
+        free(children);
+    }
+
+    TEST(pentagonChildren) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 1, 4, 0);
+
+        const int expectedCount = (5 * 7) + 6;
+        const int paddedCount = H3_EXPORT(maxH3ToChildrenSize)(pentagon, 3);
+
+        H3Index* children = calloc(paddedCount, sizeof(H3Index));
+        H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
+        H3_EXPORT(h3ToChildren)(pentagon, 3, children);
+
+        verifyCountAndUniqueness(children, paddedCount, expectedCount);
+        free(children);
+    }
 }
-
-TEST(multipleResSteps) {
-    // Lots of children. Will just confirm number and uniqueness
-    const int expectedCount = 49;
-    const int paddedCount = 60;
-
-    H3Index* children = calloc(paddedCount, sizeof(H3Index));
-    H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
-
-    verifyCountAndUniqueness(children, paddedCount, expectedCount);
-    free(children);
-}
-
-TEST(sameRes) {
-    const int expectedCount = 1;
-    const int paddedCount = 7;
-
-    H3Index* children = calloc(paddedCount, sizeof(H3Index));
-    H3_EXPORT(h3ToChildren)(sfHex8, 8, children);
-
-    verifyCountAndUniqueness(children, paddedCount, expectedCount);
-    free(children);
-}
-
-TEST(childResTooHigh) {
-    const int expectedCount = 0;
-    const int paddedCount = 7;
-
-    H3Index* children = calloc(paddedCount, sizeof(H3Index));
-    H3_EXPORT(h3ToChildren)(sfHex8, 7, children);
-
-    verifyCountAndUniqueness(children, paddedCount, expectedCount);
-    free(children);
-}
-
-TEST(pentagonChildren) {
-    H3Index pentagon;
-    setH3Index(&pentagon, 1, 4, 0);
-
-    const int expectedCount = (5 * 7) + 6;
-    const int paddedCount = H3_EXPORT(maxH3ToChildrenSize)(pentagon, 3);
-
-    H3Index* children = calloc(paddedCount, sizeof(H3Index));
-    H3_EXPORT(h3ToChildren)(sfHex8, 10, children);
-    H3_EXPORT(h3ToChildren)(pentagon, 3, children);
-
-    verifyCountAndUniqueness(children, paddedCount, expectedCount);
-    free(children);
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -20,8 +20,8 @@
 
 #define PADDED_COUNT 10
 
-static inline void verifyCountAndUniqueness(H3Index* children, int paddedCount,
-                                            int expectedCount) {
+static void verifyCountAndUniqueness(H3Index* children, int paddedCount,
+                                     int expectedCount) {
     int numFound = 0;
     for (int i = 0; i < paddedCount; i++) {
         H3Index currIndex = children[i];

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -33,7 +33,7 @@
 
 static const int MAX_DISTANCES[] = {1, 2, 5, 12, 19, 26};
 
-void h3Distance_identity_assertions(H3Index h3) {
+static inline void h3Distance_identity_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);
 
     t_assert(H3_EXPORT(h3Distance)(h3, h3) == 0, "distance to self is 0");
@@ -56,7 +56,7 @@ void h3Distance_identity_assertions(H3Index h3) {
     }
 }
 
-void h3Distance_neighbors_assertions(H3Index h3) {
+static inline void h3Distance_neighbors_assertions(H3Index h3) {
     CoordIJK origin = {0};
     t_assert(h3ToIjk(h3, h3, &origin) == 0, "got ijk for origin");
 
@@ -82,7 +82,7 @@ void h3Distance_neighbors_assertions(H3Index h3) {
     }
 }
 
-void h3Distance_kRing_assertions(H3Index h3) {
+static inline void h3Distance_kRing_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);
     if (r > 5) {
         t_assert(false, "wrong res");
@@ -109,126 +109,127 @@ void h3Distance_kRing_assertions(H3Index h3) {
     }
 }
 
-BEGIN_TESTS(h3ToIjk);
+SUITE(h3ToIjk) {
+    TEST(testIndexDistance) {
+        H3Index bc = 0;
+        setH3Index(&bc, 1, 17, 0);
+        H3Index p = 0;
+        setH3Index(&p, 1, 14, 0);
+        H3Index p2;
+        setH3Index(&p2, 1, 14, 2);
+        H3Index p3;
+        setH3Index(&p3, 1, 14, 3);
+        H3Index p4;
+        setH3Index(&p4, 1, 14, 4);
+        H3Index p5;
+        setH3Index(&p5, 1, 14, 5);
+        H3Index p6;
+        setH3Index(&p6, 1, 14, 6);
 
-TEST(testIndexDistance) {
-    H3Index bc = 0;
-    setH3Index(&bc, 1, 17, 0);
-    H3Index p = 0;
-    setH3Index(&p, 1, 14, 0);
-    H3Index p2;
-    setH3Index(&p2, 1, 14, 2);
-    H3Index p3;
-    setH3Index(&p3, 1, 14, 3);
-    H3Index p4;
-    setH3Index(&p4, 1, 14, 4);
-    H3Index p5;
-    setH3Index(&p5, 1, 14, 5);
-    H3Index p6;
-    setH3Index(&p6, 1, 14, 6);
+        t_assert(H3_EXPORT(h3Distance)(bc, p) == 3, "distance onto pentagon");
+        t_assert(H3_EXPORT(h3Distance)(bc, p2) == 2, "distance onto p2");
+        t_assert(H3_EXPORT(h3Distance)(bc, p3) == 3, "distance onto p3");
+        // TODO works correctly but is rejected due to possible pentagon
+        // distortion.
+        //    t_assert(H3_EXPORT(h3Distance)(bc, p4) == 3, "distance onto p4");
+        //    t_assert(H3_EXPORT(h3Distance)(bc, p5) == 4, "distance onto p5");
+        t_assert(H3_EXPORT(h3Distance)(bc, p6) == 2, "distance onto p6");
+    }
 
-    t_assert(H3_EXPORT(h3Distance)(bc, p) == 3, "distance onto pentagon");
-    t_assert(H3_EXPORT(h3Distance)(bc, p2) == 2, "distance onto p2");
-    t_assert(H3_EXPORT(h3Distance)(bc, p3) == 3, "distance onto p3");
-    // TODO works correctly but is rejected due to possible pentagon distortion.
-    //    t_assert(H3_EXPORT(h3Distance)(bc, p4) == 3, "distance onto p4");
-    //    t_assert(H3_EXPORT(h3Distance)(bc, p5) == 4, "distance onto p5");
-    t_assert(H3_EXPORT(h3Distance)(bc, p6) == 2, "distance onto p6");
+    TEST(testIndexDistance2) {
+        H3Index origin = 0x820c4ffffffffffL;
+        // Destination is on the other side of the pentagon
+        H3Index destination = 0x821ce7fffffffffL;
+
+        // TODO doesn't work because of pentagon distortion. Both should be 5.
+        t_assert(H3_EXPORT(h3Distance)(destination, origin) == -1,
+                 "distance in res 2 across pentagon");
+        t_assert(H3_EXPORT(h3Distance)(origin, destination) == -1,
+                 "distance in res 2 across pentagon (reversed)");
+    }
+
+    TEST(ijkDistance) {
+        CoordIJK z = {0, 0, 0};
+        CoordIJK i = {1, 0, 0};
+        CoordIJK ik = {1, 0, 1};
+        CoordIJK ij = {1, 1, 0};
+        CoordIJK j2 = {0, 2, 0};
+
+        t_assert(ijkDistance(&z, &z) == 0, "identity distance 0,0,0");
+        t_assert(ijkDistance(&i, &i) == 0, "identity distance 1,0,0");
+        t_assert(ijkDistance(&ik, &ik) == 0, "identity distance 1,0,1");
+        t_assert(ijkDistance(&ij, &ij) == 0, "identity distance 1,1,0");
+        t_assert(ijkDistance(&j2, &j2) == 0, "identity distance 0,2,0");
+
+        t_assert(ijkDistance(&z, &i) == 1, "0,0,0 to 1,0,0");
+        t_assert(ijkDistance(&z, &j2) == 2, "0,0,0 to 0,2,0");
+        t_assert(ijkDistance(&z, &ik) == 1, "0,0,0 to 1,0,1");
+        t_assert(ijkDistance(&i, &ik) == 1, "1,0,0 to 1,0,1");
+        t_assert(ijkDistance(&ik, &j2) == 3, "1,0,1 to 0,2,0");
+        t_assert(ijkDistance(&ij, &ik) == 2, "1,0,1 to 1,1,0");
+    }
+
+    TEST(h3Distance_identity) {
+        iterateAllIndexesAtRes(0, h3Distance_identity_assertions);
+        iterateAllIndexesAtRes(1, h3Distance_identity_assertions);
+        iterateAllIndexesAtRes(2, h3Distance_identity_assertions);
+    }
+
+    TEST(h3Distance_neighbors) {
+        iterateAllIndexesAtRes(0, h3Distance_neighbors_assertions);
+        iterateAllIndexesAtRes(1, h3Distance_neighbors_assertions);
+        iterateAllIndexesAtRes(2, h3Distance_neighbors_assertions);
+    }
+
+    TEST(h3Distance_kRing) {
+        iterateAllIndexesAtRes(0, h3Distance_kRing_assertions);
+        iterateAllIndexesAtRes(1, h3Distance_kRing_assertions);
+        iterateAllIndexesAtRes(2, h3Distance_kRing_assertions);
+        // Don't iterate all of res 3, to save time
+        iterateAllIndexesAtResPartial(3, h3Distance_kRing_assertions, 27);
+        // These would take too long, even at partial execution
+        //    iterateAllIndexesAtResPartial(4, h3Distance_kRing_assertions, 20);
+        //    iterateAllIndexesAtResPartial(5, h3Distance_kRing_assertions, 20);
+    }
+
+    TEST(h3DistanceBaseCells) {
+        H3Index bc1 = H3_INIT;
+        setH3Index(&bc1, 0, 15, 0);
+
+        H3Index bc2 = H3_INIT;
+        setH3Index(&bc2, 0, 8, 0);
+
+        H3Index bc3 = H3_INIT;
+        setH3Index(&bc3, 0, 31, 0);
+
+        H3Index pent1 = H3_INIT;
+        setH3Index(&pent1, 0, 4, 0);
+
+        t_assert(H3_EXPORT(h3Distance)(bc1, pent1) == 1,
+                 "distance to neighbor is 1 (15, 4)");
+        t_assert(H3_EXPORT(h3Distance)(bc1, bc2) == 1,
+                 "distance to neighbor is 1 (15, 8)");
+        t_assert(H3_EXPORT(h3Distance)(bc1, bc3) == 1,
+                 "distance to neighbor is 1 (15, 31)");
+        t_assert(H3_EXPORT(h3Distance)(pent1, bc3) == -1,
+                 "distance to neighbor is invalid");
+
+        CoordIJK ijk;
+        t_assert(h3ToIjk(pent1, bc1, &ijk) == 0, "failed to get ijk (4, 15)");
+        t_assert(_ijkMatches(&ijk, &UNIT_VECS[2]) == 1, "not at 0,1,0");
+    }
+
+    TEST(h3DistanceFailed) {
+        H3Index h3 = 0x832830fffffffffL;
+        H3Index edge =
+            H3_EXPORT(getH3UnidirectionalEdge(h3, 0x832834fffffffffL));
+        H3Index h3res2 = 0x822837fffffffffL;
+
+        t_assert(H3_EXPORT(h3Distance)(edge, h3) == -1,
+                 "edges cannot be origins");
+        t_assert(H3_EXPORT(h3Distance)(h3, edge) == -1,
+                 "edges cannot be destinations");
+        t_assert(H3_EXPORT(h3Distance)(h3, h3res2) == -1,
+                 "cannot compare at different resolutions");
+    }
 }
-
-TEST(testIndexDistance2) {
-    H3Index origin = 0x820c4ffffffffffL;
-    // Destination is on the other side of the pentagon
-    H3Index destination = 0x821ce7fffffffffL;
-
-    // TODO doesn't work because of pentagon distortion. Both should be 5.
-    t_assert(H3_EXPORT(h3Distance)(destination, origin) == -1,
-             "distance in res 2 across pentagon");
-    t_assert(H3_EXPORT(h3Distance)(origin, destination) == -1,
-             "distance in res 2 across pentagon (reversed)");
-}
-
-TEST(ijkDistance) {
-    CoordIJK z = {0, 0, 0};
-    CoordIJK i = {1, 0, 0};
-    CoordIJK ik = {1, 0, 1};
-    CoordIJK ij = {1, 1, 0};
-    CoordIJK j2 = {0, 2, 0};
-
-    t_assert(ijkDistance(&z, &z) == 0, "identity distance 0,0,0");
-    t_assert(ijkDistance(&i, &i) == 0, "identity distance 1,0,0");
-    t_assert(ijkDistance(&ik, &ik) == 0, "identity distance 1,0,1");
-    t_assert(ijkDistance(&ij, &ij) == 0, "identity distance 1,1,0");
-    t_assert(ijkDistance(&j2, &j2) == 0, "identity distance 0,2,0");
-
-    t_assert(ijkDistance(&z, &i) == 1, "0,0,0 to 1,0,0");
-    t_assert(ijkDistance(&z, &j2) == 2, "0,0,0 to 0,2,0");
-    t_assert(ijkDistance(&z, &ik) == 1, "0,0,0 to 1,0,1");
-    t_assert(ijkDistance(&i, &ik) == 1, "1,0,0 to 1,0,1");
-    t_assert(ijkDistance(&ik, &j2) == 3, "1,0,1 to 0,2,0");
-    t_assert(ijkDistance(&ij, &ik) == 2, "1,0,1 to 1,1,0");
-}
-
-TEST(h3Distance_identity) {
-    iterateAllIndexesAtRes(0, h3Distance_identity_assertions);
-    iterateAllIndexesAtRes(1, h3Distance_identity_assertions);
-    iterateAllIndexesAtRes(2, h3Distance_identity_assertions);
-}
-
-TEST(h3Distance_neighbors) {
-    iterateAllIndexesAtRes(0, h3Distance_neighbors_assertions);
-    iterateAllIndexesAtRes(1, h3Distance_neighbors_assertions);
-    iterateAllIndexesAtRes(2, h3Distance_neighbors_assertions);
-}
-
-TEST(h3Distance_kRing) {
-    iterateAllIndexesAtRes(0, h3Distance_kRing_assertions);
-    iterateAllIndexesAtRes(1, h3Distance_kRing_assertions);
-    iterateAllIndexesAtRes(2, h3Distance_kRing_assertions);
-    // Don't iterate all of res 3, to save time
-    iterateAllIndexesAtResPartial(3, h3Distance_kRing_assertions, 27);
-    // These would take too long, even at partial execution
-    //    iterateAllIndexesAtResPartial(4, h3Distance_kRing_assertions, 20);
-    //    iterateAllIndexesAtResPartial(5, h3Distance_kRing_assertions, 20);
-}
-
-TEST(h3DistanceBaseCells) {
-    H3Index bc1 = H3_INIT;
-    setH3Index(&bc1, 0, 15, 0);
-
-    H3Index bc2 = H3_INIT;
-    setH3Index(&bc2, 0, 8, 0);
-
-    H3Index bc3 = H3_INIT;
-    setH3Index(&bc3, 0, 31, 0);
-
-    H3Index pent1 = H3_INIT;
-    setH3Index(&pent1, 0, 4, 0);
-
-    t_assert(H3_EXPORT(h3Distance)(bc1, pent1) == 1,
-             "distance to neighbor is 1 (15, 4)");
-    t_assert(H3_EXPORT(h3Distance)(bc1, bc2) == 1,
-             "distance to neighbor is 1 (15, 8)");
-    t_assert(H3_EXPORT(h3Distance)(bc1, bc3) == 1,
-             "distance to neighbor is 1 (15, 31)");
-    t_assert(H3_EXPORT(h3Distance)(pent1, bc3) == -1,
-             "distance to neighbor is invalid");
-
-    CoordIJK ijk;
-    t_assert(h3ToIjk(pent1, bc1, &ijk) == 0, "failed to get ijk (4, 15)");
-    t_assert(_ijkMatches(&ijk, &UNIT_VECS[2]) == 1, "not at 0,1,0");
-}
-
-TEST(h3DistanceFailed) {
-    H3Index h3 = 0x832830fffffffffL;
-    H3Index edge = H3_EXPORT(getH3UnidirectionalEdge(h3, 0x832834fffffffffL));
-    H3Index h3res2 = 0x822837fffffffffL;
-
-    t_assert(H3_EXPORT(h3Distance)(edge, h3) == -1, "edges cannot be origins");
-    t_assert(H3_EXPORT(h3Distance)(h3, edge) == -1,
-             "edges cannot be destinations");
-    t_assert(H3_EXPORT(h3Distance)(h3, h3res2) == -1,
-             "cannot compare at different resolutions");
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3ToIjk.c
+++ b/src/apps/testapps/testH3ToIjk.c
@@ -33,7 +33,7 @@
 
 static const int MAX_DISTANCES[] = {1, 2, 5, 12, 19, 26};
 
-static inline void h3Distance_identity_assertions(H3Index h3) {
+static void h3Distance_identity_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);
 
     t_assert(H3_EXPORT(h3Distance)(h3, h3) == 0, "distance to self is 0");
@@ -56,7 +56,7 @@ static inline void h3Distance_identity_assertions(H3Index h3) {
     }
 }
 
-static inline void h3Distance_neighbors_assertions(H3Index h3) {
+static void h3Distance_neighbors_assertions(H3Index h3) {
     CoordIJK origin = {0};
     t_assert(h3ToIjk(h3, h3, &origin) == 0, "got ijk for origin");
 
@@ -82,7 +82,7 @@ static inline void h3Distance_neighbors_assertions(H3Index h3) {
     }
 }
 
-static inline void h3Distance_kRing_assertions(H3Index h3) {
+static void h3Distance_kRing_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);
     if (r > 5) {
         t_assert(false, "wrong res");

--- a/src/apps/testapps/testH3ToParent.c
+++ b/src/apps/testapps/testH3ToParent.c
@@ -18,32 +18,33 @@
 #include "h3Index.h"
 #include "test.h"
 
-BEGIN_TESTS(h3ToParent);
+SUITE(h3ToParent) {
+    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
 
-GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+    TEST(ancestorsForEachRes) {
+        H3Index child;
+        H3Index comparisonParent;
+        H3Index parent;
 
-TEST(ancestorsForEachRes) {
-    H3Index child;
-    H3Index comparisonParent;
-    H3Index parent;
+        for (int res = 1; res < 15; res++) {
+            for (int step = 0; step < res; step++) {
+                child = H3_EXPORT(geoToH3)(&sf, res);
+                parent = H3_EXPORT(h3ToParent)(child, res - step);
+                comparisonParent = H3_EXPORT(geoToH3)(&sf, res - step);
 
-    for (int res = 1; res < 15; res++) {
-        for (int step = 0; step < res; step++) {
-            child = H3_EXPORT(geoToH3)(&sf, res);
-            parent = H3_EXPORT(h3ToParent)(child, res - step);
-            comparisonParent = H3_EXPORT(geoToH3)(&sf, res - step);
-
-            t_assert(parent == comparisonParent, "Got expected parent");
+                t_assert(parent == comparisonParent, "Got expected parent");
+            }
         }
     }
+
+    TEST(invalidInputs) {
+        H3Index child = H3_EXPORT(geoToH3)(&sf, 5);
+
+        t_assert(H3_EXPORT(h3ToParent)(child, 6) == 0,
+                 "Higher resolution fails");
+        t_assert(H3_EXPORT(h3ToParent)(child, -1) == 0,
+                 "Invalid resolution fails");
+        t_assert(H3_EXPORT(h3ToParent)(child, 15) == 0,
+                 "Invalid resolution fails");
+    }
 }
-
-TEST(invalidInputs) {
-    H3Index child = H3_EXPORT(geoToH3)(&sf, 5);
-
-    t_assert(H3_EXPORT(h3ToParent)(child, 6) == 0, "Higher resolution fails");
-    t_assert(H3_EXPORT(h3ToParent)(child, -1) == 0, "Invalid resolution fails");
-    t_assert(H3_EXPORT(h3ToParent)(child, 15) == 0, "Invalid resolution fails");
-}
-
-END_TESTS();

--- a/src/apps/testapps/testH3ToParent.c
+++ b/src/apps/testapps/testH3ToParent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -27,227 +27,162 @@
 #include "test.h"
 
 // Fixtures
-GeoCoord sfGeo = {0.659966917655, -2.1364398519396};
+static GeoCoord sfGeo = {0.659966917655, -2.1364398519396};
 
-BEGIN_TESTS(h3UniEdge);
+SUITE(h3UniEdge) {
+    TEST(h3IndexesAreNeighbors) {
+        H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
+        STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
+        H3_EXPORT(hexRing)(sf, 1, ring);
 
-TEST(h3IndexesAreNeighbors) {
-    H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
-    STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
-    H3_EXPORT(hexRing)(sf, 1, ring);
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sf) == 0,
+                 "an index does not neighbor itself");
 
-    t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sf) == 0,
-             "an index does not neighbor itself");
-
-    int neighbors = 0;
-    for (int i = 0; i < H3_EXPORT(maxKringSize)(1); i++) {
-        if (ring[i] != 0 && H3_EXPORT(h3IndexesAreNeighbors)(sf, ring[i])) {
-            neighbors++;
+        int neighbors = 0;
+        for (int i = 0; i < H3_EXPORT(maxKringSize)(1); i++) {
+            if (ring[i] != 0 && H3_EXPORT(h3IndexesAreNeighbors)(sf, ring[i])) {
+                neighbors++;
+            }
         }
-    }
-    t_assert(neighbors == 6,
-             "got the expected number of neighbors from a k-ring of 1");
+        t_assert(neighbors == 6,
+                 "got the expected number of neighbors from a k-ring of 1");
 
-    STACK_ARRAY_CALLOC(H3Index, largerRing, H3_EXPORT(maxKringSize)(2));
-    H3_EXPORT(hexRing)(sf, 2, largerRing);
+        STACK_ARRAY_CALLOC(H3Index, largerRing, H3_EXPORT(maxKringSize)(2));
+        H3_EXPORT(hexRing)(sf, 2, largerRing);
 
-    neighbors = 0;
-    for (int i = 0; i < H3_EXPORT(maxKringSize)(2); i++) {
-        if (largerRing[i] != 0 &&
-            H3_EXPORT(h3IndexesAreNeighbors)(sf, largerRing[i])) {
-            neighbors++;
+        neighbors = 0;
+        for (int i = 0; i < H3_EXPORT(maxKringSize)(2); i++) {
+            if (largerRing[i] != 0 &&
+                H3_EXPORT(h3IndexesAreNeighbors)(sf, largerRing[i])) {
+                neighbors++;
+            }
         }
+        t_assert(neighbors == 0,
+                 "got no neighbors, as expected, from a k-ring of 2");
+
+        H3Index sfBroken = sf;
+        H3_SET_MODE(sfBroken, H3_UNIEDGE_MODE);
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBroken) == 0,
+                 "broken H3Indexes can't be neighbors");
+
+        H3Index sfBigger = H3_EXPORT(geoToH3)(&sfGeo, 7);
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBigger) == 0,
+                 "hexagons of different resolution can't be neighbors");
+
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(ring[2], ring[1]) == 1,
+                 "hexagons in a ring are neighbors");
     }
-    t_assert(neighbors == 0,
-             "got no neighbors, as expected, from a k-ring of 2");
 
-    H3Index sfBroken = sf;
-    H3_SET_MODE(sfBroken, H3_UNIEDGE_MODE);
-    t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBroken) == 0,
-             "broken H3Indexes can't be neighbors");
+    TEST(getH3UnidirectionalEdgeAndFriends) {
+        H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
+        STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
+        H3_EXPORT(hexRing)(sf, 1, ring);
+        H3Index sf2 = ring[0];
 
-    H3Index sfBigger = H3_EXPORT(geoToH3)(&sfGeo, 7);
-    t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBigger) == 0,
-             "hexagons of different resolution can't be neighbors");
-
-    t_assert(H3_EXPORT(h3IndexesAreNeighbors)(ring[2], ring[1]) == 1,
-             "hexagons in a ring are neighbors");
-}
-
-TEST(getH3UnidirectionalEdgeAndFriends) {
-    H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
-    STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
-    H3_EXPORT(hexRing)(sf, 1, ring);
-    H3Index sf2 = ring[0];
-
-    H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf2);
-    t_assert(sf == H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edge),
-             "can retrieve the origin from the edge");
-    t_assert(
-        sf2 == H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(edge),
-        "can retrieve the destination from the edge");
-
-    H3Index originDestination[2] = {0};
-    H3_EXPORT(getH3IndexesFromUnidirectionalEdge)(edge, originDestination);
-    t_assert(originDestination[0] == sf,
-             "got the origin first in the pair request");
-    t_assert(originDestination[1] == sf2,
-             "got the destination last in the pair request");
-
-    STACK_ARRAY_CALLOC(H3Index, largerRing, H3_EXPORT(maxKringSize)(2));
-    H3_EXPORT(hexRing)(sf, 2, largerRing);
-    H3Index sf3 = largerRing[0];
-
-    H3Index notEdge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf3);
-    t_assert(notEdge == 0, "Non-neighbors can't have edges");
-}
-
-TEST(getOriginH3IndexFromUnidirectionalEdgeBadInput) {
-    H3Index hexagon = 0x891ea6d6533ffff;
-
-    t_assert(H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(hexagon) == 0,
-             "getting the origin from a hexagon index returns 0");
-    t_assert(H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(0) == 0,
-             "getting the origin from a null index returns 0");
-}
-
-TEST(getDestinationH3IndexFromUnidirectionalEdge) {
-    H3Index hexagon = 0x891ea6d6533ffff;
-
-    t_assert(
-        H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(hexagon) == 0,
-        "getting the destination from a hexagon index returns 0");
-    t_assert(H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(0) == 0,
-             "getting the destination from a null index returns 0");
-}
-
-TEST(getH3UnidirectionalEdgeFromPentagon) {
-    H3Index pentagon;
-    setH3Index(&pentagon, 0, 4, 0);
-    H3Index adjacent;
-    setH3Index(&adjacent, 0, 8, 0);
-
-    H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(pentagon, adjacent);
-    t_assert(edge != 0, "Produces a valid edge");
-}
-
-TEST(h3UnidirectionalEdgeIsValid) {
-    H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
-    STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
-    H3_EXPORT(hexRing)(sf, 1, ring);
-    H3Index sf2 = ring[0];
-
-    H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf2);
-    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge) == 1,
-             "edges validate correctly");
-    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(sf) == 0,
-             "hexagons do not validate");
-
-    H3Index fakeEdge = sf;
-    H3_SET_MODE(fakeEdge, H3_UNIEDGE_MODE);
-    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(fakeEdge) == 0,
-             "edges without an edge specified don't work");
-
-    H3Index pentagon = 0x821c07fffffffff;
-    H3Index goodPentagonalEdge = pentagon;
-    H3_SET_MODE(goodPentagonalEdge, H3_UNIEDGE_MODE);
-    H3_SET_RESERVED_BITS(goodPentagonalEdge, 2);
-    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(goodPentagonalEdge) == 1,
-             "pentagonal edge validates");
-
-    H3Index badPentagonalEdge = goodPentagonalEdge;
-    H3_SET_RESERVED_BITS(badPentagonalEdge, 1);
-    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(badPentagonalEdge) == 0,
-             "missing pentagonal edge does not validate");
-}
-
-TEST(getH3UnidirectionalEdgesFromHexagon) {
-    H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
-    STACK_ARRAY_CALLOC(H3Index, edges, 6);
-    H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(sf, edges);
-
-    for (int i = 0; i < 6; i++) {
-        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
-                 "edge is an edge");
+        H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf2);
+        t_assert(sf == H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edge),
+                 "can retrieve the origin from the edge");
         t_assert(
-            sf == H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edges[i]),
-            "origin is correct");
-        t_assert(sf != H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(
-                           edges[i]),
-                 "destination is not origin");
+            sf2 == H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(edge),
+            "can retrieve the destination from the edge");
+
+        H3Index originDestination[2] = {0};
+        H3_EXPORT(getH3IndexesFromUnidirectionalEdge)(edge, originDestination);
+        t_assert(originDestination[0] == sf,
+                 "got the origin first in the pair request");
+        t_assert(originDestination[1] == sf2,
+                 "got the destination last in the pair request");
+
+        STACK_ARRAY_CALLOC(H3Index, largerRing, H3_EXPORT(maxKringSize)(2));
+        H3_EXPORT(hexRing)(sf, 2, largerRing);
+        H3Index sf3 = largerRing[0];
+
+        H3Index notEdge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf3);
+        t_assert(notEdge == 0, "Non-neighbors can't have edges");
     }
-}
 
-TEST(getH3UnidirectionalEdgesFromPentagon) {
-    H3Index pentagon = 0x821c07fffffffff;
-    STACK_ARRAY_CALLOC(H3Index, edges, 6);
-    H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(pentagon, edges);
+    TEST(getOriginH3IndexFromUnidirectionalEdgeBadInput) {
+        H3Index hexagon = 0x891ea6d6533ffff;
 
-    int missingEdgeCount = 0;
-    for (int i = 0; i < 6; i++) {
-        if (edges[i] == 0) {
-            missingEdgeCount++;
-        } else {
-            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
-                     "edge is an edge");
-            t_assert(
-                pentagon ==
-                    H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edges[i]),
-                "origin is correct");
-            t_assert(pentagon !=
-                         H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(
-                             edges[i]),
-                     "destination is not origin");
-        }
+        t_assert(
+            H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(hexagon) == 0,
+            "getting the origin from a hexagon index returns 0");
+        t_assert(H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(0) == 0,
+                 "getting the origin from a null index returns 0");
     }
-    t_assert(missingEdgeCount == 1,
-             "Only one edge was deleted for the pentagon");
-}
 
-TEST(getH3UnidirectionalEdgeBoundary) {
-    H3Index sf;
-    GeoBoundary boundary;
-    GeoBoundary edgeBoundary;
-    STACK_ARRAY_CALLOC(H3Index, edges, 6);
+    TEST(getDestinationH3IndexFromUnidirectionalEdge) {
+        H3Index hexagon = 0x891ea6d6533ffff;
 
-    const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
-                                       {5, 0}, {4, 5}, {0, 1}};
+        t_assert(H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(
+                     hexagon) == 0,
+                 "getting the destination from a hexagon index returns 0");
+        t_assert(H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(0) == 0,
+                 "getting the destination from a null index returns 0");
+    }
 
-    // TODO: The current implementation relies on lat/lon comparison and fails
-    // on resolutions finer than 12
-    for (int res = 0; res < 13; res++) {
-        sf = H3_EXPORT(geoToH3)(&sfGeo, res);
-        H3_EXPORT(h3ToGeoBoundary)(sf, &boundary);
+    TEST(getH3UnidirectionalEdgeFromPentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 0, 4, 0);
+        H3Index adjacent;
+        setH3Index(&adjacent, 0, 8, 0);
+
+        H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(pentagon, adjacent);
+        t_assert(edge != 0, "Produces a valid edge");
+    }
+
+    TEST(h3UnidirectionalEdgeIsValid) {
+        H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
+        STACK_ARRAY_CALLOC(H3Index, ring, H3_EXPORT(maxKringSize)(1));
+        H3_EXPORT(hexRing)(sf, 1, ring);
+        H3Index sf2 = ring[0];
+
+        H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(sf, sf2);
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge) == 1,
+                 "edges validate correctly");
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(sf) == 0,
+                 "hexagons do not validate");
+
+        H3Index fakeEdge = sf;
+        H3_SET_MODE(fakeEdge, H3_UNIEDGE_MODE);
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(fakeEdge) == 0,
+                 "edges without an edge specified don't work");
+
+        H3Index pentagon = 0x821c07fffffffff;
+        H3Index goodPentagonalEdge = pentagon;
+        H3_SET_MODE(goodPentagonalEdge, H3_UNIEDGE_MODE);
+        H3_SET_RESERVED_BITS(goodPentagonalEdge, 2);
+        t_assert(
+            H3_EXPORT(h3UnidirectionalEdgeIsValid)(goodPentagonalEdge) == 1,
+            "pentagonal edge validates");
+
+        H3Index badPentagonalEdge = goodPentagonalEdge;
+        H3_SET_RESERVED_BITS(badPentagonalEdge, 1);
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(badPentagonalEdge) == 0,
+                 "missing pentagonal edge does not validate");
+    }
+
+    TEST(getH3UnidirectionalEdgesFromHexagon) {
+        H3Index sf = H3_EXPORT(geoToH3)(&sfGeo, 9);
+        STACK_ARRAY_CALLOC(H3Index, edges, 6);
         H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(sf, edges);
 
         for (int i = 0; i < 6; i++) {
-            H3_EXPORT(getH3UnidirectionalEdgeBoundary)(edges[i], &edgeBoundary);
-            t_assert(edgeBoundary.numVerts == 2,
-                     "Got the expected number of vertices back");
-            for (int j = 0; j < edgeBoundary.numVerts; j++) {
-                t_assert(
-                    geoAlmostEqual(&edgeBoundary.verts[j],
-                                   &boundary.verts[expectedVertices[i][j]]),
-                    "Got expected vertex");
-            }
+            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
+                     "edge is an edge");
+            t_assert(sf == H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(
+                               edges[i]),
+                     "origin is correct");
+            t_assert(
+                sf != H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(
+                          edges[i]),
+                "destination is not origin");
         }
     }
-}
 
-TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
-    H3Index pentagon;
-    GeoBoundary boundary;
-    GeoBoundary edgeBoundary;
-    STACK_ARRAY_CALLOC(H3Index, edges, 6);
-
-    const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
-                                       {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
-
-    // TODO: The current implementation relies on lat/lon comparison and fails
-    // on resolutions finer than 12
-    for (int res = 1; res < 13; res += 2) {
-        setH3Index(&pentagon, res, 24, 0);
-        H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
+    TEST(getH3UnidirectionalEdgesFromPentagon) {
+        H3Index pentagon = 0x821c07fffffffff;
+        STACK_ARRAY_CALLOC(H3Index, edges, 6);
         H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(pentagon, edges);
 
         int missingEdgeCount = 0;
@@ -255,12 +190,44 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
             if (edges[i] == 0) {
                 missingEdgeCount++;
             } else {
+                t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
+                         "edge is an edge");
+                t_assert(pentagon ==
+                             H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(
+                                 edges[i]),
+                         "origin is correct");
+                t_assert(
+                    pentagon !=
+                        H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(
+                            edges[i]),
+                    "destination is not origin");
+            }
+        }
+        t_assert(missingEdgeCount == 1,
+                 "Only one edge was deleted for the pentagon");
+    }
+
+    TEST(getH3UnidirectionalEdgeBoundary) {
+        H3Index sf;
+        GeoBoundary boundary;
+        GeoBoundary edgeBoundary;
+        STACK_ARRAY_CALLOC(H3Index, edges, 6);
+
+        const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
+                                           {5, 0}, {4, 5}, {0, 1}};
+
+        // TODO: The current implementation relies on lat/lon comparison and
+        // fails on resolutions finer than 12
+        for (int res = 0; res < 13; res++) {
+            sf = H3_EXPORT(geoToH3)(&sfGeo, res);
+            H3_EXPORT(h3ToGeoBoundary)(sf, &boundary);
+            H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(sf, edges);
+
+            for (int i = 0; i < 6; i++) {
                 H3_EXPORT(getH3UnidirectionalEdgeBoundary)
                 (edges[i], &edgeBoundary);
-                t_assert(
-                    edgeBoundary.numVerts == 3,
-                    "Got the expected number of vertices back for a Class III "
-                    "pentagon");
+                t_assert(edgeBoundary.numVerts == 2,
+                         "Got the expected number of vertices back");
                 for (int j = 0; j < edgeBoundary.numVerts; j++) {
                     t_assert(
                         geoAlmostEqual(&edgeBoundary.verts[j],
@@ -269,49 +236,85 @@ TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
                 }
             }
         }
-        t_assert(missingEdgeCount == 1,
-                 "Only one edge was deleted for the pentagon");
     }
-}
 
-TEST(getH3UnidirectionalEdgeBoundaryPentagonClassII) {
-    H3Index pentagon;
-    GeoBoundary boundary;
-    GeoBoundary edgeBoundary;
-    STACK_ARRAY_CALLOC(H3Index, edges, 6);
+    TEST(getH3UnidirectionalEdgeBoundaryPentagonClassIII) {
+        H3Index pentagon;
+        GeoBoundary boundary;
+        GeoBoundary edgeBoundary;
+        STACK_ARRAY_CALLOC(H3Index, edges, 6);
 
-    const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
-                                       {4, 0},   {3, 4}, {0, 1}};
+        const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
+                                           {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
 
-    // TODO: The current implementation relies on lat/lon comparison and fails
-    // on resolutions finer than 12
-    for (int res = 0; res < 12; res += 2) {
-        setH3Index(&pentagon, res, 24, 0);
-        H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
-        H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(pentagon, edges);
+        // TODO: The current implementation relies on lat/lon comparison and
+        // fails on resolutions finer than 12
+        for (int res = 1; res < 13; res += 2) {
+            setH3Index(&pentagon, res, 24, 0);
+            H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
+            H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(pentagon, edges);
 
-        int missingEdgeCount = 0;
-        for (int i = 0; i < 6; i++) {
-            if (edges[i] == 0) {
-                missingEdgeCount++;
-            } else {
-                H3_EXPORT(getH3UnidirectionalEdgeBoundary)
-                (edges[i], &edgeBoundary);
-                t_assert(
-                    edgeBoundary.numVerts == 2,
-                    "Got the expected number of vertices back for a Class II "
-                    "pentagon");
-                for (int j = 0; j < edgeBoundary.numVerts; j++) {
-                    t_assert(
-                        geoAlmostEqual(&edgeBoundary.verts[j],
-                                       &boundary.verts[expectedVertices[i][j]]),
-                        "Got expected vertex");
+            int missingEdgeCount = 0;
+            for (int i = 0; i < 6; i++) {
+                if (edges[i] == 0) {
+                    missingEdgeCount++;
+                } else {
+                    H3_EXPORT(getH3UnidirectionalEdgeBoundary)
+                    (edges[i], &edgeBoundary);
+                    t_assert(edgeBoundary.numVerts == 3,
+                             "Got the expected number of vertices back for a "
+                             "Class III "
+                             "pentagon");
+                    for (int j = 0; j < edgeBoundary.numVerts; j++) {
+                        t_assert(geoAlmostEqual(
+                                     &edgeBoundary.verts[j],
+                                     &boundary.verts[expectedVertices[i][j]]),
+                                 "Got expected vertex");
+                    }
                 }
             }
+            t_assert(missingEdgeCount == 1,
+                     "Only one edge was deleted for the pentagon");
         }
-        t_assert(missingEdgeCount == 1,
-                 "Only one edge was deleted for the pentagon");
+    }
+
+    TEST(getH3UnidirectionalEdgeBoundaryPentagonClassII) {
+        H3Index pentagon;
+        GeoBoundary boundary;
+        GeoBoundary edgeBoundary;
+        STACK_ARRAY_CALLOC(H3Index, edges, 6);
+
+        const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
+                                           {4, 0},   {3, 4}, {0, 1}};
+
+        // TODO: The current implementation relies on lat/lon comparison and
+        // fails on resolutions finer than 12
+        for (int res = 0; res < 12; res += 2) {
+            setH3Index(&pentagon, res, 24, 0);
+            H3_EXPORT(h3ToGeoBoundary)(pentagon, &boundary);
+            H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(pentagon, edges);
+
+            int missingEdgeCount = 0;
+            for (int i = 0; i < 6; i++) {
+                if (edges[i] == 0) {
+                    missingEdgeCount++;
+                } else {
+                    H3_EXPORT(getH3UnidirectionalEdgeBoundary)
+                    (edges[i], &edgeBoundary);
+                    t_assert(edgeBoundary.numVerts == 2,
+                             "Got the expected number of vertices back for a "
+                             "Class II "
+                             "pentagon");
+                    for (int j = 0; j < edgeBoundary.numVerts; j++) {
+                        t_assert(geoAlmostEqual(
+                                     &edgeBoundary.verts[j],
+                                     &boundary.verts[expectedVertices[i][j]]),
+                                 "Got expected vertex");
+                    }
+                }
+            }
+            t_assert(missingEdgeCount == 1,
+                     "Only one edge was deleted for the pentagon");
+        }
     }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testHexRanges.c
+++ b/src/apps/testapps/testHexRanges.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testHexRanges.c
+++ b/src/apps/testapps/testHexRanges.c
@@ -18,62 +18,60 @@
 #include "algos.h"
 #include "test.h"
 
-BEGIN_TESTS(hexRanges);
+SUITE(hexRanges) {
+    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+    H3Index sfHex = H3_EXPORT(geoToH3)(&sf, 9);
+    H3Index* sfHexPtr = &sfHex;
 
-GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
-H3Index sfHex = H3_EXPORT(geoToH3)(&sf, 9);
-H3Index* sfHexPtr = &sfHex;
+    H3Index k1[] = {0x89283080ddbffff, 0x89283080c37ffff, 0x89283080c27ffff,
+                    0x89283080d53ffff, 0x89283080dcfffff, 0x89283080dc3ffff};
 
-H3Index k1[] = {0x89283080ddbffff, 0x89283080c37ffff, 0x89283080c27ffff,
-                0x89283080d53ffff, 0x89283080dcfffff, 0x89283080dc3ffff};
+    TEST(identityKRing) {
+        int err;
 
-TEST(identityKRing) {
-    int err;
+        H3Index k0[] = {0};
+        err = H3_EXPORT(hexRanges)(sfHexPtr, 1, 0, k0);
 
-    H3Index k0[] = {0};
-    err = H3_EXPORT(hexRanges)(sfHexPtr, 1, 0, k0);
+        t_assert(err == 0, "No error on hexRanges");
+        t_assert(k0[0] == sfHex, "generated identity k-ring");
+    }
 
-    t_assert(err == 0, "No error on hexRanges");
-    t_assert(k0[0] == sfHex, "generated identity k-ring");
-}
+    TEST(ring1of1) {
+        int err;
+        H3Index allKrings[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-TEST(ring1of1) {
-    int err;
-    H3Index allKrings[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        err = H3_EXPORT(hexRanges)(k1, 6, 1, allKrings);
 
-    err = H3_EXPORT(hexRanges)(k1, 6, 1, allKrings);
+        t_assert(err == 0, "No error on hexRanges");
 
-    t_assert(err == 0, "No error on hexRanges");
-
-    for (int i = 0; i < 42; i++) {
-        t_assert(allKrings[i] != 0, "index is populated");
-        if (i % 7 == 0) {
-            int index = i / 7;
-            t_assert(k1[index] == allKrings[i],
-                     "The beginning of the segment is the correct hexagon");
+        for (int i = 0; i < 42; i++) {
+            t_assert(allKrings[i] != 0, "index is populated");
+            if (i % 7 == 0) {
+                int index = i / 7;
+                t_assert(k1[index] == allKrings[i],
+                         "The beginning of the segment is the correct hexagon");
+            }
         }
     }
-}
 
-TEST(ring2of1) {
-    int err;
-    H3Index* allKrings2 = calloc(6 * (1 + 6 + 12), sizeof(H3Index));
-    err = H3_EXPORT(hexRanges)(k1, 6, 2, allKrings2);
+    TEST(ring2of1) {
+        int err;
+        H3Index* allKrings2 = calloc(6 * (1 + 6 + 12), sizeof(H3Index));
+        err = H3_EXPORT(hexRanges)(k1, 6, 2, allKrings2);
 
-    t_assert(err == 0, "No error on hexRanges");
+        t_assert(err == 0, "No error on hexRanges");
 
-    for (int i = 0; i < (6 * (1 + 6 + 12)); i++) {
-        t_assert(allKrings2[i] != 0, "index is populated");
+        for (int i = 0; i < (6 * (1 + 6 + 12)); i++) {
+            t_assert(allKrings2[i] != 0, "index is populated");
 
-        if (i % (1 + 6 + 12) == 0) {
-            int index = i / (1 + 6 + 12);
-            t_assert(k1[index] == allKrings2[i],
-                     "The beginning of the segment is the correct hexagon");
+            if (i % (1 + 6 + 12) == 0) {
+                int index = i / (1 + 6 + 12);
+                t_assert(k1[index] == allKrings2[i],
+                         "The beginning of the segment is the correct hexagon");
+            }
         }
+        free(allKrings2);
     }
-    free(allKrings2);
 }
-
-END_TESTS();

--- a/src/apps/testapps/testHexRing.c
+++ b/src/apps/testapps/testHexRing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testHexRing.c
+++ b/src/apps/testapps/testHexRing.c
@@ -20,166 +20,167 @@
 #include "h3Index.h"
 #include "test.h"
 
-BEGIN_TESTS(hexRing);
+SUITE(hexRing) {
+    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+    H3Index sfHex = H3_EXPORT(geoToH3)(&sf, 9);
 
-GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
-H3Index sfHex = H3_EXPORT(geoToH3)(&sf, 9);
+    TEST(identityKRing) {
+        int err;
 
-TEST(identityKRing) {
-    int err;
+        H3Index k0[] = {0};
+        err = H3_EXPORT(hexRing)(sfHex, 0, k0);
 
-    H3Index k0[] = {0};
-    err = H3_EXPORT(hexRing)(sfHex, 0, k0);
-
-    t_assert(err == 0, "No error on hexRing");
-    t_assert(k0[0] == sfHex, "generated identity k-ring");
-}
-
-TEST(ring1) {
-    int err;
-
-    H3Index k1[] = {0, 0, 0, 0, 0, 0};
-    H3Index expectedK1[] = {0x89283080ddbffff, 0x89283080c37ffff,
-                            0x89283080c27ffff, 0x89283080d53ffff,
-                            0x89283080dcfffff, 0x89283080dc3ffff};
-    err = H3_EXPORT(hexRing)(sfHex, 1, k1);
-
-    t_assert(err == 0, "No error on hexRing");
-
-    for (int i = 0; i < 6; i++) {
-        t_assert(k1[i] != 0, "index is populated");
-        int inList = 0;
-        for (int j = 0; j < 6; j++) {
-            if (k1[i] == expectedK1[j]) {
-                inList++;
-            }
-        }
-        t_assert(inList == 1, "index found in expected set");
+        t_assert(err == 0, "No error on hexRing");
+        t_assert(k0[0] == sfHex, "generated identity k-ring");
     }
-}
 
-TEST(ring2) {
-    int err;
+    TEST(ring1) {
+        int err;
 
-    H3Index k2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    H3Index expectedK2[] = {
-        0x89283080ca7ffff, 0x89283080cafffff, 0x89283080c33ffff,
-        0x89283080c23ffff, 0x89283080c2fffff, 0x89283080d5bffff,
-        0x89283080d43ffff, 0x89283080d57ffff, 0x89283080d1bffff,
-        0x89283080dc7ffff, 0x89283080dd7ffff, 0x89283080dd3ffff};
-    err = H3_EXPORT(hexRing)(sfHex, 2, k2);
+        H3Index k1[] = {0, 0, 0, 0, 0, 0};
+        H3Index expectedK1[] = {0x89283080ddbffff, 0x89283080c37ffff,
+                                0x89283080c27ffff, 0x89283080d53ffff,
+                                0x89283080dcfffff, 0x89283080dc3ffff};
+        err = H3_EXPORT(hexRing)(sfHex, 1, k1);
 
-    t_assert(err == 0, "No error on hexRing");
+        t_assert(err == 0, "No error on hexRing");
 
-    for (int i = 0; i < 12; i++) {
-        t_assert(k2[i] != 0, "index is populated");
-        int inList = 0;
-        for (int j = 0; j < 12; j++) {
-            if (k2[i] == expectedK2[j]) {
-                inList++;
-            }
-        }
-        t_assert(inList == 1, "index found in expected set");
-    }
-}
-
-TEST(nearPentagonRing1) {
-    int err;
-
-    H3Index nearPentagon = 0x837405fffffffff;
-    H3Index kp1[] = {0, 0, 0, 0, 0, 0};
-    err = H3_EXPORT(hexRing)(nearPentagon, 1, kp1);
-
-    t_assert(err != 0, "Should return an error when hitting a pentagon");
-}
-
-TEST(nearPentagonRing2) {
-    int err;
-
-    H3Index nearPentagon = 0x837405fffffffff;
-    H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    err = H3_EXPORT(hexRing)(nearPentagon, 2, kp2);
-
-    t_assert(err != 0, "Should return an error when hitting a pentagon");
-}
-
-TEST(onPentagon) {
-    int err;
-
-    H3Index nearPentagon;
-    setH3Index(&nearPentagon, 0, 4, 0);
-    H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    err = H3_EXPORT(hexRing)(nearPentagon, 2, kp2);
-
-    t_assert(err != 0, "Should return an error when starting at a pentagon");
-}
-
-TEST(hexRing_matches_kRingInternal) {
-    for (int res = 0; res < 2; res++) {
-        for (int i = 0; i < NUM_BASE_CELLS; i++) {
-            H3Index bc;
-            setH3Index(&bc, 0, i, 0);
-            int childrenSz = H3_EXPORT(maxUncompactSize)(&bc, 1, res);
-            H3Index *children = calloc(childrenSz, sizeof(H3Index));
-            H3_EXPORT(uncompact)(&bc, 1, children, childrenSz, res);
-
-            for (int j = 0; j < childrenSz; j++) {
-                if (children[j] == 0) {
-                    continue;
+        for (int i = 0; i < 6; i++) {
+            t_assert(k1[i] != 0, "index is populated");
+            int inList = 0;
+            for (int j = 0; j < 6; j++) {
+                if (k1[i] == expectedK1[j]) {
+                    inList++;
                 }
+            }
+            t_assert(inList == 1, "index found in expected set");
+        }
+    }
 
-                for (int k = 0; k < 3; k++) {
-                    int ringSz = k != 0 ? 6 * k : 1;
-                    int kSz = H3_EXPORT(maxKringSize)(k);
+    TEST(ring2) {
+        int err;
 
-                    H3Index *ring = calloc(ringSz, sizeof(H3Index));
-                    int failed = H3_EXPORT(hexRing)(children[j], k, ring);
+        H3Index k2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        H3Index expectedK2[] = {
+            0x89283080ca7ffff, 0x89283080cafffff, 0x89283080c33ffff,
+            0x89283080c23ffff, 0x89283080c2fffff, 0x89283080d5bffff,
+            0x89283080d43ffff, 0x89283080d57ffff, 0x89283080d1bffff,
+            0x89283080dc7ffff, 0x89283080dd7ffff, 0x89283080dd3ffff};
+        err = H3_EXPORT(hexRing)(sfHex, 2, k2);
 
-                    if (!failed) {
-                        H3Index *internalNeighbors =
-                            calloc(kSz, sizeof(H3Index));
-                        int *internalDistances = calloc(kSz, sizeof(int));
-                        _kRingInternal(children[j], k, internalNeighbors,
-                                       internalDistances, kSz, 0);
+        t_assert(err == 0, "No error on hexRing");
 
-                        int found = 0;
-                        int internalFound = 0;
-                        for (int iRing = 0; iRing < ringSz; iRing++) {
-                            if (ring[iRing] != 0) {
-                                found++;
+        for (int i = 0; i < 12; i++) {
+            t_assert(k2[i] != 0, "index is populated");
+            int inList = 0;
+            for (int j = 0; j < 12; j++) {
+                if (k2[i] == expectedK2[j]) {
+                    inList++;
+                }
+            }
+            t_assert(inList == 1, "index found in expected set");
+        }
+    }
 
-                                for (int iInternal = 0; iInternal < kSz;
-                                     iInternal++) {
-                                    if (internalNeighbors[iInternal] ==
-                                        ring[iRing]) {
-                                        internalFound++;
+    TEST(nearPentagonRing1) {
+        int err;
 
-                                        t_assert(
-                                            internalDistances[iInternal] == k,
-                                            "Ring and internal agree on "
-                                            "distance");
+        H3Index nearPentagon = 0x837405fffffffff;
+        H3Index kp1[] = {0, 0, 0, 0, 0, 0};
+        err = H3_EXPORT(hexRing)(nearPentagon, 1, kp1);
 
-                                        break;
-                                    }
-                                }
+        t_assert(err != 0, "Should return an error when hitting a pentagon");
+    }
 
-                                t_assert(found == internalFound,
-                                         "Ring and internal implementations "
-                                         "produce same output");
-                            }
-                        }
+    TEST(nearPentagonRing2) {
+        int err;
 
-                        free(internalNeighbors);
-                        free(internalDistances);
+        H3Index nearPentagon = 0x837405fffffffff;
+        H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        err = H3_EXPORT(hexRing)(nearPentagon, 2, kp2);
+
+        t_assert(err != 0, "Should return an error when hitting a pentagon");
+    }
+
+    TEST(onPentagon) {
+        int err;
+
+        H3Index nearPentagon;
+        setH3Index(&nearPentagon, 0, 4, 0);
+        H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        err = H3_EXPORT(hexRing)(nearPentagon, 2, kp2);
+
+        t_assert(err != 0,
+                 "Should return an error when starting at a pentagon");
+    }
+
+    TEST(hexRing_matches_kRingInternal) {
+        for (int res = 0; res < 2; res++) {
+            for (int i = 0; i < NUM_BASE_CELLS; i++) {
+                H3Index bc;
+                setH3Index(&bc, 0, i, 0);
+                int childrenSz = H3_EXPORT(maxUncompactSize)(&bc, 1, res);
+                H3Index *children = calloc(childrenSz, sizeof(H3Index));
+                H3_EXPORT(uncompact)(&bc, 1, children, childrenSz, res);
+
+                for (int j = 0; j < childrenSz; j++) {
+                    if (children[j] == 0) {
+                        continue;
                     }
 
-                    free(ring);
-                }
-            }
+                    for (int k = 0; k < 3; k++) {
+                        int ringSz = k != 0 ? 6 * k : 1;
+                        int kSz = H3_EXPORT(maxKringSize)(k);
 
-            free(children);
+                        H3Index *ring = calloc(ringSz, sizeof(H3Index));
+                        int failed = H3_EXPORT(hexRing)(children[j], k, ring);
+
+                        if (!failed) {
+                            H3Index *internalNeighbors =
+                                calloc(kSz, sizeof(H3Index));
+                            int *internalDistances = calloc(kSz, sizeof(int));
+                            _kRingInternal(children[j], k, internalNeighbors,
+                                           internalDistances, kSz, 0);
+
+                            int found = 0;
+                            int internalFound = 0;
+                            for (int iRing = 0; iRing < ringSz; iRing++) {
+                                if (ring[iRing] != 0) {
+                                    found++;
+
+                                    for (int iInternal = 0; iInternal < kSz;
+                                         iInternal++) {
+                                        if (internalNeighbors[iInternal] ==
+                                            ring[iRing]) {
+                                            internalFound++;
+
+                                            t_assert(
+                                                internalDistances[iInternal] ==
+                                                    k,
+                                                "Ring and internal agree on "
+                                                "distance");
+
+                                            break;
+                                        }
+                                    }
+
+                                    t_assert(
+                                        found == internalFound,
+                                        "Ring and internal implementations "
+                                        "produce same output");
+                                }
+                            }
+
+                            free(internalNeighbors);
+                            free(internalDistances);
+                        }
+
+                        free(ring);
+                    }
+                }
+
+                free(children);
+            }
         }
     }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -27,7 +27,7 @@
 #include "test.h"
 #include "utility.h"
 
-void kRing_equals_kRingInternal_assertions(H3Index h3) {
+static inline void kRing_equals_kRingInternal_assertions(H3Index h3) {
     for (int k = 0; k < 3; k++) {
         int kSz = H3_EXPORT(maxKringSize)(k);
 
@@ -67,56 +67,25 @@ void kRing_equals_kRingInternal_assertions(H3Index h3) {
     }
 }
 
-BEGIN_TESTS(kRing);
+SUITE(kRing) {
+    TEST(kRing0) {
+        GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+        H3Index sfHex0 = H3_EXPORT(geoToH3)(&sf, 0);
 
-TEST(kRing0) {
-    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
-    H3Index sfHex0 = H3_EXPORT(geoToH3)(&sf, 0);
+        H3Index k1[] = {0, 0, 0, 0, 0, 0, 0};
+        int k1Dist[] = {0, 0, 0, 0, 0, 0, 0};
+        H3Index expectedK1[] = {0x8029fffffffffff, 0x801dfffffffffff,
+                                0x8013fffffffffff, 0x8027fffffffffff,
+                                0x8049fffffffffff, 0x8051fffffffffff,
+                                0x8037fffffffffff};
+        H3_EXPORT(kRingDistances)(sfHex0, 1, k1, k1Dist);
 
-    H3Index k1[] = {0, 0, 0, 0, 0, 0, 0};
-    int k1Dist[] = {0, 0, 0, 0, 0, 0, 0};
-    H3Index expectedK1[] = {0x8029fffffffffff, 0x801dfffffffffff,
-                            0x8013fffffffffff, 0x8027fffffffffff,
-                            0x8049fffffffffff, 0x8051fffffffffff,
-                            0x8037fffffffffff};
-    H3_EXPORT(kRingDistances)(sfHex0, 1, k1, k1Dist);
-
-    for (int i = 0; i < 7; i++) {
-        t_assert(k1[i] != 0, "index is populated");
-        int inList = 0;
-        for (int j = 0; j < 7; j++) {
-            if (k1[i] == expectedK1[j]) {
-                t_assert(k1Dist[i] == (k1[i] == sfHex0 ? 0 : 1),
-                         "distance is as expected");
-                inList++;
-            }
-        }
-        t_assert(inList == 1, "index found in expected set");
-    }
-}
-
-TEST(kRing0_PolarPentagon) {
-    H3Index polar;
-    setH3Index(&polar, 0, 4, 0);
-    H3Index k2[] = {0, 0, 0, 0, 0, 0, 0};
-    int k2Dist[] = {0, 0, 0, 0, 0, 0, 0};
-    H3Index expectedK2[] = {0x8009fffffffffff,
-                            0x8007fffffffffff,
-                            0x8001fffffffffff,
-                            0x8011fffffffffff,
-                            0x801ffffffffffff,
-                            0x8019fffffffffff,
-                            0};
-    H3_EXPORT(kRingDistances)(polar, 1, k2, k2Dist);
-
-    int k2present = 0;
-    for (int i = 0; i < 7; i++) {
-        if (k2[i] != 0) {
-            k2present++;
+        for (int i = 0; i < 7; i++) {
+            t_assert(k1[i] != 0, "index is populated");
             int inList = 0;
             for (int j = 0; j < 7; j++) {
-                if (k2[i] == expectedK2[j]) {
-                    t_assert(k2Dist[i] == (k2[i] == polar ? 0 : 1),
+                if (k1[i] == expectedK1[j]) {
+                    t_assert(k1Dist[i] == (k1[i] == sfHex0 ? 0 : 1),
                              "distance is as expected");
                     inList++;
                 }
@@ -124,225 +93,257 @@ TEST(kRing0_PolarPentagon) {
             t_assert(inList == 1, "index found in expected set");
         }
     }
-    t_assert(k2present == 6, "pentagon has 5 neighbors");
-}
 
-TEST(kRing1_PolarPentagon) {
-    H3Index polar;
-    setH3Index(&polar, 1, 4, 0);
-    H3Index k2[] = {0, 0, 0, 0, 0, 0, 0};
-    int k2Dist[] = {0, 0, 0, 0, 0, 0, 0};
-    H3Index expectedK2[] = {0x81083ffffffffff,
-                            0x81093ffffffffff,
-                            0x81097ffffffffff,
-                            0x8108fffffffffff,
-                            0x8108bffffffffff,
-                            0x8109bffffffffff,
-                            0};
-    H3_EXPORT(kRingDistances)(polar, 1, k2, k2Dist);
+    TEST(kRing0_PolarPentagon) {
+        H3Index polar;
+        setH3Index(&polar, 0, 4, 0);
+        H3Index k2[] = {0, 0, 0, 0, 0, 0, 0};
+        int k2Dist[] = {0, 0, 0, 0, 0, 0, 0};
+        H3Index expectedK2[] = {0x8009fffffffffff,
+                                0x8007fffffffffff,
+                                0x8001fffffffffff,
+                                0x8011fffffffffff,
+                                0x801ffffffffffff,
+                                0x8019fffffffffff,
+                                0};
+        H3_EXPORT(kRingDistances)(polar, 1, k2, k2Dist);
 
-    int k2present = 0;
-    for (int i = 0; i < 7; i++) {
-        if (k2[i] != 0) {
-            k2present++;
-            int inList = 0;
-            for (int j = 0; j < 7; j++) {
-                if (k2[i] == expectedK2[j]) {
-                    t_assert(k2Dist[i] == (k2[i] == polar ? 0 : 1),
-                             "distance is as expected");
-                    inList++;
+        int k2present = 0;
+        for (int i = 0; i < 7; i++) {
+            if (k2[i] != 0) {
+                k2present++;
+                int inList = 0;
+                for (int j = 0; j < 7; j++) {
+                    if (k2[i] == expectedK2[j]) {
+                        t_assert(k2Dist[i] == (k2[i] == polar ? 0 : 1),
+                                 "distance is as expected");
+                        inList++;
+                    }
                 }
+                t_assert(inList == 1, "index found in expected set");
             }
-            t_assert(inList == 1, "index found in expected set");
         }
+        t_assert(k2present == 6, "pentagon has 5 neighbors");
     }
-    t_assert(k2present == 6, "pentagon has 5 neighbors");
-}
 
-TEST(kRing1_PolarPentagon_k3) {
-    H3Index polar;
-    setH3Index(&polar, 1, 4, 0);
-    H3Index k2[37] = {0};
-    int k2Dist[37] = {0};
-    H3Index expectedK2[37] = {0x81013ffffffffff,
-                              0x811fbffffffffff,
-                              0x81193ffffffffff,
-                              0x81097ffffffffff,
-                              0x81003ffffffffff,
-                              0x81183ffffffffff,
-                              0x8111bffffffffff,
-                              0x81077ffffffffff,
-                              0x811f7ffffffffff,
-                              0x81067ffffffffff,
-                              0x81093ffffffffff,
-                              0x811e7ffffffffff,
-                              0x81083ffffffffff,
-                              0x81117ffffffffff,
-                              0x8101bffffffffff,
-                              0x81107ffffffffff,
-                              0x81073ffffffffff,
-                              0x811f3ffffffffff,
-                              0x81063ffffffffff,
-                              0x8108fffffffffff,
-                              0x811e3ffffffffff,
-                              0x8119bffffffffff,
-                              0x81113ffffffffff,
-                              0x81017ffffffffff,
-                              0x81103ffffffffff,
-                              0x8109bffffffffff,
-                              0x81197ffffffffff,
-                              0x81007ffffffffff,
-                              0x8108bffffffffff,
-                              0x81187ffffffffff,
-                              0x8107bffffffffff,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0};
-    int expectedK2Dist[37] = {2, 3, 2, 1, 3, 3, 3, 2, 2, 3, 1, 3, 0,
-                              2, 3, 3, 2, 2, 3, 1, 3, 3, 2, 2, 3, 1,
-                              2, 3, 1, 3, 3, 0, 0, 0, 0, 0, 0};
-    H3_EXPORT(kRingDistances)(polar, 3, k2, k2Dist);
+    TEST(kRing1_PolarPentagon) {
+        H3Index polar;
+        setH3Index(&polar, 1, 4, 0);
+        H3Index k2[] = {0, 0, 0, 0, 0, 0, 0};
+        int k2Dist[] = {0, 0, 0, 0, 0, 0, 0};
+        H3Index expectedK2[] = {0x81083ffffffffff,
+                                0x81093ffffffffff,
+                                0x81097ffffffffff,
+                                0x8108fffffffffff,
+                                0x8108bffffffffff,
+                                0x8109bffffffffff,
+                                0};
+        H3_EXPORT(kRingDistances)(polar, 1, k2, k2Dist);
 
-    int k2present = 0;
-    for (int i = 0; i < 37; i++) {
-        if (k2[i] != 0) {
-            k2present++;
-            int inList = 0;
-            for (int j = 0; j < 37; j++) {
-                if (k2[i] == expectedK2[j]) {
-                    t_assert(k2Dist[i] == expectedK2Dist[j],
-                             "distance is as expected");
-                    inList++;
+        int k2present = 0;
+        for (int i = 0; i < 7; i++) {
+            if (k2[i] != 0) {
+                k2present++;
+                int inList = 0;
+                for (int j = 0; j < 7; j++) {
+                    if (k2[i] == expectedK2[j]) {
+                        t_assert(k2Dist[i] == (k2[i] == polar ? 0 : 1),
+                                 "distance is as expected");
+                        inList++;
+                    }
                 }
+                t_assert(inList == 1, "index found in expected set");
             }
-            t_assert(inList == 1, "index found in expected set");
         }
+        t_assert(k2present == 6, "pentagon has 5 neighbors");
     }
-    t_assert(k2present == 31, "pentagon has 30 neighbors");
-}
 
-TEST(kRing1_Pentagon_k4) {
-    H3Index pent;
-    setH3Index(&pent, 1, 14, 0);
-    H3Index k2[61] = {0};
-    int k2Dist[61] = {0};
-    H3Index expectedK2[61] = {0x811d7ffffffffff,
-                              0x810c7ffffffffff,
-                              0x81227ffffffffff,
-                              0x81293ffffffffff,
-                              0x81133ffffffffff,
-                              0x8136bffffffffff,
-                              0x81167ffffffffff,
-                              0x811d3ffffffffff,
-                              0x810c3ffffffffff,
-                              0x81223ffffffffff,
-                              0x81477ffffffffff,
-                              0x8128fffffffffff,
-                              0x81367ffffffffff,
-                              0x8112fffffffffff,
-                              0x811cfffffffffff,
-                              0x8123bffffffffff,
-                              0x810dbffffffffff,
-                              0x8112bffffffffff,
-                              0x81473ffffffffff,
-                              0x8128bffffffffff,
-                              0x81363ffffffffff,
-                              0x811cbffffffffff,
-                              0x81237ffffffffff,
-                              0x810d7ffffffffff,
-                              0x81127ffffffffff,
-                              0x8137bffffffffff,
-                              0x81287ffffffffff,
-                              0x8126bffffffffff,
-                              0x81177ffffffffff,
-                              0x810d3ffffffffff,
-                              0x81233ffffffffff,
-                              0x8150fffffffffff,
-                              0x81123ffffffffff,
-                              0x81377ffffffffff,
-                              0x81283ffffffffff,
-                              0x8102fffffffffff,
-                              0x811c3ffffffffff,
-                              0x810cfffffffffff,
-                              0x8122fffffffffff,
-                              0x8113bffffffffff,
-                              0x81373ffffffffff,
-                              0x8129bffffffffff,
-                              0x8102bffffffffff,
-                              0x811dbffffffffff,
-                              0x810cbffffffffff,
-                              0x8122bffffffffff,
-                              0x81297ffffffffff,
-                              0x81507ffffffffff,
-                              0x8136fffffffffff,
-                              0x8127bffffffffff,
-                              0x81137ffffffffff,
-                              0,
-                              0};
-    H3_EXPORT(kRingDistances)(pent, 4, k2, k2Dist);
+    TEST(kRing1_PolarPentagon_k3) {
+        H3Index polar;
+        setH3Index(&polar, 1, 4, 0);
+        H3Index k2[37] = {0};
+        int k2Dist[37] = {0};
+        H3Index expectedK2[37] = {0x81013ffffffffff,
+                                  0x811fbffffffffff,
+                                  0x81193ffffffffff,
+                                  0x81097ffffffffff,
+                                  0x81003ffffffffff,
+                                  0x81183ffffffffff,
+                                  0x8111bffffffffff,
+                                  0x81077ffffffffff,
+                                  0x811f7ffffffffff,
+                                  0x81067ffffffffff,
+                                  0x81093ffffffffff,
+                                  0x811e7ffffffffff,
+                                  0x81083ffffffffff,
+                                  0x81117ffffffffff,
+                                  0x8101bffffffffff,
+                                  0x81107ffffffffff,
+                                  0x81073ffffffffff,
+                                  0x811f3ffffffffff,
+                                  0x81063ffffffffff,
+                                  0x8108fffffffffff,
+                                  0x811e3ffffffffff,
+                                  0x8119bffffffffff,
+                                  0x81113ffffffffff,
+                                  0x81017ffffffffff,
+                                  0x81103ffffffffff,
+                                  0x8109bffffffffff,
+                                  0x81197ffffffffff,
+                                  0x81007ffffffffff,
+                                  0x8108bffffffffff,
+                                  0x81187ffffffffff,
+                                  0x8107bffffffffff,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0};
+        int expectedK2Dist[37] = {2, 3, 2, 1, 3, 3, 3, 2, 2, 3, 1, 3, 0,
+                                  2, 3, 3, 2, 2, 3, 1, 3, 3, 2, 2, 3, 1,
+                                  2, 3, 1, 3, 3, 0, 0, 0, 0, 0, 0};
+        H3_EXPORT(kRingDistances)(polar, 3, k2, k2Dist);
 
-    int k2present = 0;
-    for (int i = 0; i < 61; i++) {
-        if (k2[i] != 0) {
-            k2present++;
-            int inList = 0;
-            for (int j = 0; j < 61; j++) {
-                if (k2[i] == expectedK2[j]) {
-                    inList++;
+        int k2present = 0;
+        for (int i = 0; i < 37; i++) {
+            if (k2[i] != 0) {
+                k2present++;
+                int inList = 0;
+                for (int j = 0; j < 37; j++) {
+                    if (k2[i] == expectedK2[j]) {
+                        t_assert(k2Dist[i] == expectedK2Dist[j],
+                                 "distance is as expected");
+                        inList++;
+                    }
                 }
+                t_assert(inList == 1, "index found in expected set");
             }
-            t_assert(inList == 1, "index found in expected set");
+        }
+        t_assert(k2present == 31, "pentagon has 30 neighbors");
+    }
+
+    TEST(kRing1_Pentagon_k4) {
+        H3Index pent;
+        setH3Index(&pent, 1, 14, 0);
+        H3Index k2[61] = {0};
+        int k2Dist[61] = {0};
+        H3Index expectedK2[61] = {0x811d7ffffffffff,
+                                  0x810c7ffffffffff,
+                                  0x81227ffffffffff,
+                                  0x81293ffffffffff,
+                                  0x81133ffffffffff,
+                                  0x8136bffffffffff,
+                                  0x81167ffffffffff,
+                                  0x811d3ffffffffff,
+                                  0x810c3ffffffffff,
+                                  0x81223ffffffffff,
+                                  0x81477ffffffffff,
+                                  0x8128fffffffffff,
+                                  0x81367ffffffffff,
+                                  0x8112fffffffffff,
+                                  0x811cfffffffffff,
+                                  0x8123bffffffffff,
+                                  0x810dbffffffffff,
+                                  0x8112bffffffffff,
+                                  0x81473ffffffffff,
+                                  0x8128bffffffffff,
+                                  0x81363ffffffffff,
+                                  0x811cbffffffffff,
+                                  0x81237ffffffffff,
+                                  0x810d7ffffffffff,
+                                  0x81127ffffffffff,
+                                  0x8137bffffffffff,
+                                  0x81287ffffffffff,
+                                  0x8126bffffffffff,
+                                  0x81177ffffffffff,
+                                  0x810d3ffffffffff,
+                                  0x81233ffffffffff,
+                                  0x8150fffffffffff,
+                                  0x81123ffffffffff,
+                                  0x81377ffffffffff,
+                                  0x81283ffffffffff,
+                                  0x8102fffffffffff,
+                                  0x811c3ffffffffff,
+                                  0x810cfffffffffff,
+                                  0x8122fffffffffff,
+                                  0x8113bffffffffff,
+                                  0x81373ffffffffff,
+                                  0x8129bffffffffff,
+                                  0x8102bffffffffff,
+                                  0x811dbffffffffff,
+                                  0x810cbffffffffff,
+                                  0x8122bffffffffff,
+                                  0x81297ffffffffff,
+                                  0x81507ffffffffff,
+                                  0x8136fffffffffff,
+                                  0x8127bffffffffff,
+                                  0x81137ffffffffff,
+                                  0,
+                                  0};
+        H3_EXPORT(kRingDistances)(pent, 4, k2, k2Dist);
+
+        int k2present = 0;
+        for (int i = 0; i < 61; i++) {
+            if (k2[i] != 0) {
+                k2present++;
+                int inList = 0;
+                for (int j = 0; j < 61; j++) {
+                    if (k2[i] == expectedK2[j]) {
+                        inList++;
+                    }
+                }
+                t_assert(inList == 1, "index found in expected set");
+            }
+        }
+        t_assert(k2present == 51, "pentagon has 50 neighbors");
+    }
+
+    TEST(kRing_equals_kRingInternal) {
+        // Check that kRingDistances output matches _kRingInternal,
+        // since kRingDistances will sometimes use a different implementation.
+
+        for (int res = 0; res < 2; res++) {
+            iterateAllIndexesAtRes(res, kRing_equals_kRingInternal_assertions);
         }
     }
-    t_assert(k2present == 51, "pentagon has 50 neighbors");
-}
 
-TEST(kRing_equals_kRingInternal) {
-    // Check that kRingDistances output matches _kRingInternal,
-    // since kRingDistances will sometimes use a different implementation.
-
-    for (int res = 0; res < 2; res++) {
-        iterateAllIndexesAtRes(res, kRing_equals_kRingInternal_assertions);
+    TEST(h3NeighborRotations_identity) {
+        // This is undefined behavior, but it's helpful for it to make sense.
+        H3Index origin = 0x811d7ffffffffffL;
+        int rotations = 0;
+        t_assert(
+            h3NeighborRotations(origin, CENTER_DIGIT, &rotations) == origin,
+            "Moving to self goes to self");
     }
-}
 
-TEST(h3NeighborRotations_identity) {
-    // This is undefined behavior, but it's helpful for it to make sense.
-    H3Index origin = 0x811d7ffffffffffL;
-    int rotations = 0;
-    t_assert(h3NeighborRotations(origin, CENTER_DIGIT, &rotations) == origin,
-             "Moving to self goes to self");
-}
+    TEST(cwOffsetPent) {
+        // Try to find a case where h3NeighborRotations would not pass the
+        // cwOffsetPent check, and would hit a line marked as unreachable.
 
-TEST(cwOffsetPent) {
-    // Try to find a case where h3NeighborRotations would not pass the
-    // cwOffsetPent check, and would hit a line marked as unreachable.
+        // To do this, we need to find a case that would move from one
+        // non-pentagon base cell into the deleted k-subsequence of a pentagon
+        // base cell, and neither of the cwOffsetPent values are the original
+        // base cell's face.
 
-    // To do this, we need to find a case that would move from one non-pentagon
-    // base cell into the deleted k-subsequence of a pentagon base cell, and
-    // neither of the cwOffsetPent values are the original base cell's face.
+        for (int pentagon = 0; pentagon < NUM_BASE_CELLS; pentagon++) {
+            if (!_isBaseCellPentagon(pentagon)) {
+                continue;
+            }
 
-    for (int pentagon = 0; pentagon < NUM_BASE_CELLS; pentagon++) {
-        if (!_isBaseCellPentagon(pentagon)) {
-            continue;
-        }
+            for (int neighbor = 0; neighbor < NUM_BASE_CELLS; neighbor++) {
+                FaceIJK homeFaceIjk;
+                _baseCellToFaceIjk(neighbor, &homeFaceIjk);
+                int neighborFace = homeFaceIjk.face;
 
-        for (int neighbor = 0; neighbor < NUM_BASE_CELLS; neighbor++) {
-            FaceIJK homeFaceIjk;
-            _baseCellToFaceIjk(neighbor, &homeFaceIjk);
-            int neighborFace = homeFaceIjk.face;
-
-            // Only direction 2 needs to be checked, because that is the only
-            // direction where we can move from digit 2 to digit 1, and into the
-            // deleted k subsequence.
-            t_assert(_getBaseCellNeighbor(neighbor, J_AXES_DIGIT) != pentagon ||
-                         _baseCellIsCwOffset(pentagon, neighborFace),
-                     "cwOffsetPent is reachable");
+                // Only direction 2 needs to be checked, because that is the
+                // only direction where we can move from digit 2 to digit 1, and
+                // into the deleted k subsequence.
+                t_assert(
+                    _getBaseCellNeighbor(neighbor, J_AXES_DIGIT) != pentagon ||
+                        _baseCellIsCwOffset(pentagon, neighborFace),
+                    "cwOffsetPent is reachable");
+            }
         }
     }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -27,7 +27,7 @@
 #include "test.h"
 #include "utility.h"
 
-static inline void kRing_equals_kRingInternal_assertions(H3Index h3) {
+static void kRing_equals_kRingInternal_assertions(H3Index h3) {
     for (int k = 0; k < 3; k++) {
         int kSz = H3_EXPORT(maxKringSize)(k);
 

--- a/src/apps/testapps/testLinkedGeo.c
+++ b/src/apps/testapps/testLinkedGeo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testLinkedGeo.c
+++ b/src/apps/testapps/testLinkedGeo.c
@@ -22,52 +22,52 @@
 #include "test.h"
 
 // Fixtures
-GeoCoord vertex1;
-GeoCoord vertex2;
-GeoCoord vertex3;
-GeoCoord vertex4;
+static GeoCoord vertex1;
+static GeoCoord vertex2;
+static GeoCoord vertex3;
+static GeoCoord vertex4;
 
-BEGIN_TESTS(linkedGeo);
+SUITE(linkedGeo) {
+    setGeoDegs(&vertex1, 87.372002166, 166.160981117);
+    setGeoDegs(&vertex2, 87.370101364, 166.160184306);
+    setGeoDegs(&vertex3, 87.369088356, 166.196239997);
+    setGeoDegs(&vertex4, 87.369975080, 166.233115768);
 
-setGeoDegs(&vertex1, 87.372002166, 166.160981117);
-setGeoDegs(&vertex2, 87.370101364, 166.160184306);
-setGeoDegs(&vertex3, 87.369088356, 166.196239997);
-setGeoDegs(&vertex4, 87.369975080, 166.233115768);
+    TEST(createLinkedGeo) {
+        LinkedGeoPolygon* polygon = calloc(1, sizeof(LinkedGeoPolygon));
+        LinkedGeoLoop* loop;
+        LinkedGeoCoord* coord;
+        initLinkedPolygon(polygon);
 
-TEST(createLinkedGeo) {
-    LinkedGeoPolygon* polygon = calloc(1, sizeof(LinkedGeoPolygon));
-    LinkedGeoLoop* loop;
-    LinkedGeoCoord* coord;
-    initLinkedPolygon(polygon);
+        loop = addNewLinkedLoop(polygon);
+        t_assert(loop != NULL, "Loop created");
+        coord = addLinkedCoord(loop, &vertex1);
+        t_assert(coord != NULL, "Coord created");
+        coord = addLinkedCoord(loop, &vertex2);
+        t_assert(coord != NULL, "Coord created");
+        coord = addLinkedCoord(loop, &vertex3);
+        t_assert(coord != NULL, "Coord created");
 
-    loop = addNewLinkedLoop(polygon);
-    t_assert(loop != NULL, "Loop created");
-    coord = addLinkedCoord(loop, &vertex1);
-    t_assert(coord != NULL, "Coord created");
-    coord = addLinkedCoord(loop, &vertex2);
-    t_assert(coord != NULL, "Coord created");
-    coord = addLinkedCoord(loop, &vertex3);
-    t_assert(coord != NULL, "Coord created");
+        loop = addNewLinkedLoop(polygon);
+        t_assert(loop != NULL, "Loop createed");
+        coord = addLinkedCoord(loop, &vertex2);
+        t_assert(coord != NULL, "Coord created");
+        coord = addLinkedCoord(loop, &vertex4);
+        t_assert(coord != NULL, "Coord created");
 
-    loop = addNewLinkedLoop(polygon);
-    t_assert(loop != NULL, "Loop createed");
-    coord = addLinkedCoord(loop, &vertex2);
-    t_assert(coord != NULL, "Coord created");
-    coord = addLinkedCoord(loop, &vertex4);
-    t_assert(coord != NULL, "Coord created");
+        t_assert(countLinkedPolygons(polygon) == 1, "Polygon count correct");
+        t_assert(countLinkedLoops(polygon) == 2, "Loop count correct");
+        t_assert(countLinkedCoords(polygon->first) == 3,
+                 "Coord count 1 correct");
+        t_assert(countLinkedCoords(polygon->last) == 2,
+                 "Coord count 2 correct");
 
-    t_assert(countLinkedPolygons(polygon) == 1, "Polygon count correct");
-    t_assert(countLinkedLoops(polygon) == 2, "Loop count correct");
-    t_assert(countLinkedCoords(polygon->first) == 3, "Coord count 1 correct");
-    t_assert(countLinkedCoords(polygon->last) == 2, "Coord count 2 correct");
+        LinkedGeoPolygon* nextPolygon = addNewLinkedPolygon(polygon);
+        t_assert(nextPolygon != NULL, "polygon created");
 
-    LinkedGeoPolygon* nextPolygon = addNewLinkedPolygon(polygon);
-    t_assert(nextPolygon != NULL, "polygon created");
+        t_assert(countLinkedPolygons(polygon) == 2, "Polygon count correct");
 
-    t_assert(countLinkedPolygons(polygon) == 2, "Polygon count correct");
-
-    H3_EXPORT(destroyLinkedPolygon)(polygon);
-    free(polygon);
+        H3_EXPORT(destroyLinkedPolygon)(polygon);
+        free(polygon);
+    }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testMaxH3ToChildrenSize.c
+++ b/src/apps/testapps/testMaxH3ToChildrenSize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testMaxH3ToChildrenSize.c
+++ b/src/apps/testapps/testMaxH3ToChildrenSize.c
@@ -18,21 +18,19 @@
 #include "h3Index.h"
 #include "test.h"
 
-BEGIN_TESTS(maxH3ToChildrenSize);
+SUITE(maxH3ToChildrenSize) {
+    GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
 
-GeoCoord sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
+    TEST(maxH3ToChildrenSize) {
+        H3Index parent = H3_EXPORT(geoToH3)(&sf, 7);
 
-TEST(maxH3ToChildrenSize) {
-    H3Index parent = H3_EXPORT(geoToH3)(&sf, 7);
-
-    t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 3) == 0,
-             "got expected size for coarser res");
-    t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 7) == 1,
-             "got expected size for same res");
-    t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 8) == 7,
-             "got expected size for child res");
-    t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 9) == 7 * 7,
-             "got expected size for grandchild res");
+        t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 3) == 0,
+                 "got expected size for coarser res");
+        t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 7) == 1,
+                 "got expected size for same res");
+        t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 8) == 7,
+                 "got expected size for child res");
+        t_assert(H3_EXPORT(maxH3ToChildrenSize)(parent, 9) == 7 * 7,
+                 "got expected size for grandchild res");
+    }
 }
-
-END_TESTS();

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -22,24 +22,24 @@
 #include "test.h"
 
 // Fixtures
-GeoCoord sfVerts[] = {
+static GeoCoord sfVerts[] = {
     {0.659966917655, -2.1364398519396},  {0.6595011102219, -2.1359434279405},
     {0.6583348114025, -2.1354884206045}, {0.6581220034068, -2.1382437718946},
     {0.6594479998527, -2.1384597563896}, {0.6599990002976, -2.1376771158464}};
-Geofence sfGeofence = {.numVerts = 6, .verts = sfVerts};
-GeoPolygon sfGeoPolygon;
+static Geofence sfGeofence = {.numVerts = 6, .verts = sfVerts};
+static GeoPolygon sfGeoPolygon;
 
-GeoCoord holeVerts[] = {{0.6595072188743, -2.1371053983433},
-                        {0.6591482046471, -2.1373141048153},
-                        {0.6592295020837, -2.1365222838402}};
-Geofence holeGeofence = {.numVerts = 3, .verts = holeVerts};
-GeoPolygon holeGeoPolygon;
+static GeoCoord holeVerts[] = {{0.6595072188743, -2.1371053983433},
+                               {0.6591482046471, -2.1373141048153},
+                               {0.6592295020837, -2.1365222838402}};
+static Geofence holeGeofence = {.numVerts = 3, .verts = holeVerts};
+static GeoPolygon holeGeoPolygon;
 
-GeoCoord emptyVerts[] = {{0.659966917655, -2.1364398519394},
-                         {0.659966917655, -2.1364398519395},
-                         {0.659966917655, -2.1364398519396}};
-Geofence emptyGeofence = {.numVerts = 3, .verts = emptyVerts};
-GeoPolygon emptyGeoPolygon;
+static GeoCoord emptyVerts[] = {{0.659966917655, -2.1364398519394},
+                                {0.659966917655, -2.1364398519395},
+                                {0.659966917655, -2.1364398519396}};
+static Geofence emptyGeofence = {.numVerts = 3, .verts = emptyVerts};
+static GeoPolygon emptyGeoPolygon;
 
 static int countActualHexagons(H3Index* hexagons, int numHexagons) {
     int actualNumHexagons = 0;
@@ -51,249 +51,253 @@ static int countActualHexagons(H3Index* hexagons, int numHexagons) {
     return actualNumHexagons;
 }
 
-BEGIN_TESTS(polyfill);
+SUITE(polyfill) {
+    sfGeoPolygon.geofence = sfGeofence;
+    sfGeoPolygon.numHoles = 0;
 
-sfGeoPolygon.geofence = sfGeofence;
-sfGeoPolygon.numHoles = 0;
+    holeGeoPolygon.geofence = sfGeofence;
+    holeGeoPolygon.numHoles = 1;
+    holeGeoPolygon.holes = &holeGeofence;
 
-holeGeoPolygon.geofence = sfGeofence;
-holeGeoPolygon.numHoles = 1;
-holeGeoPolygon.holes = &holeGeofence;
+    emptyGeoPolygon.geofence = emptyGeofence;
+    emptyGeoPolygon.numHoles = 0;
 
-emptyGeoPolygon.geofence = emptyGeofence;
-emptyGeoPolygon.numHoles = 0;
+    TEST(maxPolyfillSize) {
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
+        t_assert(numHexagons == 3169, "got expected max polyfill size");
 
-TEST(maxPolyfillSize) {
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-    t_assert(numHexagons == 3169, "got expected max polyfill size");
+        numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
+        t_assert(numHexagons == 3169, "got expected max polyfill size (hole)");
 
-    numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-    t_assert(numHexagons == 3169, "got expected max polyfill size (hole)");
-
-    numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
-    t_assert(numHexagons == 1, "got expected max polyfill size (empty)");
-}
-
-TEST(polyfill) {
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&sfGeoPolygon, 9, hexagons);
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == 1253, "got expected polyfill size");
-    free(hexagons);
-}
-
-TEST(polyfillHole) {
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&holeGeoPolygon, 9, hexagons);
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == 1214, "got expected polyfill size (hole)");
-    free(hexagons);
-}
-
-TEST(polyfillEmpty) {
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&emptyGeoPolygon, 9, hexagons);
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == 0, "got expected polyfill size (empty)");
-    free(hexagons);
-}
-
-TEST(polyfillExact) {
-    GeoCoord somewhere = {1, 2};
-    H3Index origin = H3_EXPORT(geoToH3)(&somewhere, 9);
-    GeoBoundary boundary;
-    H3_EXPORT(h3ToGeoBoundary)(origin, &boundary);
-
-    GeoCoord* verts = calloc(boundary.numVerts + 1, sizeof(GeoCoord));
-    for (int i = 0; i < boundary.numVerts; i++) {
-        verts[i] = boundary.verts[i];
+        numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
+        t_assert(numHexagons == 1, "got expected max polyfill size (empty)");
     }
-    verts[boundary.numVerts] = boundary.verts[0];
 
-    Geofence someGeofence;
-    someGeofence.numVerts = boundary.numVerts + 1;
-    someGeofence.verts = verts;
-    GeoPolygon someHexagon;
-    someHexagon.geofence = someGeofence;
-    someHexagon.numHoles = 0;
+    TEST(polyfill) {
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
 
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&someHexagon, 9);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3_EXPORT(polyfill)(&sfGeoPolygon, 9, hexagons);
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
 
-    H3_EXPORT(polyfill)(&someHexagon, 9, hexagons);
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == 1, "got expected polyfill size (1)");
-    free(hexagons);
-    free(verts);
-}
-
-TEST(polyfillTransmeridian) {
-    GeoCoord primeMeridianVerts[] = {
-        {0.01, 0.01}, {0.01, -0.01}, {-0.01, -0.01}, {-0.01, 0.01}};
-    Geofence primeMeridianGeofence = {.numVerts = 4,
-                                      .verts = primeMeridianVerts};
-    GeoPolygon primeMeridianGeoPolygon = {.geofence = primeMeridianGeofence,
-                                          .numHoles = 0};
-
-    GeoCoord transMeridianVerts[] = {{0.01, -M_PI + 0.01},
-                                     {0.01, M_PI - 0.01},
-                                     {-0.01, M_PI - 0.01},
-                                     {-0.01, -M_PI + 0.01}};
-    Geofence transMeridianGeofence = {.numVerts = 4,
-                                      .verts = transMeridianVerts};
-    GeoPolygon transMeridianGeoPolygon = {.geofence = transMeridianGeofence,
-                                          .numHoles = 0};
-
-    GeoCoord transMeridianHoleVerts[] = {{0.005, -M_PI + 0.005},
-                                         {0.005, M_PI - 0.005},
-                                         {-0.005, M_PI - 0.005},
-                                         {-0.005, -M_PI + 0.005}};
-    Geofence transMeridianHoleGeofence = {.numVerts = 4,
-                                          .verts = transMeridianHoleVerts};
-    GeoPolygon transMeridianHoleGeoPolygon = {
-        .geofence = transMeridianGeofence,
-        .numHoles = 1,
-        .holes = &transMeridianHoleGeofence};
-    GeoPolygon transMeridianFilledHoleGeoPolygon = {
-        .geofence = transMeridianHoleGeofence, .numHoles = 0};
-
-    int expectedSize;
-
-    // Prime meridian case
-    expectedSize = 4228;
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&primeMeridianGeoPolygon, 7);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&primeMeridianGeoPolygon, 7, hexagons);
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == expectedSize,
-             "got expected polyfill size (prime meridian)");
-
-    // Transmeridian case
-    // This doesn't exactly match the prime meridian count because of slight
-    // differences in hex size and grid offset between the two cases
-    expectedSize = 4238;
-    numHexagons = H3_EXPORT(maxPolyfillSize)(&transMeridianGeoPolygon, 7);
-    H3Index* hexagonsTM = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&transMeridianGeoPolygon, 7, hexagonsTM);
-    actualNumHexagons = countActualHexagons(hexagonsTM, numHexagons);
-
-    t_assert(actualNumHexagons == expectedSize,
-             "got expected polyfill size (transmeridian)");
-
-    // Transmeridian filled hole case -- only needed for calculating hole size
-    numHexagons =
-        H3_EXPORT(maxPolyfillSize)(&transMeridianFilledHoleGeoPolygon, 7);
-    H3Index* hexagonsTMFH = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&transMeridianFilledHoleGeoPolygon, 7, hexagonsTMFH);
-    int actualNumHoleHexagons = countActualHexagons(hexagonsTMFH, numHexagons);
-
-    // Transmeridian hole case
-    numHexagons = H3_EXPORT(maxPolyfillSize)(&transMeridianHoleGeoPolygon, 7);
-    H3Index* hexagonsTMH = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&transMeridianHoleGeoPolygon, 7, hexagonsTMH);
-    actualNumHexagons = countActualHexagons(hexagonsTMH, numHexagons);
-
-    t_assert(actualNumHexagons == expectedSize - actualNumHoleHexagons,
-             "got expected polyfill size (transmeridian hole)");
-
-    free(hexagons);
-    free(hexagonsTM);
-    free(hexagonsTMFH);
-    free(hexagonsTMH);
-}
-
-TEST(polyfillTransmeridianComplex) {
-    // This polygon is "complex" in that it has > 4 vertices - this
-    // tests for a bug that was taking the max and min longitude as
-    // the bounds for transmeridian polygons
-    GeoCoord verts[] = {{0.1, -M_PI + 0.00001},  {0.1, M_PI - 0.00001},
-                        {0.05, M_PI - 0.2},      {-0.1, M_PI - 0.00001},
-                        {-0.1, -M_PI + 0.00001}, {-0.05, -M_PI + 0.2}};
-    Geofence geofence = {.numVerts = 6, .verts = verts};
-    GeoPolygon polygon = {.geofence = geofence, .numHoles = 0};
-
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&polygon, 4);
-
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-    H3_EXPORT(polyfill)(&polygon, 4, hexagons);
-
-    int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
-
-    t_assert(actualNumHexagons == 1204,
-             "got expected polyfill size (complex transmeridian)");
-
-    free(hexagons);
-}
-
-TEST(polyfillPentagon) {
-    H3Index pentagon;
-    setH3Index(&pentagon, 9, 24, 0);
-    GeoCoord coord;
-    H3_EXPORT(h3ToGeo)(pentagon, &coord);
-
-    // Length of half an edge of the polygon, in radians
-    double edgeLength2 = H3_EXPORT(degsToRads)(0.001);
-
-    GeoCoord boundingTopRigt = coord;
-    boundingTopRigt.lat += edgeLength2;
-    boundingTopRigt.lon += edgeLength2;
-
-    GeoCoord boundingTopLeft = coord;
-    boundingTopLeft.lat += edgeLength2;
-    boundingTopLeft.lon -= edgeLength2;
-
-    GeoCoord boundingBottomRight = coord;
-    boundingBottomRight.lat -= edgeLength2;
-    boundingBottomRight.lon += edgeLength2;
-
-    GeoCoord boundingBottomLeft = coord;
-    boundingBottomLeft.lat -= edgeLength2;
-    boundingBottomLeft.lon -= edgeLength2;
-
-    GeoCoord verts[] = {boundingBottomLeft, boundingTopLeft, boundingTopRigt,
-                        boundingBottomRight};
-
-    Geofence geofence;
-    geofence.verts = verts;
-    geofence.numVerts = 4;
-
-    GeoPolygon polygon;
-    polygon.geofence = geofence;
-    polygon.numHoles = 0;
-
-    int numHexagons = H3_EXPORT(maxPolyfillSize)(&polygon, 9);
-    H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
-
-    H3_EXPORT(polyfill)(&polygon, 9, hexagons);
-
-    int found = 0;
-    int numPentagons = 0;
-    for (int i = 0; i < numHexagons; i++) {
-        if (hexagons[i] != 0) {
-            found++;
-        }
-        if (H3_EXPORT(h3IsPentagon)(hexagons[i])) {
-            numPentagons++;
-        }
+        t_assert(actualNumHexagons == 1253, "got expected polyfill size");
+        free(hexagons);
     }
-    t_assert(found == 1, "one index found");
-    t_assert(numPentagons == 1, "one pentagon found");
-    free(hexagons);
-}
 
-END_TESTS();
+    TEST(polyfillHole) {
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&holeGeoPolygon, 9, hexagons);
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
+
+        t_assert(actualNumHexagons == 1214,
+                 "got expected polyfill size (hole)");
+        free(hexagons);
+    }
+
+    TEST(polyfillEmpty) {
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&emptyGeoPolygon, 9, hexagons);
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
+
+        t_assert(actualNumHexagons == 0, "got expected polyfill size (empty)");
+        free(hexagons);
+    }
+
+    TEST(polyfillExact) {
+        GeoCoord somewhere = {1, 2};
+        H3Index origin = H3_EXPORT(geoToH3)(&somewhere, 9);
+        GeoBoundary boundary;
+        H3_EXPORT(h3ToGeoBoundary)(origin, &boundary);
+
+        GeoCoord* verts = calloc(boundary.numVerts + 1, sizeof(GeoCoord));
+        for (int i = 0; i < boundary.numVerts; i++) {
+            verts[i] = boundary.verts[i];
+        }
+        verts[boundary.numVerts] = boundary.verts[0];
+
+        Geofence someGeofence;
+        someGeofence.numVerts = boundary.numVerts + 1;
+        someGeofence.verts = verts;
+        GeoPolygon someHexagon;
+        someHexagon.geofence = someGeofence;
+        someHexagon.numHoles = 0;
+
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&someHexagon, 9);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&someHexagon, 9, hexagons);
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
+
+        t_assert(actualNumHexagons == 1, "got expected polyfill size (1)");
+        free(hexagons);
+        free(verts);
+    }
+
+    TEST(polyfillTransmeridian) {
+        GeoCoord primeMeridianVerts[] = {
+            {0.01, 0.01}, {0.01, -0.01}, {-0.01, -0.01}, {-0.01, 0.01}};
+        Geofence primeMeridianGeofence = {.numVerts = 4,
+                                          .verts = primeMeridianVerts};
+        GeoPolygon primeMeridianGeoPolygon = {.geofence = primeMeridianGeofence,
+                                              .numHoles = 0};
+
+        GeoCoord transMeridianVerts[] = {{0.01, -M_PI + 0.01},
+                                         {0.01, M_PI - 0.01},
+                                         {-0.01, M_PI - 0.01},
+                                         {-0.01, -M_PI + 0.01}};
+        Geofence transMeridianGeofence = {.numVerts = 4,
+                                          .verts = transMeridianVerts};
+        GeoPolygon transMeridianGeoPolygon = {.geofence = transMeridianGeofence,
+                                              .numHoles = 0};
+
+        GeoCoord transMeridianHoleVerts[] = {{0.005, -M_PI + 0.005},
+                                             {0.005, M_PI - 0.005},
+                                             {-0.005, M_PI - 0.005},
+                                             {-0.005, -M_PI + 0.005}};
+        Geofence transMeridianHoleGeofence = {.numVerts = 4,
+                                              .verts = transMeridianHoleVerts};
+        GeoPolygon transMeridianHoleGeoPolygon = {
+            .geofence = transMeridianGeofence,
+            .numHoles = 1,
+            .holes = &transMeridianHoleGeofence};
+        GeoPolygon transMeridianFilledHoleGeoPolygon = {
+            .geofence = transMeridianHoleGeofence, .numHoles = 0};
+
+        int expectedSize;
+
+        // Prime meridian case
+        expectedSize = 4228;
+        int numHexagons =
+            H3_EXPORT(maxPolyfillSize)(&primeMeridianGeoPolygon, 7);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&primeMeridianGeoPolygon, 7, hexagons);
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
+
+        t_assert(actualNumHexagons == expectedSize,
+                 "got expected polyfill size (prime meridian)");
+
+        // Transmeridian case
+        // This doesn't exactly match the prime meridian count because of slight
+        // differences in hex size and grid offset between the two cases
+        expectedSize = 4238;
+        numHexagons = H3_EXPORT(maxPolyfillSize)(&transMeridianGeoPolygon, 7);
+        H3Index* hexagonsTM = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&transMeridianGeoPolygon, 7, hexagonsTM);
+        actualNumHexagons = countActualHexagons(hexagonsTM, numHexagons);
+
+        t_assert(actualNumHexagons == expectedSize,
+                 "got expected polyfill size (transmeridian)");
+
+        // Transmeridian filled hole case -- only needed for calculating hole
+        // size
+        numHexagons =
+            H3_EXPORT(maxPolyfillSize)(&transMeridianFilledHoleGeoPolygon, 7);
+        H3Index* hexagonsTMFH = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)
+        (&transMeridianFilledHoleGeoPolygon, 7, hexagonsTMFH);
+        int actualNumHoleHexagons =
+            countActualHexagons(hexagonsTMFH, numHexagons);
+
+        // Transmeridian hole case
+        numHexagons =
+            H3_EXPORT(maxPolyfillSize)(&transMeridianHoleGeoPolygon, 7);
+        H3Index* hexagonsTMH = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&transMeridianHoleGeoPolygon, 7, hexagonsTMH);
+        actualNumHexagons = countActualHexagons(hexagonsTMH, numHexagons);
+
+        t_assert(actualNumHexagons == expectedSize - actualNumHoleHexagons,
+                 "got expected polyfill size (transmeridian hole)");
+
+        free(hexagons);
+        free(hexagonsTM);
+        free(hexagonsTMFH);
+        free(hexagonsTMH);
+    }
+
+    TEST(polyfillTransmeridianComplex) {
+        // This polygon is "complex" in that it has > 4 vertices - this
+        // tests for a bug that was taking the max and min longitude as
+        // the bounds for transmeridian polygons
+        GeoCoord verts[] = {{0.1, -M_PI + 0.00001},  {0.1, M_PI - 0.00001},
+                            {0.05, M_PI - 0.2},      {-0.1, M_PI - 0.00001},
+                            {-0.1, -M_PI + 0.00001}, {-0.05, -M_PI + 0.2}};
+        Geofence geofence = {.numVerts = 6, .verts = verts};
+        GeoPolygon polygon = {.geofence = geofence, .numHoles = 0};
+
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&polygon, 4);
+
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3_EXPORT(polyfill)(&polygon, 4, hexagons);
+
+        int actualNumHexagons = countActualHexagons(hexagons, numHexagons);
+
+        t_assert(actualNumHexagons == 1204,
+                 "got expected polyfill size (complex transmeridian)");
+
+        free(hexagons);
+    }
+
+    TEST(polyfillPentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 9, 24, 0);
+        GeoCoord coord;
+        H3_EXPORT(h3ToGeo)(pentagon, &coord);
+
+        // Length of half an edge of the polygon, in radians
+        double edgeLength2 = H3_EXPORT(degsToRads)(0.001);
+
+        GeoCoord boundingTopRigt = coord;
+        boundingTopRigt.lat += edgeLength2;
+        boundingTopRigt.lon += edgeLength2;
+
+        GeoCoord boundingTopLeft = coord;
+        boundingTopLeft.lat += edgeLength2;
+        boundingTopLeft.lon -= edgeLength2;
+
+        GeoCoord boundingBottomRight = coord;
+        boundingBottomRight.lat -= edgeLength2;
+        boundingBottomRight.lon += edgeLength2;
+
+        GeoCoord boundingBottomLeft = coord;
+        boundingBottomLeft.lat -= edgeLength2;
+        boundingBottomLeft.lon -= edgeLength2;
+
+        GeoCoord verts[] = {boundingBottomLeft, boundingTopLeft,
+                            boundingTopRigt, boundingBottomRight};
+
+        Geofence geofence;
+        geofence.verts = verts;
+        geofence.numVerts = 4;
+
+        GeoPolygon polygon;
+        polygon.geofence = geofence;
+        polygon.numHoles = 0;
+
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(&polygon, 9);
+        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        H3_EXPORT(polyfill)(&polygon, 9, hexagons);
+
+        int found = 0;
+        int numPentagons = 0;
+        for (int i = 0; i < numHexagons; i++) {
+            if (hexagons[i] != 0) {
+                found++;
+            }
+            if (H3_EXPORT(h3IsPentagon)(hexagons[i])) {
+                numPentagons++;
+            }
+        }
+        t_assert(found == 1, "one index found");
+        t_assert(numPentagons == 1, "one pentagon found");
+        free(hexagons);
+    }
+}

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Uber Technologies, Inc.
+ * Copyright 2017-2018 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -25,7 +25,7 @@
 #include "test.h"
 
 // Fixtures
-GeoCoord sfVerts[] = {
+static GeoCoord sfVerts[] = {
     {0.659966917655, -2.1364398519396},  {0.6595011102219, -2.1359434279405},
     {0.6583348114025, -2.1354884206045}, {0.6581220034068, -2.1382437718946},
     {0.6594479998527, -2.1384597563896}, {0.6599990002976, -2.1376771158464}};
@@ -38,519 +38,528 @@ static void createLinkedLoop(LinkedGeoLoop* loop, GeoCoord* verts,
     }
 }
 
-BEGIN_TESTS(polygon);
+SUITE(polygon) {
+    TEST(pointInsideGeofence) {
+        Geofence geofence = {.numVerts = 6, .verts = sfVerts};
 
-TEST(pointInsideGeofence) {
-    Geofence geofence = {.numVerts = 6, .verts = sfVerts};
+        GeoCoord inside = {0.659, -2.136};
+        GeoCoord somewhere = {1, 2};
 
-    GeoCoord inside = {0.659, -2.136};
-    GeoCoord somewhere = {1, 2};
+        BBox bbox;
+        bboxFromGeofence(&geofence, &bbox);
 
-    BBox bbox;
-    bboxFromGeofence(&geofence, &bbox);
+        t_assert(!pointInsideGeofence(&geofence, &bbox, &sfVerts[0]),
+                 "contains exact");
+        t_assert(pointInsideGeofence(&geofence, &bbox, &sfVerts[4]),
+                 "contains exact 4");
+        t_assert(pointInsideGeofence(&geofence, &bbox, &inside),
+                 "contains point inside");
+        t_assert(!pointInsideGeofence(&geofence, &bbox, &somewhere),
+                 "contains somewhere else");
+    }
 
-    t_assert(!pointInsideGeofence(&geofence, &bbox, &sfVerts[0]),
-             "contains exact");
-    t_assert(pointInsideGeofence(&geofence, &bbox, &sfVerts[4]),
-             "contains exact 4");
-    t_assert(pointInsideGeofence(&geofence, &bbox, &inside),
-             "contains point inside");
-    t_assert(!pointInsideGeofence(&geofence, &bbox, &somewhere),
-             "contains somewhere else");
+    TEST(pointInsideGeofenceTransmeridian) {
+        GeoCoord verts[] = {{0.01, -M_PI + 0.01},
+                            {0.01, M_PI - 0.01},
+                            {-0.01, M_PI - 0.01},
+                            {-0.01, -M_PI + 0.01}};
+        Geofence transMeridianGeofence = {.numVerts = 4, .verts = verts};
+
+        GeoCoord eastPoint = {0.001, -M_PI + 0.001};
+        GeoCoord eastPointOutside = {0.001, -M_PI + 0.1};
+        GeoCoord westPoint = {0.001, M_PI - 0.001};
+        GeoCoord westPointOutside = {0.001, M_PI - 0.1};
+
+        BBox bbox;
+        bboxFromGeofence(&transMeridianGeofence, &bbox);
+
+        t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &westPoint),
+                 "contains point to the west of the antimeridian");
+        t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPoint),
+                 "contains point to the east of the antimeridian");
+        t_assert(
+            !pointInsideGeofence(&transMeridianGeofence, &bbox,
+                                 &westPointOutside),
+            "does not contain outside point to the west of the antimeridian");
+        t_assert(
+            !pointInsideGeofence(&transMeridianGeofence, &bbox,
+                                 &eastPointOutside),
+            "does not contain outside point to the east of the antimeridian");
+    }
+
+    TEST(pointInsideLinkedGeoLoop) {
+        GeoCoord somewhere = {1, 2};
+        GeoCoord inside = {0.659, -2.136};
+
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &sfVerts[0], 6);
+
+        BBox bbox;
+        bboxFromLinkedGeoLoop(&loop, &bbox);
+
+        t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &inside),
+                 "contains exact4");
+        t_assert(!pointInsideLinkedGeoLoop(&loop, &bbox, &somewhere),
+                 "contains somewhere else");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(bboxFromGeofence) {
+        GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+        Geofence geofence = {.numVerts = 4, .verts = verts};
+
+        const BBox expected = {1.1, 0.7, 0.7, 0.2};
+
+        BBox result;
+        bboxFromGeofence(&geofence, &result);
+        t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+    }
+
+    TEST(bboxFromGeofenceTransmeridian) {
+        GeoCoord verts[] = {{0.1, -M_PI + 0.1},  {0.1, M_PI - 0.1},
+                            {0.05, M_PI - 0.2},  {-0.1, M_PI - 0.1},
+                            {-0.1, -M_PI + 0.1}, {-0.05, -M_PI + 0.2}};
+        Geofence geofence = {.numVerts = 6, .verts = verts};
+
+        const BBox expected = {0.1, -0.1, -M_PI + 0.2, M_PI - 0.2};
+
+        BBox result;
+        bboxFromGeofence(&geofence, &result);
+        t_assert(bboxEquals(&result, &expected),
+                 "Got expected transmeridian bbox");
+    }
+
+    TEST(bboxFromGeofenceNoVertices) {
+        Geofence geofence;
+        geofence.verts = NULL;
+        geofence.numVerts = 0;
+
+        const BBox expected = {0.0, 0.0, 0.0, 0.0};
+
+        BBox result;
+        bboxFromGeofence(&geofence, &result);
+
+        t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+    }
+
+    TEST(bboxesFromGeoPolygon) {
+        GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+        Geofence geofence = {.numVerts = 4, .verts = verts};
+        GeoPolygon polygon = {.geofence = geofence, .numHoles = 0};
+
+        const BBox expected = {1.1, 0.7, 0.7, 0.2};
+
+        BBox* result = calloc(sizeof(BBox), 1);
+        bboxesFromGeoPolygon(&polygon, result);
+        t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
+
+        free(result);
+    }
+
+    TEST(bboxesFromGeoPolygonHole) {
+        GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+        Geofence geofence = {.numVerts = 4, .verts = verts};
+
+        // not a real hole, but doesn't matter for the test
+        GeoCoord holeVerts[] = {{0.9, 0.3}, {0.9, 0.5}, {1.0, 0.7}, {0.9, 0.3}};
+        Geofence holeGeofence = {.numVerts = 4, .verts = holeVerts};
+
+        GeoPolygon polygon = {
+            .geofence = geofence, .numHoles = 1, .holes = &holeGeofence};
+
+        const BBox expected = {1.1, 0.7, 0.7, 0.2};
+        const BBox expectedHole = {1.0, 0.9, 0.7, 0.3};
+
+        BBox* result = calloc(sizeof(BBox), 2);
+        bboxesFromGeoPolygon(&polygon, result);
+        t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
+        t_assert(bboxEquals(&result[1], &expectedHole),
+                 "Got expected hole bbox");
+
+        free(result);
+    }
+
+    TEST(bboxFromLinkedGeoLoop) {
+        GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
+
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &verts[0], 4);
+
+        const BBox expected = {1.1, 0.7, 0.7, 0.2};
+
+        BBox result;
+        bboxFromLinkedGeoLoop(&loop, &result);
+        t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(bboxFromLinkedGeoLoopNoVertices) {
+        LinkedGeoLoop loop;
+        initLinkedLoop(&loop);
+
+        const BBox expected = {0.0, 0.0, 0.0, 0.0};
+
+        BBox result;
+        bboxFromLinkedGeoLoop(&loop, &result);
+
+        t_assert(bboxEquals(&result, &expected), "Got expected bbox");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(isClockwiseGeofence) {
+        GeoCoord verts[] = {{0, 0}, {0.1, 0.1}, {0, 0.1}};
+        Geofence geofence = {.numVerts = 3, .verts = verts};
+
+        t_assert(isClockwiseGeofence(&geofence),
+                 "Got true for clockwise geofence");
+    }
+
+    TEST(isClockwiseLinkedGeoLoop) {
+        GeoCoord verts[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &verts[0], 3);
+
+        t_assert(isClockwiseLinkedGeoLoop(&loop),
+                 "Got true for clockwise loop");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(isNotClockwiseLinkedGeoLoop) {
+        GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &verts[0], 4);
+
+        t_assert(!isClockwiseLinkedGeoLoop(&loop),
+                 "Got false for counter-clockwise loop");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(isClockwiseGeofenceTransmeridian) {
+        GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                            {0.4, -M_PI + 0.1},
+                            {-0.4, -M_PI + 0.1},
+                            {-0.4, M_PI - 0.1}};
+        Geofence geofence = {.numVerts = 4, .verts = verts};
+
+        t_assert(isClockwiseGeofence(&geofence),
+                 "Got true for clockwise geofence");
+    }
+
+    TEST(isClockwiseLinkedGeoLoopTransmeridian) {
+        GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                            {0.4, -M_PI + 0.1},
+                            {-0.4, -M_PI + 0.1},
+                            {-0.4, M_PI - 0.1}};
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &verts[0], 4);
+
+        t_assert(isClockwiseLinkedGeoLoop(&loop),
+                 "Got true for clockwise transmeridian loop");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(isNotClockwiseLinkedGeoLoopTransmeridian) {
+        GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                            {-0.4, M_PI - 0.1},
+                            {-0.4, -M_PI + 0.1},
+                            {0.4, -M_PI + 0.1}};
+        LinkedGeoLoop loop;
+        createLinkedLoop(&loop, &verts[0], 4);
+
+        t_assert(!isClockwiseLinkedGeoLoop(&loop),
+                 "Got false for counter-clockwise transmeridian loop");
+
+        destroyLinkedGeoLoop(&loop);
+    }
+
+    TEST(normalizeMultiPolygonSingle) {
+        GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}};
+
+        LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, outer);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 1, "Loop count correct");
+        t_assert(polygon.first == outer, "Got expected loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonTwoOuterLoops) {
+        GeoCoord verts1[] = {{0, 0}, {0, 1}, {1, 1}};
+
+        LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
+        assert(outer1 != NULL);
+        createLinkedLoop(outer1, &verts1[0], 3);
+
+        GeoCoord verts2[] = {{2, 2}, {2, 3}, {3, 3}};
+
+        LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
+        assert(outer2 != NULL);
+        createLinkedLoop(outer2, &verts2[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, outer1);
+        addLinkedLoop(&polygon, outer2);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 1,
+                 "Loop count on first polygon correct");
+        t_assert(countLinkedLoops(polygon.next) == 1,
+                 "Loop count on second polygon correct");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonOneHole) {
+        GeoCoord verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
+
+        LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 4);
+
+        GeoCoord verts2[] = {{1, 1}, {2, 2}, {1, 2}};
+
+        LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
+        assert(inner != NULL);
+        createLinkedLoop(inner, &verts2[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, inner);
+        addLinkedLoop(&polygon, outer);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 2,
+                 "Loop count on first polygon correct");
+        t_assert(polygon.first == outer, "Got expected outer loop");
+        t_assert(polygon.first->next == inner, "Got expected inner loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonTwoHoles) {
+        GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
+
+        LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 4);
+
+        GeoCoord verts2[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
+
+        LinkedGeoLoop* inner1 = calloc(1, sizeof(*inner1));
+        assert(inner1 != NULL);
+        createLinkedLoop(inner1, &verts2[0], 3);
+
+        GeoCoord verts3[] = {{0.2, 0.2}, {0.3, 0.3}, {0.2, 0.3}};
+
+        LinkedGeoLoop* inner2 = calloc(1, sizeof(*inner2));
+        assert(inner2 != NULL);
+        createLinkedLoop(inner2, &verts3[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, inner2);
+        addLinkedLoop(&polygon, outer);
+        addLinkedLoop(&polygon, inner1);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 1,
+                 "Polygon count correct for 2 holes");
+        t_assert(polygon.first == outer, "Got expected outer loop");
+        t_assert(countLinkedLoops(&polygon) == 3,
+                 "Loop count on first polygon correct");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonTwoDonuts) {
+        GeoCoord verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
+        LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 4);
+
+        GeoCoord verts2[] = {{1, 1}, {2, 2}, {1, 2}};
+        LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
+        assert(inner != NULL);
+        createLinkedLoop(inner, &verts2[0], 3);
+
+        GeoCoord verts3[] = {{0, 0}, {0, -3}, {-3, -3}, {-3, 0}};
+        LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer));
+        assert(outer2 != NULL);
+        createLinkedLoop(outer2, &verts3[0], 4);
+
+        GeoCoord verts4[] = {{-1, -1}, {-2, -2}, {-1, -2}};
+        LinkedGeoLoop* inner2 = calloc(1, sizeof(*inner));
+        assert(inner2 != NULL);
+        createLinkedLoop(inner2, &verts4[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, inner2);
+        addLinkedLoop(&polygon, inner);
+        addLinkedLoop(&polygon, outer);
+        addLinkedLoop(&polygon, outer2);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 2,
+                 "Loop count on first polygon correct");
+        t_assert(countLinkedCoords(polygon.first) == 4,
+                 "Got expected outer loop");
+        t_assert(countLinkedCoords(polygon.first->next) == 3,
+                 "Got expected inner loop");
+        t_assert(countLinkedLoops(polygon.next) == 2,
+                 "Loop count on second polygon correct");
+        t_assert(countLinkedCoords(polygon.next->first) == 4,
+                 "Got expected outer loop");
+        t_assert(countLinkedCoords(polygon.next->first->next) == 3,
+                 "Got expected inner loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonNestedDonuts) {
+        GeoCoord verts[] = {{0.2, 0.2}, {0.2, -0.2}, {-0.2, -0.2}, {-0.2, 0.2}};
+        LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 4);
+
+        GeoCoord verts2[] = {
+            {0.1, 0.1}, {-0.1, 0.1}, {-0.1, -0.1}, {0.1, -0.1}};
+        LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
+        assert(inner != NULL);
+        createLinkedLoop(inner, &verts2[0], 4);
+
+        GeoCoord verts3[] = {
+            {0.6, 0.6}, {0.6, -0.6}, {-0.6, -0.6}, {-0.6, 0.6}};
+        LinkedGeoLoop* outerBig = calloc(1, sizeof(*outerBig));
+        assert(outerBig != NULL);
+        createLinkedLoop(outerBig, &verts3[0], 4);
+
+        GeoCoord verts4[] = {
+            {0.5, 0.5}, {-0.5, 0.5}, {-0.5, -0.5}, {0.5, -0.5}};
+        LinkedGeoLoop* innerBig = calloc(1, sizeof(*innerBig));
+        assert(innerBig != NULL);
+        createLinkedLoop(innerBig, &verts4[0], 4);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, inner);
+        addLinkedLoop(&polygon, outerBig);
+        addLinkedLoop(&polygon, innerBig);
+        addLinkedLoop(&polygon, outer);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 2,
+                 "Loop count on first polygon correct");
+        t_assert(polygon.first == outerBig, "Got expected outer loop");
+        t_assert(polygon.first->next == innerBig, "Got expected inner loop");
+        t_assert(countLinkedLoops(polygon.next) == 2,
+                 "Loop count on second polygon correct");
+        t_assert(polygon.next->first == outer, "Got expected outer loop");
+        t_assert(polygon.next->first->next == inner, "Got expected inner loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonNoOuterLoops) {
+        GeoCoord verts1[] = {{0, 0}, {1, 1}, {0, 1}};
+
+        LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
+        assert(outer1 != NULL);
+        createLinkedLoop(outer1, &verts1[0], 3);
+
+        GeoCoord verts2[] = {{2, 2}, {3, 3}, {2, 3}};
+
+        LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
+        assert(outer2 != NULL);
+        createLinkedLoop(outer2, &verts2[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, outer1);
+        addLinkedLoop(&polygon, outer2);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_ERR_UNASSIGNED_HOLES,
+                 "Expected error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 0,
+                 "Loop count as expected with invalid input");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygonAlreadyNormalized) {
+        GeoCoord verts1[] = {{0, 0}, {0, 1}, {1, 1}};
+
+        LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
+        assert(outer1 != NULL);
+        createLinkedLoop(outer1, &verts1[0], 3);
+
+        GeoCoord verts2[] = {{2, 2}, {2, 3}, {3, 3}};
+
+        LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
+        assert(outer2 != NULL);
+        createLinkedLoop(outer2, &verts2[0], 3);
+
+        LinkedGeoPolygon polygon;
+        initLinkedPolygon(&polygon);
+        addLinkedLoop(&polygon, outer1);
+        LinkedGeoPolygon* next = addNewLinkedPolygon(&polygon);
+        addLinkedLoop(next, outer2);
+
+        // Should be a no-op
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_ERR_MULTIPLE_POLYGONS,
+                 "Expected error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 1,
+                 "Loop count on first polygon correct");
+        t_assert(polygon.first == outer1, "Got expected outer loop");
+        t_assert(countLinkedLoops(polygon.next) == 1,
+                 "Loop count on second polygon correct");
+        t_assert(polygon.next->first == outer2, "Got expected outer loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
 }
-
-TEST(pointInsideGeofenceTransmeridian) {
-    GeoCoord verts[] = {{0.01, -M_PI + 0.01},
-                        {0.01, M_PI - 0.01},
-                        {-0.01, M_PI - 0.01},
-                        {-0.01, -M_PI + 0.01}};
-    Geofence transMeridianGeofence = {.numVerts = 4, .verts = verts};
-
-    GeoCoord eastPoint = {0.001, -M_PI + 0.001};
-    GeoCoord eastPointOutside = {0.001, -M_PI + 0.1};
-    GeoCoord westPoint = {0.001, M_PI - 0.001};
-    GeoCoord westPointOutside = {0.001, M_PI - 0.1};
-
-    BBox bbox;
-    bboxFromGeofence(&transMeridianGeofence, &bbox);
-
-    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &westPoint),
-             "contains point to the west of the antimeridian");
-    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPoint),
-             "contains point to the east of the antimeridian");
-    t_assert(
-        !pointInsideGeofence(&transMeridianGeofence, &bbox, &westPointOutside),
-        "does not contain outside point to the west of the antimeridian");
-    t_assert(
-        !pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPointOutside),
-        "does not contain outside point to the east of the antimeridian");
-}
-
-TEST(pointInsideLinkedGeoLoop) {
-    GeoCoord somewhere = {1, 2};
-    GeoCoord inside = {0.659, -2.136};
-
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &sfVerts[0], 6);
-
-    BBox bbox;
-    bboxFromLinkedGeoLoop(&loop, &bbox);
-
-    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &inside),
-             "contains exact4");
-    t_assert(!pointInsideLinkedGeoLoop(&loop, &bbox, &somewhere),
-             "contains somewhere else");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(bboxFromGeofence) {
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    Geofence geofence = {.numVerts = 4, .verts = verts};
-
-    const BBox expected = {1.1, 0.7, 0.7, 0.2};
-
-    BBox result;
-    bboxFromGeofence(&geofence, &result);
-    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-}
-
-TEST(bboxFromGeofenceTransmeridian) {
-    GeoCoord verts[] = {{0.1, -M_PI + 0.1},  {0.1, M_PI - 0.1},
-                        {0.05, M_PI - 0.2},  {-0.1, M_PI - 0.1},
-                        {-0.1, -M_PI + 0.1}, {-0.05, -M_PI + 0.2}};
-    Geofence geofence = {.numVerts = 6, .verts = verts};
-
-    const BBox expected = {0.1, -0.1, -M_PI + 0.2, M_PI - 0.2};
-
-    BBox result;
-    bboxFromGeofence(&geofence, &result);
-    t_assert(bboxEquals(&result, &expected), "Got expected transmeridian bbox");
-}
-
-TEST(bboxFromGeofenceNoVertices) {
-    Geofence geofence;
-    geofence.verts = NULL;
-    geofence.numVerts = 0;
-
-    const BBox expected = {0.0, 0.0, 0.0, 0.0};
-
-    BBox result;
-    bboxFromGeofence(&geofence, &result);
-
-    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-}
-
-TEST(bboxesFromGeoPolygon) {
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    Geofence geofence = {.numVerts = 4, .verts = verts};
-    GeoPolygon polygon = {.geofence = geofence, .numHoles = 0};
-
-    const BBox expected = {1.1, 0.7, 0.7, 0.2};
-
-    BBox* result = calloc(sizeof(BBox), 1);
-    bboxesFromGeoPolygon(&polygon, result);
-    t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
-
-    free(result);
-}
-
-TEST(bboxesFromGeoPolygonHole) {
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-    Geofence geofence = {.numVerts = 4, .verts = verts};
-
-    // not a real hole, but doesn't matter for the test
-    GeoCoord holeVerts[] = {{0.9, 0.3}, {0.9, 0.5}, {1.0, 0.7}, {0.9, 0.3}};
-    Geofence holeGeofence = {.numVerts = 4, .verts = holeVerts};
-
-    GeoPolygon polygon = {
-        .geofence = geofence, .numHoles = 1, .holes = &holeGeofence};
-
-    const BBox expected = {1.1, 0.7, 0.7, 0.2};
-    const BBox expectedHole = {1.0, 0.9, 0.7, 0.3};
-
-    BBox* result = calloc(sizeof(BBox), 2);
-    bboxesFromGeoPolygon(&polygon, result);
-    t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
-    t_assert(bboxEquals(&result[1], &expectedHole), "Got expected hole bbox");
-
-    free(result);
-}
-
-TEST(bboxFromLinkedGeoLoop) {
-    GeoCoord verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
-
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &verts[0], 4);
-
-    const BBox expected = {1.1, 0.7, 0.7, 0.2};
-
-    BBox result;
-    bboxFromLinkedGeoLoop(&loop, &result);
-    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(bboxFromLinkedGeoLoopNoVertices) {
-    LinkedGeoLoop loop;
-    initLinkedLoop(&loop);
-
-    const BBox expected = {0.0, 0.0, 0.0, 0.0};
-
-    BBox result;
-    bboxFromLinkedGeoLoop(&loop, &result);
-
-    t_assert(bboxEquals(&result, &expected), "Got expected bbox");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(isClockwiseGeofence) {
-    GeoCoord verts[] = {{0, 0}, {0.1, 0.1}, {0, 0.1}};
-    Geofence geofence = {.numVerts = 3, .verts = verts};
-
-    t_assert(isClockwiseGeofence(&geofence), "Got true for clockwise geofence");
-}
-
-TEST(isClockwiseLinkedGeoLoop) {
-    GeoCoord verts[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &verts[0], 3);
-
-    t_assert(isClockwiseLinkedGeoLoop(&loop), "Got true for clockwise loop");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(isNotClockwiseLinkedGeoLoop) {
-    GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &verts[0], 4);
-
-    t_assert(!isClockwiseLinkedGeoLoop(&loop),
-             "Got false for counter-clockwise loop");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(isClockwiseGeofenceTransmeridian) {
-    GeoCoord verts[] = {{0.4, M_PI - 0.1},
-                        {0.4, -M_PI + 0.1},
-                        {-0.4, -M_PI + 0.1},
-                        {-0.4, M_PI - 0.1}};
-    Geofence geofence = {.numVerts = 4, .verts = verts};
-
-    t_assert(isClockwiseGeofence(&geofence), "Got true for clockwise geofence");
-}
-
-TEST(isClockwiseLinkedGeoLoopTransmeridian) {
-    GeoCoord verts[] = {{0.4, M_PI - 0.1},
-                        {0.4, -M_PI + 0.1},
-                        {-0.4, -M_PI + 0.1},
-                        {-0.4, M_PI - 0.1}};
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &verts[0], 4);
-
-    t_assert(isClockwiseLinkedGeoLoop(&loop),
-             "Got true for clockwise transmeridian loop");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(isNotClockwiseLinkedGeoLoopTransmeridian) {
-    GeoCoord verts[] = {{0.4, M_PI - 0.1},
-                        {-0.4, M_PI - 0.1},
-                        {-0.4, -M_PI + 0.1},
-                        {0.4, -M_PI + 0.1}};
-    LinkedGeoLoop loop;
-    createLinkedLoop(&loop, &verts[0], 4);
-
-    t_assert(!isClockwiseLinkedGeoLoop(&loop),
-             "Got false for counter-clockwise transmeridian loop");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(normalizeMultiPolygonSingle) {
-    GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}};
-
-    LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
-    assert(outer != NULL);
-    createLinkedLoop(outer, &verts[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, outer);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 1, "Loop count correct");
-    t_assert(polygon.first == outer, "Got expected loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonTwoOuterLoops) {
-    GeoCoord verts1[] = {{0, 0}, {0, 1}, {1, 1}};
-
-    LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
-    assert(outer1 != NULL);
-    createLinkedLoop(outer1, &verts1[0], 3);
-
-    GeoCoord verts2[] = {{2, 2}, {2, 3}, {3, 3}};
-
-    LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
-    assert(outer2 != NULL);
-    createLinkedLoop(outer2, &verts2[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, outer1);
-    addLinkedLoop(&polygon, outer2);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 1,
-             "Loop count on first polygon correct");
-    t_assert(countLinkedLoops(polygon.next) == 1,
-             "Loop count on second polygon correct");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonOneHole) {
-    GeoCoord verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
-
-    LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
-    assert(outer != NULL);
-    createLinkedLoop(outer, &verts[0], 4);
-
-    GeoCoord verts2[] = {{1, 1}, {2, 2}, {1, 2}};
-
-    LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
-    assert(inner != NULL);
-    createLinkedLoop(inner, &verts2[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, inner);
-    addLinkedLoop(&polygon, outer);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 2,
-             "Loop count on first polygon correct");
-    t_assert(polygon.first == outer, "Got expected outer loop");
-    t_assert(polygon.first->next == inner, "Got expected inner loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonTwoHoles) {
-    GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
-
-    LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
-    assert(outer != NULL);
-    createLinkedLoop(outer, &verts[0], 4);
-
-    GeoCoord verts2[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
-
-    LinkedGeoLoop* inner1 = calloc(1, sizeof(*inner1));
-    assert(inner1 != NULL);
-    createLinkedLoop(inner1, &verts2[0], 3);
-
-    GeoCoord verts3[] = {{0.2, 0.2}, {0.3, 0.3}, {0.2, 0.3}};
-
-    LinkedGeoLoop* inner2 = calloc(1, sizeof(*inner2));
-    assert(inner2 != NULL);
-    createLinkedLoop(inner2, &verts3[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, inner2);
-    addLinkedLoop(&polygon, outer);
-    addLinkedLoop(&polygon, inner1);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 1,
-             "Polygon count correct for 2 holes");
-    t_assert(polygon.first == outer, "Got expected outer loop");
-    t_assert(countLinkedLoops(&polygon) == 3,
-             "Loop count on first polygon correct");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonTwoDonuts) {
-    GeoCoord verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
-    LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
-    assert(outer != NULL);
-    createLinkedLoop(outer, &verts[0], 4);
-
-    GeoCoord verts2[] = {{1, 1}, {2, 2}, {1, 2}};
-    LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
-    assert(inner != NULL);
-    createLinkedLoop(inner, &verts2[0], 3);
-
-    GeoCoord verts3[] = {{0, 0}, {0, -3}, {-3, -3}, {-3, 0}};
-    LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer));
-    assert(outer2 != NULL);
-    createLinkedLoop(outer2, &verts3[0], 4);
-
-    GeoCoord verts4[] = {{-1, -1}, {-2, -2}, {-1, -2}};
-    LinkedGeoLoop* inner2 = calloc(1, sizeof(*inner));
-    assert(inner2 != NULL);
-    createLinkedLoop(inner2, &verts4[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, inner2);
-    addLinkedLoop(&polygon, inner);
-    addLinkedLoop(&polygon, outer);
-    addLinkedLoop(&polygon, outer2);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 2,
-             "Loop count on first polygon correct");
-    t_assert(countLinkedCoords(polygon.first) == 4, "Got expected outer loop");
-    t_assert(countLinkedCoords(polygon.first->next) == 3,
-             "Got expected inner loop");
-    t_assert(countLinkedLoops(polygon.next) == 2,
-             "Loop count on second polygon correct");
-    t_assert(countLinkedCoords(polygon.next->first) == 4,
-             "Got expected outer loop");
-    t_assert(countLinkedCoords(polygon.next->first->next) == 3,
-             "Got expected inner loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonNestedDonuts) {
-    GeoCoord verts[] = {{0.2, 0.2}, {0.2, -0.2}, {-0.2, -0.2}, {-0.2, 0.2}};
-    LinkedGeoLoop* outer = calloc(1, sizeof(*outer));
-    assert(outer != NULL);
-    createLinkedLoop(outer, &verts[0], 4);
-
-    GeoCoord verts2[] = {{0.1, 0.1}, {-0.1, 0.1}, {-0.1, -0.1}, {0.1, -0.1}};
-    LinkedGeoLoop* inner = calloc(1, sizeof(*inner));
-    assert(inner != NULL);
-    createLinkedLoop(inner, &verts2[0], 4);
-
-    GeoCoord verts3[] = {{0.6, 0.6}, {0.6, -0.6}, {-0.6, -0.6}, {-0.6, 0.6}};
-    LinkedGeoLoop* outerBig = calloc(1, sizeof(*outerBig));
-    assert(outerBig != NULL);
-    createLinkedLoop(outerBig, &verts3[0], 4);
-
-    GeoCoord verts4[] = {{0.5, 0.5}, {-0.5, 0.5}, {-0.5, -0.5}, {0.5, -0.5}};
-    LinkedGeoLoop* innerBig = calloc(1, sizeof(*innerBig));
-    assert(innerBig != NULL);
-    createLinkedLoop(innerBig, &verts4[0], 4);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, inner);
-    addLinkedLoop(&polygon, outerBig);
-    addLinkedLoop(&polygon, innerBig);
-    addLinkedLoop(&polygon, outer);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_SUCCESS, "No error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 2,
-             "Loop count on first polygon correct");
-    t_assert(polygon.first == outerBig, "Got expected outer loop");
-    t_assert(polygon.first->next == innerBig, "Got expected inner loop");
-    t_assert(countLinkedLoops(polygon.next) == 2,
-             "Loop count on second polygon correct");
-    t_assert(polygon.next->first == outer, "Got expected outer loop");
-    t_assert(polygon.next->first->next == inner, "Got expected inner loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonNoOuterLoops) {
-    GeoCoord verts1[] = {{0, 0}, {1, 1}, {0, 1}};
-
-    LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
-    assert(outer1 != NULL);
-    createLinkedLoop(outer1, &verts1[0], 3);
-
-    GeoCoord verts2[] = {{2, 2}, {3, 3}, {2, 3}};
-
-    LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
-    assert(outer2 != NULL);
-    createLinkedLoop(outer2, &verts2[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, outer1);
-    addLinkedLoop(&polygon, outer2);
-
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_ERR_UNASSIGNED_HOLES,
-             "Expected error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 0,
-             "Loop count as expected with invalid input");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-TEST(normalizeMultiPolygonAlreadyNormalized) {
-    GeoCoord verts1[] = {{0, 0}, {0, 1}, {1, 1}};
-
-    LinkedGeoLoop* outer1 = calloc(1, sizeof(*outer1));
-    assert(outer1 != NULL);
-    createLinkedLoop(outer1, &verts1[0], 3);
-
-    GeoCoord verts2[] = {{2, 2}, {2, 3}, {3, 3}};
-
-    LinkedGeoLoop* outer2 = calloc(1, sizeof(*outer2));
-    assert(outer2 != NULL);
-    createLinkedLoop(outer2, &verts2[0], 3);
-
-    LinkedGeoPolygon polygon;
-    initLinkedPolygon(&polygon);
-    addLinkedLoop(&polygon, outer1);
-    LinkedGeoPolygon* next = addNewLinkedPolygon(&polygon);
-    addLinkedLoop(next, outer2);
-
-    // Should be a no-op
-    int result = normalizeMultiPolygon(&polygon);
-
-    t_assert(result == NORMALIZATION_ERR_MULTIPLE_POLYGONS,
-             "Expected error code returned");
-
-    t_assert(countLinkedPolygons(&polygon) == 2, "Polygon count correct");
-    t_assert(countLinkedLoops(&polygon) == 1,
-             "Loop count on first polygon correct");
-    t_assert(polygon.first == outer1, "Got expected outer loop");
-    t_assert(countLinkedLoops(polygon.next) == 1,
-             "Loop count on second polygon correct");
-    t_assert(polygon.next->first == outer2, "Got expected outer loop");
-
-    H3_EXPORT(destroyLinkedPolygon)(&polygon);
-}
-
-END_TESTS();

--- a/src/apps/testapps/testVec2d.c
+++ b/src/apps/testapps/testVec2d.c
@@ -20,42 +20,40 @@
 #include "test.h"
 #include "vec2d.h"
 
-BEGIN_TESTS(Vec2d);
+SUITE(Vec2d) {
+    TEST(_v2dMag) {
+        Vec2d v = {3.0, 4.0};
+        double expected = 5.0;
+        double mag = _v2dMag(&v);
+        t_assert(fabs(mag - expected) < DBL_EPSILON, "magnitude as expected");
+    }
 
-TEST(_v2dMag) {
-    Vec2d v = {3.0, 4.0};
-    double expected = 5.0;
-    double mag = _v2dMag(&v);
-    t_assert(fabs(mag - expected) < DBL_EPSILON, "magnitude as expected");
+    TEST(_v2dIntersect) {
+        Vec2d p0 = {2.0, 2.0};
+        Vec2d p1 = {6.0, 6.0};
+        Vec2d p2 = {0.0, 4.0};
+        Vec2d p3 = {10.0, 4.0};
+        Vec2d intersection = {0.0, 0.0};
+
+        _v2dIntersect(&p0, &p1, &p2, &p3, &intersection);
+
+        double expectedX = 4.0;
+        double expectedY = 4.0;
+
+        t_assert(fabs(intersection.x - expectedX) < DBL_EPSILON,
+                 "X coord as expected");
+        t_assert(fabs(intersection.y - expectedY) < DBL_EPSILON,
+                 "Y coord as expected");
+    }
+
+    TEST(_v2dEquals) {
+        Vec2d v1 = {3.0, 4.0};
+        Vec2d v2 = {3.0, 4.0};
+        Vec2d v3 = {3.5, 4.0};
+        Vec2d v4 = {3.0, 4.5};
+
+        t_assert(_v2dEquals(&v1, &v2), "true for equal vectors");
+        t_assert(!_v2dEquals(&v1, &v3), "false for different x");
+        t_assert(!_v2dEquals(&v1, &v4), "false for different y");
+    }
 }
-
-TEST(_v2dIntersect) {
-    Vec2d p0 = {2.0, 2.0};
-    Vec2d p1 = {6.0, 6.0};
-    Vec2d p2 = {0.0, 4.0};
-    Vec2d p3 = {10.0, 4.0};
-    Vec2d intersection = {0.0, 0.0};
-
-    _v2dIntersect(&p0, &p1, &p2, &p3, &intersection);
-
-    double expectedX = 4.0;
-    double expectedY = 4.0;
-
-    t_assert(fabs(intersection.x - expectedX) < DBL_EPSILON,
-             "X coord as expected");
-    t_assert(fabs(intersection.y - expectedY) < DBL_EPSILON,
-             "Y coord as expected");
-}
-
-TEST(_v2dEquals) {
-    Vec2d v1 = {3.0, 4.0};
-    Vec2d v2 = {3.0, 4.0};
-    Vec2d v3 = {3.5, 4.0};
-    Vec2d v4 = {3.0, 4.5};
-
-    t_assert(_v2dEquals(&v1, &v2), "true for equal vectors");
-    t_assert(!_v2dEquals(&v1, &v3), "false for different x");
-    t_assert(!_v2dEquals(&v1, &v4), "false for different y");
-}
-
-END_TESTS();

--- a/src/apps/testapps/testVec3d.c
+++ b/src/apps/testapps/testVec3d.c
@@ -20,47 +20,45 @@
 #include "test.h"
 #include "vec3d.h"
 
-BEGIN_TESTS(Vec3d);
+SUITE(Vec3d) {
+    TEST(_pointSquareDist) {
+        Vec3d v1 = {0, 0, 0};
+        Vec3d v2 = {1, 0, 0};
+        Vec3d v3 = {0, 1, 1};
+        Vec3d v4 = {1, 1, 1};
+        Vec3d v5 = {1, 1, 2};
 
-TEST(_pointSquareDist) {
-    Vec3d v1 = {0, 0, 0};
-    Vec3d v2 = {1, 0, 0};
-    Vec3d v3 = {0, 1, 1};
-    Vec3d v4 = {1, 1, 1};
-    Vec3d v5 = {1, 1, 2};
+        t_assert(fabs(_pointSquareDist(&v1, &v1)) < DBL_EPSILON,
+                 "distance to self is 0");
+        t_assert(fabs(_pointSquareDist(&v1, &v2) - 1) < DBL_EPSILON,
+                 "distance to <1,0,0> is 1");
+        t_assert(fabs(_pointSquareDist(&v1, &v3) - 2) < DBL_EPSILON,
+                 "distance to <0,1,1> is 2");
+        t_assert(fabs(_pointSquareDist(&v1, &v4) - 3) < DBL_EPSILON,
+                 "distance to <1,1,1> is 3");
+        t_assert(fabs(_pointSquareDist(&v1, &v5) - 6) < DBL_EPSILON,
+                 "distance to <1,1,2> is 6");
+    }
 
-    t_assert(fabs(_pointSquareDist(&v1, &v1)) < DBL_EPSILON,
-             "distance to self is 0");
-    t_assert(fabs(_pointSquareDist(&v1, &v2) - 1) < DBL_EPSILON,
-             "distance to <1,0,0> is 1");
-    t_assert(fabs(_pointSquareDist(&v1, &v3) - 2) < DBL_EPSILON,
-             "distance to <0,1,1> is 2");
-    t_assert(fabs(_pointSquareDist(&v1, &v4) - 3) < DBL_EPSILON,
-             "distance to <1,1,1> is 3");
-    t_assert(fabs(_pointSquareDist(&v1, &v5) - 6) < DBL_EPSILON,
-             "distance to <1,1,2> is 6");
+    TEST(_geoToVec3d) {
+        Vec3d origin = {0};
+
+        GeoCoord c1 = {0, 0};
+        Vec3d p1;
+        _geoToVec3d(&c1, &p1);
+        t_assert(fabs(_pointSquareDist(&origin, &p1) - 1) < EPSILON_RAD,
+                 "Geo point is on the unit sphere");
+
+        GeoCoord c2 = {M_PI_2, 0};
+        Vec3d p2;
+        _geoToVec3d(&c2, &p2);
+        t_assert(fabs(_pointSquareDist(&p1, &p2) - 2) < EPSILON_RAD,
+                 "Geo point is on another axis");
+
+        GeoCoord c3 = {M_PI, 0};
+        Vec3d p3;
+        _geoToVec3d(&c3, &p3);
+        t_assert(fabs(_pointSquareDist(&p1, &p3) - 4) < EPSILON_RAD,
+                 "Geo point is the other side of the sphere");
+    }
 }
-
-TEST(_geoToVec3d) {
-    Vec3d origin = {0};
-
-    GeoCoord c1 = {0, 0};
-    Vec3d p1;
-    _geoToVec3d(&c1, &p1);
-    t_assert(fabs(_pointSquareDist(&origin, &p1) - 1) < EPSILON_RAD,
-             "Geo point is on the unit sphere");
-
-    GeoCoord c2 = {M_PI_2, 0};
-    Vec3d p2;
-    _geoToVec3d(&c2, &p2);
-    t_assert(fabs(_pointSquareDist(&p1, &p2) - 2) < EPSILON_RAD,
-             "Geo point is on another axis");
-
-    GeoCoord c3 = {M_PI, 0};
-    Vec3d p3;
-    _geoToVec3d(&c3, &p3);
-    t_assert(fabs(_pointSquareDist(&p1, &p3) - 4) < EPSILON_RAD,
-             "Geo point is the other side of the sphere");
-}
-
-END_TESTS();

--- a/src/apps/testapps/testVertexGraph.c
+++ b/src/apps/testapps/testVertexGraph.c
@@ -22,285 +22,286 @@
 #include "vertexGraph.h"
 
 // Fixtures
-GeoCoord center;
-GeoCoord vertex1;
-GeoCoord vertex2;
-GeoCoord vertex3;
-GeoCoord vertex4;
-GeoCoord vertex5;
-GeoCoord vertex6;
+static GeoCoord center;
+static GeoCoord vertex1;
+static GeoCoord vertex2;
+static GeoCoord vertex3;
+static GeoCoord vertex4;
+static GeoCoord vertex5;
+static GeoCoord vertex6;
 
-BEGIN_TESTS(vertexGraph);
+SUITE(vertexGraph) {
+    setGeoDegs(&center, 37.77362016769341, -122.41673772517154);
+    setGeoDegs(&vertex1, 87.372002166, 166.160981117);
+    setGeoDegs(&vertex2, 87.370101364, 166.160184306);
+    setGeoDegs(&vertex3, 87.369088356, 166.196239997);
+    setGeoDegs(&vertex4, 87.369975080, 166.233115768);
+    setGeoDegs(&vertex5, 0, 0);
+    setGeoDegs(&vertex6, -10, -10);
 
-setGeoDegs(&center, 37.77362016769341, -122.41673772517154);
-setGeoDegs(&vertex1, 87.372002166, 166.160981117);
-setGeoDegs(&vertex2, 87.370101364, 166.160184306);
-setGeoDegs(&vertex3, 87.369088356, 166.196239997);
-setGeoDegs(&vertex4, 87.369975080, 166.233115768);
-setGeoDegs(&vertex5, 0, 0);
-setGeoDegs(&vertex6, -10, -10);
+    TEST(makeVertexGraph) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        t_assert(graph.numBuckets == 10, "numBuckets set");
+        t_assert(graph.size == 0, "size set");
+        destroyVertexGraph(&graph);
+    }
 
-TEST(makeVertexGraph) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    t_assert(graph.numBuckets == 10, "numBuckets set");
-    t_assert(graph.size == 0, "size set");
-    destroyVertexGraph(&graph);
-}
+    TEST(vertexHash) {
+        H3Index centerIndex;
+        GeoBoundary outline;
+        uint32_t hash1;
+        uint32_t hash2;
+        int numBuckets = 1000;
 
-TEST(vertexHash) {
-    H3Index centerIndex;
-    GeoBoundary outline;
-    uint32_t hash1;
-    uint32_t hash2;
-    int numBuckets = 1000;
-
-    for (int res = 0; res < 11; res++) {
-        centerIndex = H3_EXPORT(geoToH3)(&center, res);
-        H3_EXPORT(h3ToGeoBoundary)(centerIndex, &outline);
-        for (int i = 0; i < outline.numVerts; i++) {
-            hash1 = _hashVertex(&outline.verts[i], res, numBuckets);
-            hash2 = _hashVertex(&outline.verts[(i + 1) % outline.numVerts], res,
-                                numBuckets);
-            t_assert(hash1 != hash2, "Hashes must not be equal");
+        for (int res = 0; res < 11; res++) {
+            centerIndex = H3_EXPORT(geoToH3)(&center, res);
+            H3_EXPORT(h3ToGeoBoundary)(centerIndex, &outline);
+            for (int i = 0; i < outline.numVerts; i++) {
+                hash1 = _hashVertex(&outline.verts[i], res, numBuckets);
+                hash2 = _hashVertex(&outline.verts[(i + 1) % outline.numVerts],
+                                    res, numBuckets);
+                t_assert(hash1 != hash2, "Hashes must not be equal");
+            }
         }
     }
+
+    TEST(vertexHashNegative) {
+        int numBuckets = 10;
+        t_assert(_hashVertex(&vertex5, 5, numBuckets) < numBuckets,
+                 "zero vertex hashes correctly");
+        t_assert(_hashVertex(&vertex6, 5, numBuckets) < numBuckets,
+                 "negative coordinates vertex hashes correctly");
+    }
+
+    TEST(addVertexNode) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+        VertexNode* addedNode;
+
+        // Basic add
+        addedNode = addVertexNode(&graph, &vertex1, &vertex2);
+        node = findNodeForEdge(&graph, &vertex1, &vertex2);
+        t_assert(node != NULL, "Node found");
+        t_assert(node == addedNode, "Right node found");
+        t_assert(graph.size == 1, "Graph size incremented");
+
+        // Collision add
+        addedNode = addVertexNode(&graph, &vertex1, &vertex3);
+        node = findNodeForEdge(&graph, &vertex1, &vertex3);
+        t_assert(node != NULL, "Node found after hash collision");
+        t_assert(node == addedNode, "Right node found");
+        t_assert(graph.size == 2, "Graph size incremented");
+
+        // Collision add #2
+        addedNode = addVertexNode(&graph, &vertex1, &vertex4);
+        node = findNodeForEdge(&graph, &vertex1, &vertex4);
+        t_assert(node != NULL, "Node found after 2nd hash collision");
+        t_assert(node == addedNode, "Right node found");
+        t_assert(graph.size == 3, "Graph size incremented");
+
+        // Exact match no-op
+        node = findNodeForEdge(&graph, &vertex1, &vertex2);
+        addedNode = addVertexNode(&graph, &vertex1, &vertex2);
+        t_assert(node == findNodeForEdge(&graph, &vertex1, &vertex2),
+                 "Exact match did not change existing node");
+        t_assert(node == addedNode, "Old node returned");
+        t_assert(graph.size == 3, "Graph size was not changed");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(addVertexNodeDupe) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+        VertexNode* addedNode;
+
+        // Basic add
+        addedNode = addVertexNode(&graph, &vertex1, &vertex2);
+        node = findNodeForEdge(&graph, &vertex1, &vertex2);
+        t_assert(node != NULL, "Node found");
+        t_assert(node == addedNode, "Right node found");
+        t_assert(graph.size == 1, "Graph size incremented");
+
+        // Dupe add
+        addedNode = addVertexNode(&graph, &vertex1, &vertex2);
+        t_assert(node == addedNode, "addVertexNode returned the original node");
+        t_assert(graph.size == 1, "Graph size not incremented");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(findNodeForEdge) {
+        // Basic lookup tested in testAddVertexNode, only test failures here
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+
+        // Empty graph
+        node = findNodeForEdge(&graph, &vertex1, &vertex2);
+        t_assert(node == NULL, "Node lookup failed correctly for empty graph");
+
+        addVertexNode(&graph, &vertex1, &vertex2);
+
+        // Different hash
+        node = findNodeForEdge(&graph, &vertex3, &vertex2);
+        t_assert(node == NULL,
+                 "Node lookup failed correctly for different hash");
+
+        // Hash collision
+        node = findNodeForEdge(&graph, &vertex1, &vertex3);
+        t_assert(node == NULL,
+                 "Node lookup failed correctly for hash collision");
+
+        addVertexNode(&graph, &vertex1, &vertex4);
+
+        // Hash collision, list iteration
+        node = findNodeForEdge(&graph, &vertex1, &vertex3);
+        t_assert(node == NULL,
+                 "Node lookup failed correctly for collision w/iteration");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(findNodeForVertex) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+
+        // Empty graph
+        node = findNodeForVertex(&graph, &vertex1);
+        t_assert(node == NULL, "Node lookup failed correctly for empty graph");
+
+        addVertexNode(&graph, &vertex1, &vertex2);
+
+        node = findNodeForVertex(&graph, &vertex1);
+        t_assert(node != NULL, "Node lookup succeeded for correct node");
+
+        node = findNodeForVertex(&graph, &vertex3);
+        t_assert(node == NULL,
+                 "Node lookup failed correctly for different node");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(removeVertexNode) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+        int success;
+
+        // Straight removal
+        node = addVertexNode(&graph, &vertex1, &vertex2);
+        success = removeVertexNode(&graph, node) == 0;
+
+        t_assert(success, "Removal successful");
+        t_assert(findNodeForVertex(&graph, &vertex1) == NULL,
+                 "Node lookup cannot find node");
+        t_assert(graph.size == 0, "Graph size decremented");
+
+        // Remove end of list
+        addVertexNode(&graph, &vertex1, &vertex2);
+        node = addVertexNode(&graph, &vertex1, &vertex3);
+        success = removeVertexNode(&graph, node) == 0;
+
+        t_assert(success, "Removal successful");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) == NULL,
+                 "Node lookup cannot find node");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex2)->next == NULL,
+                 "Base bucket node not pointing to node");
+        t_assert(graph.size == 1, "Graph size decremented");
+
+        // This removal is just cleanup
+        node = findNodeForVertex(&graph, &vertex1);
+        assert(removeVertexNode(&graph, node) == 0);
+
+        // Remove beginning of list
+        node = addVertexNode(&graph, &vertex1, &vertex2);
+        addVertexNode(&graph, &vertex1, &vertex3);
+        success = removeVertexNode(&graph, node) == 0;
+
+        t_assert(success, "Removal successful");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex2) == NULL,
+                 "Node lookup cannot find node");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) != NULL,
+                 "Node lookup can find previous end of list");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex3)->next == NULL,
+                 "Base bucket node not pointing to node");
+        t_assert(graph.size == 1, "Graph size decremented");
+
+        // This removal is just cleanup
+        node = findNodeForVertex(&graph, &vertex1);
+        assert(removeVertexNode(&graph, node) == 0);
+
+        // Remove middle of list
+        addVertexNode(&graph, &vertex1, &vertex2);
+        node = addVertexNode(&graph, &vertex1, &vertex3);
+        addVertexNode(&graph, &vertex1, &vertex4);
+        success = removeVertexNode(&graph, node) == 0;
+
+        t_assert(success, "Removal successful");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) == NULL,
+                 "Node lookup cannot find node");
+        t_assert(findNodeForEdge(&graph, &vertex1, &vertex4) != NULL,
+                 "Node lookup can find previous end of list");
+        t_assert(graph.size == 2, "Graph size decremented");
+
+        // Remove non-existent node
+        node = calloc(1, sizeof(VertexNode));
+        success = removeVertexNode(&graph, node) == 0;
+
+        t_assert(!success, "Removal of non-existent node fails");
+        t_assert(graph.size == 2, "Graph size unchanged");
+
+        free(node);
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(firstVertexNode) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        VertexNode* node;
+        VertexNode* addedNode;
+
+        node = firstVertexNode(&graph);
+        t_assert(node == NULL, "No node found for empty graph");
+
+        addedNode = addVertexNode(&graph, &vertex1, &vertex2);
+
+        node = firstVertexNode(&graph);
+        t_assert(node == addedNode, "Node found");
+
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(destroyEmptyVertexGraph) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 10, 9);
+        destroyVertexGraph(&graph);
+    }
+
+    TEST(singleBucketVertexGraph) {
+        VertexGraph graph;
+        initVertexGraph(&graph, 1, 9);
+        VertexNode* node;
+
+        t_assert(graph.numBuckets == 1, "1 bucket created");
+
+        node = firstVertexNode(&graph);
+        t_assert(node == NULL, "No node found for empty graph");
+
+        node = addVertexNode(&graph, &vertex1, &vertex2);
+        t_assert(node != NULL, "Node added");
+        t_assert(firstVertexNode(&graph) == node, "First node is node");
+
+        addVertexNode(&graph, &vertex2, &vertex3);
+        addVertexNode(&graph, &vertex3, &vertex4);
+        t_assert(firstVertexNode(&graph) == node, "First node is still node");
+        t_assert(graph.size == 3, "Graph size updated");
+
+        destroyVertexGraph(&graph);
+    }
 }
-
-TEST(vertexHashNegative) {
-    int numBuckets = 10;
-    t_assert(_hashVertex(&vertex5, 5, numBuckets) < numBuckets,
-             "zero vertex hashes correctly");
-    t_assert(_hashVertex(&vertex6, 5, numBuckets) < numBuckets,
-             "negative coordinates vertex hashes correctly");
-}
-
-TEST(addVertexNode) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-    VertexNode* addedNode;
-
-    // Basic add
-    addedNode = addVertexNode(&graph, &vertex1, &vertex2);
-    node = findNodeForEdge(&graph, &vertex1, &vertex2);
-    t_assert(node != NULL, "Node found");
-    t_assert(node == addedNode, "Right node found");
-    t_assert(graph.size == 1, "Graph size incremented");
-
-    // Collision add
-    addedNode = addVertexNode(&graph, &vertex1, &vertex3);
-    node = findNodeForEdge(&graph, &vertex1, &vertex3);
-    t_assert(node != NULL, "Node found after hash collision");
-    t_assert(node == addedNode, "Right node found");
-    t_assert(graph.size == 2, "Graph size incremented");
-
-    // Collision add #2
-    addedNode = addVertexNode(&graph, &vertex1, &vertex4);
-    node = findNodeForEdge(&graph, &vertex1, &vertex4);
-    t_assert(node != NULL, "Node found after 2nd hash collision");
-    t_assert(node == addedNode, "Right node found");
-    t_assert(graph.size == 3, "Graph size incremented");
-
-    // Exact match no-op
-    node = findNodeForEdge(&graph, &vertex1, &vertex2);
-    addedNode = addVertexNode(&graph, &vertex1, &vertex2);
-    t_assert(node == findNodeForEdge(&graph, &vertex1, &vertex2),
-             "Exact match did not change existing node");
-    t_assert(node == addedNode, "Old node returned");
-    t_assert(graph.size == 3, "Graph size was not changed");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(addVertexNodeDupe) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-    VertexNode* addedNode;
-
-    // Basic add
-    addedNode = addVertexNode(&graph, &vertex1, &vertex2);
-    node = findNodeForEdge(&graph, &vertex1, &vertex2);
-    t_assert(node != NULL, "Node found");
-    t_assert(node == addedNode, "Right node found");
-    t_assert(graph.size == 1, "Graph size incremented");
-
-    // Dupe add
-    addedNode = addVertexNode(&graph, &vertex1, &vertex2);
-    t_assert(node == addedNode, "addVertexNode returned the original node");
-    t_assert(graph.size == 1, "Graph size not incremented");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(findNodeForEdge) {
-    // Basic lookup tested in testAddVertexNode, only test failures here
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-
-    // Empty graph
-    node = findNodeForEdge(&graph, &vertex1, &vertex2);
-    t_assert(node == NULL, "Node lookup failed correctly for empty graph");
-
-    addVertexNode(&graph, &vertex1, &vertex2);
-
-    // Different hash
-    node = findNodeForEdge(&graph, &vertex3, &vertex2);
-    t_assert(node == NULL, "Node lookup failed correctly for different hash");
-
-    // Hash collision
-    node = findNodeForEdge(&graph, &vertex1, &vertex3);
-    t_assert(node == NULL, "Node lookup failed correctly for hash collision");
-
-    addVertexNode(&graph, &vertex1, &vertex4);
-
-    // Hash collision, list iteration
-    node = findNodeForEdge(&graph, &vertex1, &vertex3);
-    t_assert(node == NULL,
-             "Node lookup failed correctly for collision w/iteration");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(findNodeForVertex) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-
-    // Empty graph
-    node = findNodeForVertex(&graph, &vertex1);
-    t_assert(node == NULL, "Node lookup failed correctly for empty graph");
-
-    addVertexNode(&graph, &vertex1, &vertex2);
-
-    node = findNodeForVertex(&graph, &vertex1);
-    t_assert(node != NULL, "Node lookup succeeded for correct node");
-
-    node = findNodeForVertex(&graph, &vertex3);
-    t_assert(node == NULL, "Node lookup failed correctly for different node");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(removeVertexNode) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-    int success;
-
-    // Straight removal
-    node = addVertexNode(&graph, &vertex1, &vertex2);
-    success = removeVertexNode(&graph, node) == 0;
-
-    t_assert(success, "Removal successful");
-    t_assert(findNodeForVertex(&graph, &vertex1) == NULL,
-             "Node lookup cannot find node");
-    t_assert(graph.size == 0, "Graph size decremented");
-
-    // Remove end of list
-    addVertexNode(&graph, &vertex1, &vertex2);
-    node = addVertexNode(&graph, &vertex1, &vertex3);
-    success = removeVertexNode(&graph, node) == 0;
-
-    t_assert(success, "Removal successful");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) == NULL,
-             "Node lookup cannot find node");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex2)->next == NULL,
-             "Base bucket node not pointing to node");
-    t_assert(graph.size == 1, "Graph size decremented");
-
-    // This removal is just cleanup
-    node = findNodeForVertex(&graph, &vertex1);
-    assert(removeVertexNode(&graph, node) == 0);
-
-    // Remove beginning of list
-    node = addVertexNode(&graph, &vertex1, &vertex2);
-    addVertexNode(&graph, &vertex1, &vertex3);
-    success = removeVertexNode(&graph, node) == 0;
-
-    t_assert(success, "Removal successful");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex2) == NULL,
-             "Node lookup cannot find node");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) != NULL,
-             "Node lookup can find previous end of list");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex3)->next == NULL,
-             "Base bucket node not pointing to node");
-    t_assert(graph.size == 1, "Graph size decremented");
-
-    // This removal is just cleanup
-    node = findNodeForVertex(&graph, &vertex1);
-    assert(removeVertexNode(&graph, node) == 0);
-
-    // Remove middle of list
-    addVertexNode(&graph, &vertex1, &vertex2);
-    node = addVertexNode(&graph, &vertex1, &vertex3);
-    addVertexNode(&graph, &vertex1, &vertex4);
-    success = removeVertexNode(&graph, node) == 0;
-
-    t_assert(success, "Removal successful");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex3) == NULL,
-             "Node lookup cannot find node");
-    t_assert(findNodeForEdge(&graph, &vertex1, &vertex4) != NULL,
-             "Node lookup can find previous end of list");
-    t_assert(graph.size == 2, "Graph size decremented");
-
-    // Remove non-existent node
-    node = calloc(1, sizeof(VertexNode));
-    success = removeVertexNode(&graph, node) == 0;
-
-    t_assert(!success, "Removal of non-existent node fails");
-    t_assert(graph.size == 2, "Graph size unchanged");
-
-    free(node);
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(firstVertexNode) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    VertexNode* node;
-    VertexNode* addedNode;
-
-    node = firstVertexNode(&graph);
-    t_assert(node == NULL, "No node found for empty graph");
-
-    addedNode = addVertexNode(&graph, &vertex1, &vertex2);
-
-    node = firstVertexNode(&graph);
-    t_assert(node == addedNode, "Node found");
-
-    destroyVertexGraph(&graph);
-}
-
-TEST(destroyEmptyVertexGraph) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 10, 9);
-    destroyVertexGraph(&graph);
-}
-
-TEST(singleBucketVertexGraph) {
-    VertexGraph graph;
-    initVertexGraph(&graph, 1, 9);
-    VertexNode* node;
-
-    t_assert(graph.numBuckets == 1, "1 bucket created");
-
-    node = firstVertexNode(&graph);
-    t_assert(node == NULL, "No node found for empty graph");
-
-    node = addVertexNode(&graph, &vertex1, &vertex2);
-    t_assert(node != NULL, "Node added");
-    t_assert(firstVertexNode(&graph) == node, "First node is node");
-
-    addVertexNode(&graph, &vertex2, &vertex3);
-    addVertexNode(&graph, &vertex3, &vertex4);
-    t_assert(firstVertexNode(&graph) == node, "First node is still node");
-    t_assert(graph.size == 3, "Graph size updated");
-
-    destroyVertexGraph(&graph);
-}
-
-END_TESTS();


### PR DESCRIPTION
* Adds assertion macro that works even in non-debug builds.
* Assertion macro preserves condition as a string to emit on failure.
* Eliminates `BEGIN_TESTS` and `END_TESTS` macro pairs in favor of block macro `SUITE`.
* Adds `static` and `inline` where possible for internal testing methods.