### PR TITLE
Add isClockwise algorithm

### DIFF
--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -253,6 +253,22 @@ TEST(isClockwiseLinkedGeoLoop) {
     destroyLinkedGeoLoop(&loop);
 }
 
+TEST(isClockwiseLinkedGeoLoopFloats) {
+    const GeoCoord verts[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 3; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
+             "Got true for clockwise loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
 TEST(isNotClockwiseLinkedGeoLoop) {
     const GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}};
 
@@ -260,6 +276,22 @@ TEST(isNotClockwiseLinkedGeoLoop) {
     initLinkedLoop(&loop);
 
     for (int i = 0; i < 3; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
+             "Got false for counter-clockwise loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
+TEST(isNotClockwiseLinkedGeoLoopFloats) {
+    const GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 4; i++) {
         addLinkedCoord(&loop, &verts[i]);
     }
 

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -237,4 +237,36 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
     destroyLinkedGeoLoop(&loop);
 }
 
+TEST(isClockwiseLinkedGeoLoop) {
+    const GeoCoord verts[] = {{0, 0}, {1, 1}, {1, 0}, {0, 0}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 4; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
+             "Got true for clockwise loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
+TEST(isNotClockwiseLinkedGeoLoop) {
+    const GeoCoord verts[] = {{0, 0}, {1, 0}, {1, 1}, {0, 0}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 4; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
+             "Got false for counter-clockwise loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
 END_TESTS();

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -238,12 +238,12 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
 }
 
 TEST(isClockwiseLinkedGeoLoop) {
-    const GeoCoord verts[] = {{0, 0}, {1, 1}, {1, 0}, {0, 0}};
+    const GeoCoord verts[] = {{0, 0}, {1, 1}, {0, 1}};
 
     LinkedGeoLoop loop;
     initLinkedLoop(&loop);
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 3; i++) {
         addLinkedCoord(&loop, &verts[i]);
     }
 
@@ -254,12 +254,12 @@ TEST(isClockwiseLinkedGeoLoop) {
 }
 
 TEST(isNotClockwiseLinkedGeoLoop) {
-    const GeoCoord verts[] = {{0, 0}, {1, 0}, {1, 1}, {0, 0}};
+    const GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}};
 
     LinkedGeoLoop loop;
     initLinkedLoop(&loop);
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 3; i++) {
         addLinkedCoord(&loop, &verts[i]);
     }
 

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -238,7 +238,7 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
 }
 
 TEST(isClockwiseGeofence) {
-    GeoCoord verts[] = {{0, 0}, {1, 1}, {0, 1}};
+    GeoCoord verts[] = {{0, 0}, {0.1, 0.1}, {0, 0.1}};
 
     Geofence geofence;
     geofence.verts = verts;
@@ -246,22 +246,6 @@ TEST(isClockwiseGeofence) {
 
     t_assert(isClockwiseGeofence(&geofence) == true,
              "Got true for clockwise geofence");
-}
-
-TEST(isClockwiseLinkedGeoLoop) {
-    const GeoCoord verts[] = {{0, 0}, {1, 1}, {0, 1}};
-
-    LinkedGeoLoop loop;
-    initLinkedLoop(&loop);
-
-    for (int i = 0; i < 3; i++) {
-        addLinkedCoord(&loop, &verts[i]);
-    }
-
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
-             "Got true for clockwise loop");
-
-    destroyLinkedGeoLoop(&loop);
 }
 
 TEST(isClockwiseLinkedGeoLoopFloats) {
@@ -281,22 +265,6 @@ TEST(isClockwiseLinkedGeoLoopFloats) {
 }
 
 TEST(isNotClockwiseLinkedGeoLoop) {
-    const GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}};
-
-    LinkedGeoLoop loop;
-    initLinkedLoop(&loop);
-
-    for (int i = 0; i < 3; i++) {
-        addLinkedCoord(&loop, &verts[i]);
-    }
-
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
-             "Got false for counter-clockwise loop");
-
-    destroyLinkedGeoLoop(&loop);
-}
-
-TEST(isNotClockwiseLinkedGeoLoopFloats) {
     const GeoCoord verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
 
     LinkedGeoLoop loop;
@@ -308,6 +276,44 @@ TEST(isNotClockwiseLinkedGeoLoopFloats) {
 
     t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
              "Got false for counter-clockwise loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
+TEST(isClockwiseLinkedGeoLoopTransmeridian) {
+    const GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                              {0.4, -M_PI + 0.1},
+                              {-0.4, -M_PI + 0.1},
+                              {-0.4, M_PI - 0.1}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 4; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
+             "Got true for clockwise transmeridian loop");
+
+    destroyLinkedGeoLoop(&loop);
+}
+
+TEST(isNotClockwiseLinkedGeoLoopTransmeridian) {
+    const GeoCoord verts[] = {{0.4, M_PI - 0.1},
+                              {-0.4, M_PI - 0.1},
+                              {-0.4, -M_PI + 0.1},
+                              {0.4, -M_PI + 0.1}};
+
+    LinkedGeoLoop loop;
+    initLinkedLoop(&loop);
+
+    for (int i = 0; i < 4; i++) {
+        addLinkedCoord(&loop, &verts[i]);
+    }
+
+    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
+             "Got false for counter-clockwise transmeridian loop");
 
     destroyLinkedGeoLoop(&loop);
 }

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -237,6 +237,17 @@ TEST(bboxFromLinkedGeoLoopNoVertices) {
     destroyLinkedGeoLoop(&loop);
 }
 
+TEST(isClockwiseGeofence) {
+    GeoCoord verts[] = {{0, 0}, {1, 1}, {0, 1}};
+
+    Geofence geofence;
+    geofence.verts = verts;
+    geofence.numVerts = 3;
+
+    t_assert(isClockwiseGeofence(&geofence) == true,
+             "Got true for clockwise geofence");
+}
+
 TEST(isClockwiseLinkedGeoLoop) {
     const GeoCoord verts[] = {{0, 0}, {1, 1}, {0, 1}};
 

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -248,7 +248,7 @@ TEST(isClockwiseGeofence) {
              "Got true for clockwise geofence");
 }
 
-TEST(isClockwiseLinkedGeoLoopFloats) {
+TEST(isClockwiseLinkedGeoLoop) {
     const GeoCoord verts[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
 
     LinkedGeoLoop loop;

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -74,11 +74,11 @@ TEST(pointInsideGeofence) {
     BBox bbox;
     bboxFromGeofence(&sfGeofence, &bbox);
 
-    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[0]) == false,
+    t_assert(!pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[0]),
              "contains exact");
-    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[4]) == true,
+    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &sfVerts[4]),
              "contains exact4");
-    t_assert(pointInsideGeofence(&sfGeofence, &bbox, &somewhere) == false,
+    t_assert(!pointInsideGeofence(&sfGeofence, &bbox, &somewhere),
              "contains somewhere else");
 }
 
@@ -91,18 +91,16 @@ TEST(pointInsideGeofenceTransmeridian) {
     BBox bbox;
     bboxFromGeofence(&transMeridianGeofence, &bbox);
 
+    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &westPoint),
+             "contains point to the west of the antimeridian");
+    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPoint),
+             "contains point to the east of the antimeridian");
     t_assert(
-        pointInsideGeofence(&transMeridianGeofence, &bbox, &westPoint) == true,
-        "contains point to the west of the antimeridian");
+        !pointInsideGeofence(&transMeridianGeofence, &bbox, &westPointOutside),
+        "does not contain outside point to the west of the antimeridian");
     t_assert(
-        pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPoint) == true,
-        "contains point to the east of the antimeridian");
-    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox,
-                                 &westPointOutside) == false,
-             "does not contain outside point to the west of the antimeridian");
-    t_assert(pointInsideGeofence(&transMeridianGeofence, &bbox,
-                                 &eastPointOutside) == false,
-             "does not contain outside point to the east of the antimeridian");
+        !pointInsideGeofence(&transMeridianGeofence, &bbox, &eastPointOutside),
+        "does not contain outside point to the east of the antimeridian");
 }
 
 TEST(pointInsideLinkedGeoLoop) {
@@ -119,9 +117,9 @@ TEST(pointInsideLinkedGeoLoop) {
     BBox bbox;
     bboxFromLinkedGeoLoop(&loop, &bbox);
 
-    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &inside) == true,
+    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &inside),
              "contains exact4");
-    t_assert(pointInsideLinkedGeoLoop(&loop, &bbox, &somewhere) == false,
+    t_assert(!pointInsideLinkedGeoLoop(&loop, &bbox, &somewhere),
              "contains somewhere else");
 
     destroyLinkedGeoLoop(&loop);
@@ -244,8 +242,7 @@ TEST(isClockwiseGeofence) {
     geofence.verts = verts;
     geofence.numVerts = 3;
 
-    t_assert(isClockwiseGeofence(&geofence) == true,
-             "Got true for clockwise geofence");
+    t_assert(isClockwiseGeofence(&geofence), "Got true for clockwise geofence");
 }
 
 TEST(isClockwiseLinkedGeoLoop) {
@@ -258,8 +255,7 @@ TEST(isClockwiseLinkedGeoLoop) {
         addLinkedCoord(&loop, &verts[i]);
     }
 
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
-             "Got true for clockwise loop");
+    t_assert(isClockwiseLinkedGeoLoop(&loop), "Got true for clockwise loop");
 
     destroyLinkedGeoLoop(&loop);
 }
@@ -274,7 +270,7 @@ TEST(isNotClockwiseLinkedGeoLoop) {
         addLinkedCoord(&loop, &verts[i]);
     }
 
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
+    t_assert(!isClockwiseLinkedGeoLoop(&loop),
              "Got false for counter-clockwise loop");
 
     destroyLinkedGeoLoop(&loop);
@@ -293,7 +289,7 @@ TEST(isClockwiseLinkedGeoLoopTransmeridian) {
         addLinkedCoord(&loop, &verts[i]);
     }
 
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == true,
+    t_assert(isClockwiseLinkedGeoLoop(&loop),
              "Got true for clockwise transmeridian loop");
 
     destroyLinkedGeoLoop(&loop);
@@ -312,7 +308,7 @@ TEST(isNotClockwiseLinkedGeoLoopTransmeridian) {
         addLinkedCoord(&loop, &verts[i]);
     }
 
-    t_assert(isClockwiseLinkedGeoLoop(&loop) == false,
+    t_assert(!isClockwiseLinkedGeoLoop(&loop),
              "Got false for counter-clockwise transmeridian loop");
 
     destroyLinkedGeoLoop(&loop);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -64,7 +64,6 @@ bool pointInsideGeofence(const Geofence* loop, const BBox* bbox,
                          const GeoCoord* coord);
 bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
                         const GeoCoord* coord);
-void isClockwiseLinkedGeofence(const Geofence* loop);
 void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
 bool pointInsideLinkedGeoLoop(const LinkedGeoLoop* loop, const BBox* bbox,
                               const GeoCoord* coord);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -58,16 +58,62 @@
 /** Macro: Whether a LinkedGeoLoop is empty */
 #define IS_EMPTY_LINKED_LOOP(loop) loop->first == NULL
 
-void bboxFromGeofence(const Geofence* loop, BBox* bbox);
+// Defined directly in polygon.c:
 void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes);
-bool pointInsideGeofence(const Geofence* loop, const BBox* bbox,
-                         const GeoCoord* coord);
 bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
                         const GeoCoord* coord);
+
+// The following functions are created via macro in polygonAlgos.h,
+// so their signatures are documented here:
+
+/**
+ * Create a bounding box from a Geofence
+ * @param geofence Input Geofence
+ * @param bbox     Output bbox
+ */
+void bboxFromGeofence(const Geofence* loop, BBox* bbox);
+
+/**
+ * Take a given Geofence data structure and check if it
+ * contains a given geo coordinate.
+ * @param loop          The geofence
+ * @param bbox          The bbox for the loop
+ * @param coord         The coordinate to check
+ * @return              Whether the point is contained
+ */
+bool pointInsideGeofence(const Geofence* loop, const BBox* bbox,
+                         const GeoCoord* coord);
+
+/**
+ * Create a bounding box from a LinkedGeoLoop
+ * @param geofence Input Geofence
+ * @param bbox     Output bbox
+ */
 void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
+
+/**
+ * Take a given LinkedGeoLoop data structure and check if it
+ * contains a given geo coordinate.
+ * @param loop          The linked loop
+ * @param bbox          The bbox for the loop
+ * @param coord         The coordinate to check
+ * @return              Whether the point is contained
+ */
 bool pointInsideLinkedGeoLoop(const LinkedGeoLoop* loop, const BBox* bbox,
                               const GeoCoord* coord);
-bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop* loop);
+
+/**
+ * Whether the winding order of a given Geofence is clockwise
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
+ */
 bool isClockwiseGeofence(const Geofence* geofence);
+
+/**
+ * Whether the winding order of a given LinkedGeoLoop is clockwise
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
+ */
+bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop* loop);
 
 #endif

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -68,8 +68,10 @@ bool pointInsideGeofence(const Geofence* loop, const BBox* bbox,
                          const GeoCoord* coord);
 bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
                         const GeoCoord* coord);
+void isClockwiseLinkedGeofence(const Geofence* loop);
 void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
 bool pointInsideLinkedGeoLoop(const LinkedGeoLoop* loop, const BBox* bbox,
                               const GeoCoord* coord);
+bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop* loop);
 
 #endif

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -73,5 +73,6 @@ void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
 bool pointInsideLinkedGeoLoop(const LinkedGeoLoop* loop, const BBox* bbox,
                               const GeoCoord* coord);
 bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop* loop);
+bool isClockwiseGeofence(const Geofence* geofence);
 
 #endif

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -58,10 +58,6 @@
 /** Macro: Whether a LinkedGeoLoop is empty */
 #define IS_EMPTY_LINKED_LOOP(loop) loop->first == NULL
 
-/** Macro: Normalize longitude */
-#define NORMALIZE_LNG(lng, isTransmeridian) \
-    isTransmeridian&& lng < 0 ? lng + M_2PI : lng
-
 void bboxFromGeofence(const Geofence* loop, BBox* bbox);
 void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes);
 bool pointInsideGeofence(const Geofence* loop, const BBox* bbox,

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -51,6 +51,10 @@
 #define LOOP_ALGO_TJOIN(a, b) LOOP_ALGO_XTJOIN(a, b)
 #define GENERIC_LOOP_ALGO(func) LOOP_ALGO_TJOIN(func, TYPE)
 
+/** Macro: Normalize longitude, dealing with transmeridian arcs */
+#define NORMALIZE_LON(lon, isTransmeridian) \
+    (isTransmeridian && lon < 0 ? lon + (double) M_2PI : lon)
+
 /**
  * pointInside is the core loop of the point-in-poly algorithm
  * @param loop  The loop to check
@@ -68,7 +72,7 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
     bool contains = false;
 
     double lat = coord->lat;
-    double lng = NORMALIZE_LNG(coord->lon, isTransmeridian);
+    double lng = NORMALIZE_LON(coord->lon, isTransmeridian);
 
     GeoCoord a;
     GeoCoord b;
@@ -92,8 +96,8 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
             continue;
         }
 
-        double aLng = NORMALIZE_LNG(a.lon, isTransmeridian);
-        double bLng = NORMALIZE_LNG(b.lon, isTransmeridian);
+        double aLng = NORMALIZE_LON(a.lon, isTransmeridian);
+        double bLng = NORMALIZE_LON(b.lon, isTransmeridian);
 
         // Rays are cast in the longitudinal direction, in case a point
         // exactly matches, to decide tiebreakers, bias westerly
@@ -108,7 +112,7 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
         // of a to b
         double ratio = (lat - a.lat) / (b.lat - a.lat);
         double testLng =
-            NORMALIZE_LNG(aLng + (bLng - aLng) * ratio, isTransmeridian);
+            NORMALIZE_LON(aLng + (bLng - aLng) * ratio, isTransmeridian);
 
         // Intersection of the ray
         if (testLng > lng) {
@@ -175,12 +179,13 @@ void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
 }
 
 /**
- * Whether the winding order of a given loop is clockwise. In GeoJSON,
- * clockwise loops are always inner loops (holes).
- * @param loop  The loop to check
- * @return      Whether the loop is clockwise
+ * Whether the winding order of a given loop is clockwise, with normalization
+ * for loops crossing the antimeridian.
+ * @param loop              The loop to check
+ * @param isTransmeridian   Whether the loop crosses the antimeridian
+ * @return                  Whether the loop is clockwise
  */
-bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
+static bool GENERIC_LOOP_ALGO(isClockwiseNormalized)(const TYPE* loop, bool isTransmeridian) {
     double sum = 0;
     GeoCoord a;
     GeoCoord b;
@@ -188,8 +193,23 @@ bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
     INIT_ITERATION;
     while (true) {
         ITERATE(loop, a, b);
-        sum += ((b.lon - a.lon) * (b.lat + a.lat));
+        // If we identify a transmeridian arc (> 180 degrees longitude),
+        // start over with the transmeridian flag set
+        if (!isTransmeridian && fabs(a.lon - b.lon) > M_PI) {
+            return GENERIC_LOOP_ALGO(isClockwiseNormalized)(loop, true);
+        }
+        sum += ((NORMALIZE_LON(b.lon, isTransmeridian) - NORMALIZE_LON(a.lon, isTransmeridian)) * (b.lat + a.lat));
     }
 
     return sum > 0;
+}
+
+/**
+ * Whether the winding order of a given loop is clockwise. In GeoJSON,
+ * clockwise loops are always inner loops (holes).
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
+ */
+bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
+    return GENERIC_LOOP_ALGO(isClockwiseNormalized)(loop, false);
 }

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -181,7 +181,7 @@ void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
  * @return      Whether the loop is clockwise
  */
 bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
-    int sum = 0;
+    double sum = 0;
     GeoCoord a;
     GeoCoord b;
 

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -173,3 +173,23 @@ void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
         bbox->west = tmp;
     }
 }
+
+/**
+ * Whether the winding order of a given loop is clockwise. In GeoJSON,
+ * clockwise loops are always inner loops (holes).
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
+ */
+bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
+    int sum = 0;
+    GeoCoord a;
+    GeoCoord b;
+
+    INIT_ITERATION;
+    while (true) {
+        ITERATE(loop, a, b);
+        sum += ((b.lon - a.lon) * (b.lat + a.lat));
+    }
+
+    return sum > 0;
+}

--- a/src/h3lib/lib/polygon.c
+++ b/src/h3lib/lib/polygon.c
@@ -40,13 +40,6 @@
  */
 
 /**
- * Create a bounding box from a Geofence
- * @name bboxFromGeofence
- * @param geofence Input Geofence
- * @param bbox     Output bbox
- */
-
-/**
  * Take a given LinkedGeoLoop data structure and check if it
  * contains a given geo coordinate.
  * @name pointInsideLinkedGeoLoop
@@ -58,10 +51,31 @@
  */
 
 /**
+ * Create a bounding box from a Geofence
+ * @name bboxFromGeofence
+ * @param geofence Input Geofence
+ * @param bbox     Output bbox
+ */
+
+/**
  * Create a bounding box from a LinkedGeoLoop
  * @name bboxFromLinkedGeoLoop
  * @param geofence Input Geofence
  * @param bbox     Output bbox
+ */
+
+/**
+ * Whether the winding order of a given Geofence is clockwise
+ * @name isClockwiseGeofence
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
+ */
+
+/**
+ * Whether the winding order of a given LinkedGeoLoop is clockwise
+ * @name isClockwiseLinkedGeoLoop
+ * @param loop  The loop to check
+ * @return      Whether the loop is clockwise
  */
 
 // Define macros used in polygon algos for Geofence

--- a/src/h3lib/lib/polygon.c
+++ b/src/h3lib/lib/polygon.c
@@ -26,58 +26,6 @@
 #include "geoCoord.h"
 #include "h3api.h"
 
-// Functions created via the include file:
-
-/**
- * Take a given Geofence data structure and check if it
- * contains a given geo coordinate.
- * @name pointInsideGeofence
- *
- * @param loop          The geofence
- * @param bbox          The bbox for the loop
- * @param coord         The coordinate to check
- * @return              Whether the point is contained
- */
-
-/**
- * Take a given LinkedGeoLoop data structure and check if it
- * contains a given geo coordinate.
- * @name pointInsideLinkedGeoLoop
- *
- * @param loop          The linked loop
- * @param bbox          The bbox for the loop
- * @param coord         The coordinate to check
- * @return              Whether the point is contained
- */
-
-/**
- * Create a bounding box from a Geofence
- * @name bboxFromGeofence
- * @param geofence Input Geofence
- * @param bbox     Output bbox
- */
-
-/**
- * Create a bounding box from a LinkedGeoLoop
- * @name bboxFromLinkedGeoLoop
- * @param geofence Input Geofence
- * @param bbox     Output bbox
- */
-
-/**
- * Whether the winding order of a given Geofence is clockwise
- * @name isClockwiseGeofence
- * @param loop  The loop to check
- * @return      Whether the loop is clockwise
- */
-
-/**
- * Whether the winding order of a given LinkedGeoLoop is clockwise
- * @name isClockwiseLinkedGeoLoop
- * @param loop  The loop to check
- * @return      Whether the loop is clockwise
- */
-
 // Define macros used in polygon algos for Geofence
 #define TYPE Geofence
 #define INIT_ITERATION INIT_ITERATION_GEOFENCE


### PR DESCRIPTION
More prep for #53. 

Adds `isClockwiseLinkedGeoLoop` and `isClockwiseGeofence` (we don't actually need `isClockwiseGeofence` but we get it for free and it was easier to include it than try to remove it). The algorithm is cribbed from [Turf.js](https://github.com/Turfjs/turf/blob/master/packages/turf-boolean-clockwise/index.ts) and adapted to use the existing H3 approach for handling shapes that cross the antimeridian.