### PR TITLE
Update rotation switch statement to array lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
 ## [Unreleased]
+### Changed
+- Improved direction rotation speed by replacing switch case statements with jump tables.
 
 ## [3.1.1] - 2018-08-29
 ### Fixed

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -400,28 +400,55 @@ void _ijkRotate60cw(CoordIJK* ijk) {
 }
 
 /**
+ * Mapping of single Counter-Clockwise rotation.
+ */
+static const Direction ROTATE_60_CCW[8] = {
+    /** CENTER_DIGIT -> CENTER_DIGIT */
+    CENTER_DIGIT,
+    /** K_AXES_DIGIT -> IK_AXES_DIGIT */
+    IK_AXES_DIGIT,
+    /** J_AXES_DIGIT -> JK_AXES_DIGIT */
+    JK_AXES_DIGIT,
+    /** JK_AXES_DIGIT -> K_AXES_DIGIT */
+    K_AXES_DIGIT,
+    /** I_AXES_DIGIT -> IJ_AXES_DIGIT */
+    IJ_AXES_DIGIT,
+    /** IK_AXES_DIGIT -> I_AXES_DIGIT */
+    I_AXES_DIGIT,
+    /** IJ_AXES_DIGIT -> J_AXES_DIGIT */
+    J_AXES_DIGIT,
+    /** INVALID_DIGIT -> INVALID_DIGIT */
+    INVALID_DIGIT};
+
+/**
  * Rotates indexing digit 60 degrees counter-clockwise. Returns result.
  *
  * @param digit Indexing digit (between 1 and 6 inclusive)
  */
 Direction _rotate60ccw(Direction digit) {
-    switch (digit) {
-        case K_AXES_DIGIT:
-            return IK_AXES_DIGIT;
-        case IK_AXES_DIGIT:
-            return I_AXES_DIGIT;
-        case I_AXES_DIGIT:
-            return IJ_AXES_DIGIT;
-        case IJ_AXES_DIGIT:
-            return J_AXES_DIGIT;
-        case J_AXES_DIGIT:
-            return JK_AXES_DIGIT;
-        case JK_AXES_DIGIT:
-            return K_AXES_DIGIT;
-        default:
-            return digit;
-    }
+    return ROTATE_60_CCW[digit];
 }
+
+/**
+ * Mapping of single Clockwise rotation.
+ */
+static const Direction ROTATE_60_CW[8] = {
+    /** CENTER_DIGIT -> CENTER_DIGIT */
+    CENTER_DIGIT,
+    /** K_AXES_DIGIT -> JK_AXES_DIGIT */
+    JK_AXES_DIGIT,
+    /** J_AXES_DIGIT -> IJ_AXES_DIGIT */
+    IJ_AXES_DIGIT,
+    /** JK_AXES_DIGIT -> J_AXES_DIGIT */
+    J_AXES_DIGIT,
+    /** I_AXES_DIGIT -> IK_AXES_DIGIT */
+    IK_AXES_DIGIT,
+    /** IK_AXES_DIGIT -> K_AXES_DIGIT */
+    K_AXES_DIGIT,
+    /** IJ_AXES_DIGIT -> I_AXES_DIGIT */
+    I_AXES_DIGIT,
+    /** INVALID_DIGIT -> INVALID_DIGIT */
+    INVALID_DIGIT};
 
 /**
  * Rotates indexing digit 60 degrees clockwise. Returns result.
@@ -429,22 +456,7 @@ Direction _rotate60ccw(Direction digit) {
  * @param digit Indexing digit (between 1 and 6 inclusive)
  */
 Direction _rotate60cw(Direction digit) {
-    switch (digit) {
-        case K_AXES_DIGIT:
-            return JK_AXES_DIGIT;
-        case JK_AXES_DIGIT:
-            return J_AXES_DIGIT;
-        case J_AXES_DIGIT:
-            return IJ_AXES_DIGIT;
-        case IJ_AXES_DIGIT:
-            return I_AXES_DIGIT;
-        case I_AXES_DIGIT:
-            return IK_AXES_DIGIT;
-        case IK_AXES_DIGIT:
-            return K_AXES_DIGIT;
-        default:
-            return digit;
-    }
+    return ROTATE_60_CW[digit];
 }
 
 /**

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -425,9 +425,7 @@ static const Direction ROTATE_60_CCW[8] = {
  *
  * @param digit Indexing digit (between 1 and 6 inclusive)
  */
-Direction _rotate60ccw(Direction digit) {
-    return ROTATE_60_CCW[digit];
-}
+Direction _rotate60ccw(Direction digit) { return ROTATE_60_CCW[digit]; }
 
 /**
  * Mapping of single Clockwise rotation.
@@ -455,9 +453,7 @@ static const Direction ROTATE_60_CW[8] = {
  *
  * @param digit Indexing digit (between 1 and 6 inclusive)
  */
-Direction _rotate60cw(Direction digit) {
-    return ROTATE_60_CW[digit];
-}
+Direction _rotate60cw(Direction digit) { return ROTATE_60_CW[digit]; }
 
 /**
  * Find the normalized ijk coordinates of the hex centered on the indicated


### PR DESCRIPTION
_rotate60cw and _rotate60ccw, which are called a lot by core algorithms uses a switch statement which can be replaced by an array lookup, which should be a lot faster.