### PR TITLE
Add a benchmark for kRing on a pentagon

### DIFF
--- a/src/apps/benchmarks/benchmarkKRing.c
+++ b/src/apps/benchmarks/benchmarkKRing.c
@@ -14,19 +14,28 @@
  * limitations under the License.
  */
 #include "benchmark.h"
+#include "h3Index.h"
 #include "h3api.h"
 
 // Fixtures
 H3Index hex = 0x89283080ddbffff;
 
+H3Index pentagon;
+
 BEGIN_BENCHMARKS();
 
+setH3Index(&pentagon, 9, 4, CENTER_DIGIT);
 H3Index* out = malloc(H3_EXPORT(maxKringSize)(40) * sizeof(H3Index));
 
 BENCHMARK(kRing10, 10000, { H3_EXPORT(kRing)(hex, 10, out); });
 BENCHMARK(kRing20, 10000, { H3_EXPORT(kRing)(hex, 20, out); });
 BENCHMARK(kRing30, 10000, { H3_EXPORT(kRing)(hex, 30, out); });
 BENCHMARK(kRing40, 10000, { H3_EXPORT(kRing)(hex, 40, out); });
+
+BENCHMARK(kRingPentagon10, 500, { H3_EXPORT(kRing)(pentagon, 10, out); });
+BENCHMARK(kRingPentagon20, 500, { H3_EXPORT(kRing)(pentagon, 20, out); });
+BENCHMARK(kRingPentagon30, 50, { H3_EXPORT(kRing)(pentagon, 30, out); });
+BENCHMARK(kRingPentagon40, 10, { H3_EXPORT(kRing)(pentagon, 40, out); });
 
 free(out);
 

--- a/src/apps/benchmarks/benchmarkKRing.c
+++ b/src/apps/benchmarks/benchmarkKRing.c
@@ -19,12 +19,10 @@
 
 // Fixtures
 H3Index hex = 0x89283080ddbffff;
-
-H3Index pentagon;
+H3Index pentagon = 0x89080000003ffff;
 
 BEGIN_BENCHMARKS();
 
-setH3Index(&pentagon, 9, 4, CENTER_DIGIT);
 H3Index* out = malloc(H3_EXPORT(maxKringSize)(40) * sizeof(H3Index));
 
 BENCHMARK(kRing10, 10000, { H3_EXPORT(kRing)(hex, 10, out); });


### PR DESCRIPTION
This case falls back to the DFS approach which is much slower
than non-pentagon cases.