### PR TITLE
Do not consider indexes in deleted pentagon subsequences to be valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
+## [Unreleased]
+### Changed
+- Indexes in deleted pentagon subsequences are not considered valid.
+
 ## [3.2.0] - 2018-10-04
 ### Added
 - `experimentalH3ToLocalIj` function for getting local coordinates for an index. (#102)

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -123,6 +123,13 @@ SUITE(h3Index) {
                  "h3IsValid failed on too large digit");
     }
 
+    TEST(h3BadDigitInvalid) {
+        H3Index h;
+        setH3Index(&h, 1, 4, K_AXES_DIGIT);
+        t_assert(!H3_EXPORT(h3IsValid)(h),
+                 "h3IsValid failed on deleted subsequence");
+    }
+
     TEST(h3ToString) {
         const size_t bufSz = 17;
         char buf[17] = {0};

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -186,13 +186,6 @@ void localIjToH3_traverse_assertions(H3Index h3) {
         if (!failed) {
             t_assert(H3_EXPORT(h3IsValid)(testH3),
                      "test coordinates result in valid index");
-            if (_isBaseCellPentagon(H3_EXPORT(h3GetBaseCell)(testH3))) {
-                // h3IsValid doesn't test for indexes representing part of the
-                // deleted subsequence.
-                t_assert(
-                    _h3LeadingNonZeroDigit(testH3) != K_AXES_DIGIT,
-                    "index is in a valid subsequence on a pentagon base cell.");
-            }
 
             CoordIJ expectedIj;
             int reverseFailed =

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -84,8 +84,17 @@ int H3_EXPORT(h3IsValid)(H3Index h) {
     int res = H3_GET_RESOLUTION(h);
     if (res < 0 || res > MAX_H3_RES) return 0;
 
+    bool foundFirstNonZeroDigit = false;
     for (int r = 1; r <= res; r++) {
         Direction digit = H3_GET_INDEX_DIGIT(h, r);
+
+        if (!foundFirstNonZeroDigit && digit != CENTER_DIGIT) {
+            foundFirstNonZeroDigit = true;
+            if (_isBaseCellPentagon(baseCell) && digit == K_AXES_DIGIT) {
+                return 0;
+            }
+        }
+
         if (digit < CENTER_DIGIT || digit >= NUM_DIGITS) return 0;
     }
 


### PR DESCRIPTION
These indexes should never be generated by the H3 library, and it doesn't appear to be defined what cell they refer to.

See #147