### PR TITLE
Add h3-node to list of bindings

### DIFF
--- a/docs/community/bindings.md
+++ b/docs/community/bindings.md
@@ -21,6 +21,7 @@ As a C library, bindings can be made to call H3 functions from different program
 ## JavaScript
 
 - [uber/h3-js](https://github.com/uber/h3-js)
+- [dfellis/h3-node](https://github.com/dfellis/h3-node)
 
 ## OCaml
 


### PR DESCRIPTION
Hey @isaacbrodsky et al. :)

The [h3-node](https://github.com/dfellis/h3-node) binding is now at a proof-of-concept phase with the two primary H3 functions implemented and tested for correctness.

Putting this PR up for inclusion in the bindings list. Can wait for it being published on NPM if you prefer, though.