### PR TITLE
Add hexLine function to return the line of indexes between a given start and end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h](./src/h3lib/include/h3api.h).
 
 ## [Unreleased]
+### Added
+- `h3Line` and `h3LineSize` functions for getting the line of indexes between some start and end (inclusive) (#165)
 ### Changed
 - Indexes in deleted pentagon subsequences are not considered valid.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/testH3SetToLinkedGeo.c
     src/apps/testapps/testH3ToLocalIj.c
     src/apps/testapps/testH3Distance.c
+    src/apps/testapps/testH3Line.c
     src/apps/testapps/testCoordIj.c
     src/apps/miscapps/h3ToGeoBoundaryHier.c
     src/apps/miscapps/h3ToGeoHier.c
@@ -466,6 +467,7 @@ if(BUILD_TESTING)
     add_h3_test(testVec3d src/apps/testapps/testVec3d.c)
     add_h3_test(testH3ToLocalIj src/apps/testapps/testH3ToLocalIj.c)
     add_h3_test(testH3Distance src/apps/testapps/testH3Distance.c)
+    add_h3_test(testH3Line src/apps/testapps/testH3Line.c)
     add_h3_test(testCoordIj src/apps/testapps/testCoordIj.c)
 
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ set(OTHER_SOURCE_FILES
     src/apps/benchmarks/benchmarkPolygon.c
     src/apps/benchmarks/benchmarkH3SetToLinkedGeo.c
     src/apps/benchmarks/benchmarkKRing.c
+    src/apps/benchmarks/benchmarkH3Line.c
     src/apps/benchmarks/benchmarkH3Api.c)
 
 set(ALL_SOURCE_FILES
@@ -489,6 +490,7 @@ if(BUILD_TESTING)
 
     add_h3_benchmark(benchmarkH3Api src/apps/benchmarks/benchmarkH3Api.c)
     add_h3_benchmark(benchmarkKRing src/apps/benchmarks/benchmarkKRing.c)
+    add_h3_benchmark(benchmarkH3Line src/apps/benchmarks/benchmarkH3Line.c)
     add_h3_benchmark(benchmarkH3SetToLinkedGeo src/apps/benchmarks/benchmarkH3SetToLinkedGeo.c)
     add_h3_benchmark(benchmarkPolyfill src/apps/benchmarks/benchmarkPolyfill.c)
     add_h3_benchmark(benchmarkPolygon src/apps/benchmarks/benchmarkPolygon.c)

--- a/docs/api/traversal.md
+++ b/docs/api/traversal.md
@@ -96,6 +96,38 @@ Produces the hollow hexagonal ring centered at origin with sides of length k.
  
 Returns 0 if no pentagonal distortion was encountered.
 
+## h3Line
+
+```
+int h3Line(H3Index start, H3Index end, H3Index* out);
+```
+
+Given two H3 indexes, return the line of indexes between them (inclusive).
+
+This function may fail to find the line between two indexes, for
+example if they are very far apart. It may also fail when finding
+distances for indexes on opposite sides of a pentagon.
+
+*Notes:*
+
+ * The specific output of this function should not be considered stable
+   across library versions. The only guarantees the library provides are
+   that the line length will be `h3Distance(start, end) + 1` and that
+   every index in the line will be a neighbor of the preceding index.
+
+ * Lines are drawn in grid space, and may not correspond exactly to either
+   Cartesian lines or great arcs.
+
+## h3LineSize
+
+```
+int h3LineSize(H3Index start, H3Index end);
+```
+
+Number of indexes in a line from the start index to the end index,
+to be used for allocating memory. Returns a negative number if the
+line cannot be computed.
+
 ## h3Distance
 
 ```

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -21,6 +21,7 @@
 #define UTILITY_H
 
 #include <stdio.h>
+#include "coordijk.h"
 #include "h3api.h"
 
 #define BUFF_SIZE 256
@@ -32,6 +33,8 @@
 void error(const char* msg);
 void h3Print(H3Index h);    // prints as integer
 void h3Println(H3Index h);  // prints as integer
+
+void coordIjkPrint(const CoordIJK* c);
 
 void geoToStringRads(const GeoCoord* p, char* str);
 void geoToStringDegs(const GeoCoord* p, char* str);

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -23,6 +23,7 @@
 #include <stackAlloc.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "coordijk.h"
 #include "geoCoord.h"
 #include "h3Index.h"
 #include "h3api.h"
@@ -43,6 +44,13 @@ void h3Print(H3Index h) { printf("%" PRIx64, h); }
  * Prints the H3Index and a newline
  */
 void h3Println(H3Index h) { printf("%" PRIx64 "\n", h); }
+
+/**
+ * Prints the CoordIJK
+ */
+void coordIjkPrint(const CoordIJK* c) {
+    printf("[%d, %d, %d]", c->i, c->j, c->k);
+}
 
 /**
  * Assumes `str` is big enough to hold the result.

--- a/src/apps/benchmarks/benchmarkH3Line.c
+++ b/src/apps/benchmarks/benchmarkH3Line.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "benchmark.h"
+#include "h3api.h"
+
+// Fixtures
+H3Index startIndex = 0x89283082803ffff;
+H3Index endNear = 0x892830814b3ffff;
+H3Index endFar = 0x8929a5653c3ffff;
+
+BEGIN_BENCHMARKS();
+
+H3Index* out =
+    calloc(H3_EXPORT(h3LineSize)(startIndex, endFar), sizeof(H3Index));
+
+BENCHMARK(h3LineNear, 10000, {
+    H3_EXPORT(h3Line)(startIndex, endNear, out);
+});
+BENCHMARK(h3LineFar, 1000, {
+    H3_EXPORT(h3Line)(startIndex, endFar, out);
+});
+
+free(out);
+
+END_BENCHMARKS();

--- a/src/apps/benchmarks/benchmarkH3Line.c
+++ b/src/apps/benchmarks/benchmarkH3Line.c
@@ -26,12 +26,8 @@ BEGIN_BENCHMARKS();
 H3Index* out =
     calloc(H3_EXPORT(h3LineSize)(startIndex, endFar), sizeof(H3Index));
 
-BENCHMARK(h3LineNear, 10000, {
-    H3_EXPORT(h3Line)(startIndex, endNear, out);
-});
-BENCHMARK(h3LineFar, 1000, {
-    H3_EXPORT(h3Line)(startIndex, endFar, out);
-});
+BENCHMARK(h3LineNear, 10000, { H3_EXPORT(h3Line)(startIndex, endNear, out); });
+BENCHMARK(h3LineFar, 1000, { H3_EXPORT(h3Line)(startIndex, endFar, out); });
 
 free(out);
 

--- a/src/apps/testapps/testCoordIj.c
+++ b/src/apps/testapps/testCoordIj.c
@@ -62,4 +62,18 @@ SUITE(coordIj) {
                      "got same ijk coordinates back");
         }
     }
+
+    TEST(ijkToCube_roundtrip) {
+        for (Direction dir = CENTER_DIGIT; dir < NUM_DIGITS; dir++) {
+            CoordIJK ijk = {0};
+            _neighbor(&ijk, dir);
+            CoordIJK original = {ijk.i, ijk.j, ijk.k};
+
+            ijkToCube(&ijk);
+            cubeToIjk(&ijk);
+
+            t_assert(_ijkMatches(&ijk, &original),
+                     "got same ijk coordinates back");
+        }
+    }
 }

--- a/src/apps/testapps/testH3Line.c
+++ b/src/apps/testapps/testH3Line.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief tests H3 distance function.
+ *
+ *  usage: `testH3Distance`
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "h3Index.h"
+#include "h3api.h"
+#include "localij.h"
+#include "stackAlloc.h"
+#include "test.h"
+#include "utility.h"
+
+static const int MAX_DISTANCES[] = {1, 2, 5, 12, 19, 26};
+
+/**
+ * Property-based testing of h3Line output
+ */
+static void h3Line_assertions(H3Index start, H3Index end) {
+    int sz = H3_EXPORT(h3LineSize)(start, end);
+    t_assert(sz > 0, "got valid size");
+    STACK_ARRAY_CALLOC(H3Index, line, sz);
+
+    int err = H3_EXPORT(h3Line)(start, end, line);
+
+    t_assert(err == 0, "no error on line");
+    t_assert(line[0] == start, "line starts with start index");
+    t_assert(line[sz - 1] == end, "line ends with end index");
+
+    for (int i = 1; i < sz; i++) {
+        t_assert(H3_EXPORT(h3IsValid)(line[i]), "index is valid");
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(line[i], line[i - 1]),
+                 "index is a neighbor of the previous index");
+        if (i > 1) {
+            t_assert(
+                !H3_EXPORT(h3IndexesAreNeighbors)(line[i], line[i - 3]),
+                "index is not a neighbor of the index before the previous");
+        }
+    }
+}
+
+/**
+ * Tests for invalid h3Line input
+ */
+static void h3Line_invalid_assertions(H3Index start, H3Index end) {
+    int sz = H3_EXPORT(h3LineSize)(start, end);
+    t_assert(sz < 0, "line size marked as invalid");
+
+    H3Index* line = {0};
+    int err = H3_EXPORT(h3Line)(start, end, line);
+    t_assert(err != 0, "line marked as invalid");
+}
+
+/**
+ * Test for lines from an index to all neighbors within a kRing
+ */
+static void h3Line_kRing_assertions(H3Index h3) {
+    int r = H3_GET_RESOLUTION(h3);
+    t_assert(r <= 5, "resolution supported by test function (kRing)");
+    int maxK = MAX_DISTANCES[r];
+
+    int sz = H3_EXPORT(maxKringSize)(maxK);
+    STACK_ARRAY_CALLOC(H3Index, neighbors, sz);
+    H3_EXPORT(kRing)(h3, maxK, neighbors);
+
+    if (H3_EXPORT(h3IsPentagon)(h3)) {
+        return;
+    }
+
+    for (int i = 0; i < sz; i++) {
+        if (neighbors[i] == 0) {
+            continue;
+        }
+        int distance = H3_EXPORT(h3Distance)(h3, neighbors[i]);
+        if (distance >= 0) {
+            h3Line_assertions(h3, neighbors[i]);
+        } else {
+            h3Line_invalid_assertions(h3, neighbors[i]);
+        }
+    }
+}
+
+SUITE(h3Distance) {
+    TEST(h3Distance_kRing) {
+        iterateAllIndexesAtRes(0, h3Line_kRing_assertions);
+        iterateAllIndexesAtRes(1, h3Line_kRing_assertions);
+        iterateAllIndexesAtRes(2, h3Line_kRing_assertions);
+        // Don't iterate all of res 3, to save time
+        iterateAllIndexesAtResPartial(3, h3Line_kRing_assertions, 6);
+        // Further resolutions aren't tested to save time.
+    }
+}

--- a/src/apps/testapps/testH3Line.c
+++ b/src/apps/testapps/testH3Line.c
@@ -98,8 +98,8 @@ static void h3Line_kRing_assertions(H3Index h3) {
     }
 }
 
-SUITE(h3Distance) {
-    TEST(h3Distance_kRing) {
+SUITE(h3Line) {
+    TEST(h3Line_kRing) {
         iterateAllIndexesAtRes(0, h3Line_kRing_assertions);
         iterateAllIndexesAtRes(1, h3Line_kRing_assertions);
         iterateAllIndexesAtRes(2, h3Line_kRing_assertions);

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -123,7 +123,7 @@ void h3ToLocalIj_neighbors_assertions(H3Index h3) {
 
 /**
  * Test that the neighbors (k-ring), if they can be found in the local IJ
- * coordinate space, can be converetd back to indexes.
+ * coordinate space, can be converted back to indexes.
  */
 void localIjToH3_kRing_assertions(H3Index h3) {
     int r = H3_GET_RESOLUTION(h3);

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -107,5 +107,7 @@ Direction _rotate60cw(Direction digit);
 int ijkDistance(const CoordIJK* a, const CoordIJK* b);
 void ijkToIj(const CoordIJK* ijk, CoordIJ* ij);
 void ijToIjk(const CoordIJ* ij, CoordIJK* ijk);
+void ijkToCube(CoordIJK* ijk);
+void cubeToIjk(CoordIJK* ijk);
 
 #endif

--- a/src/h3lib/include/h3api.h
+++ b/src/h3lib/include/h3api.h
@@ -459,6 +459,17 @@ void H3_EXPORT(getH3UnidirectionalEdgeBoundary)(H3Index edge, GeoBoundary *gb);
 int H3_EXPORT(h3Distance)(H3Index origin, H3Index h3);
 /** @} */
 
+/** @defgroup h3Line h3Line
+ * Functions for h3Line
+ * @{
+ */
+/** @brief Number of indexes in a line connecting two indexes */
+int H3_EXPORT(h3LineSize)(H3Index start, H3Index end);
+
+/** @brief Line of h3 indexes connecting two indexes */
+int H3_EXPORT(h3Line)(H3Index start, H3Index end, H3Index *out);
+/** @} */
+
 /** @defgroup experimentalH3ToLocalIj experimentalH3ToLocalIj
  * Functions for experimentalH3ToLocalIj
  * @{

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -532,3 +532,23 @@ void ijToIjk(const CoordIJ* ij, CoordIJK* ijk) {
 
     _ijkNormalize(ijk);
 }
+
+/**
+ * Convert IJK coordinates to cube coordinates, in place
+ * @param ijk Coordinate to convert
+ */
+void ijkToCube(CoordIJK* ijk) {
+    ijk->i = -ijk->i + ijk->k;
+    ijk->j = ijk->j - ijk->k;
+    ijk->k = -ijk->i - ijk->j;
+}
+
+/**
+ * Convert cube coordinates to IJK coordinates, in place
+ * @param ijk Coordinate to convert
+ */
+void cubeToIjk(CoordIJK* ijk) {
+    ijk->i = -ijk->i;
+    ijk->k = 0;
+    _ijkNormalize(ijk);
+}

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -183,10 +183,8 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
         if (originOnPent) {
             int originLeadingDigit = _h3LeadingNonZeroDigit(origin);
 
-            if ((isResClassIII(res) &&
-                 FAILED_DIRECTIONS_III[originLeadingDigit][dir]) ||
-                (!isResClassIII(res) &&
-                 FAILED_DIRECTIONS_II[originLeadingDigit][dir])) {
+            if (FAILED_DIRECTIONS_III[originLeadingDigit][dir] ||
+                FAILED_DIRECTIONS_II[originLeadingDigit][dir]) {
                 // TODO this part of the pentagon might not be unfolded
                 // correctly.
                 return 3;
@@ -541,4 +539,101 @@ int H3_EXPORT(h3Distance)(H3Index origin, H3Index h3) {
     }
 
     return ijkDistance(&originIjk, &h3Ijk);
+}
+
+/**
+ * Number of indexes in a line from the start index to the end index,
+ * to be used for allocating memory. Returns a negative number if the
+ * line cannot be computed.
+ *
+ * @param start Start index of the line
+ * @param end End index of the line
+ * @return Size of the line, or a negative number if the line cannot
+ * be computed.
+ */
+int H3_EXPORT(h3LineSize)(H3Index start, H3Index end) {
+    int distance = H3_EXPORT(h3Distance)(start, end);
+    return distance >= 0 ? distance + 1 : distance;
+}
+
+/**
+ * Given cube coords as floats, round to valid integer coordinates. Algorithm
+ * from https://www.redblobgames.com/grids/hexagons/#rounding
+ * @param i   Floating-point I coord
+ * @param j   Floating-point J coord
+ * @param k   Floating-point K coord
+ * @param ijk IJK coord struct, modified in place
+ */
+static void cubeRound(float i, float j, float k, CoordIJK* ijk) {
+    int ri = round(i);
+    int rj = round(j);
+    int rk = round(k);
+
+    float iDiff = fabs((float)ri - i);
+    float jDiff = fabs((float)rj - j);
+    float kDiff = fabs((float)rk - k);
+
+    // Round, maintaining valid cube coords
+    if (iDiff > jDiff && iDiff > kDiff) {
+        ri = -rj - rk;
+    } else if (jDiff > kDiff) {
+        rj = -ri - rk;
+    } else {
+        rk = -ri - rj;
+    }
+
+    ijk->i = ri;
+    ijk->j = rj;
+    ijk->k = rk;
+}
+
+/**
+ * Given two H3 indexes, return the line of indexes between them (inclusive).
+ *
+ * This function may fail to find the line between two indexes, for
+ * example if they are very far apart. It may also fail when finding
+ * distances for indexes on opposite sides of a pentagon.
+ *
+ * @param start Start index of the line
+ * @param end End index of the line
+ * @param out Output array, which must be of size h3LineSize(start, end)
+ * @return 0 on success, or another value on failure.
+ */
+int H3_EXPORT(h3Line)(H3Index start, H3Index end, H3Index* out) {
+    int distance = H3_EXPORT(h3Distance)(start, end);
+    // Early exit if we can't calculate the line
+    if (distance < 0) {
+        return distance;
+    }
+
+    // Get IJK coords for the start and end. We've already confirmed
+    // that these can be calculated with the distance check above.
+    CoordIJK startIjk = {0};
+    CoordIJK endIjk = {0};
+
+    // Convert H3 addresses to IJK coords
+    h3ToLocalIjk(start, start, &startIjk);
+    h3ToLocalIjk(start, end, &endIjk);
+
+    // Convert IJK to cube coordinates suitable for linear interpolation
+    ijkToCube(&startIjk);
+    ijkToCube(&endIjk);
+
+    float iStep =
+        distance ? (float)(endIjk.i - startIjk.i) / (float)distance : 0;
+    float jStep =
+        distance ? (float)(endIjk.j - startIjk.j) / (float)distance : 0;
+    float kStep =
+        distance ? (float)(endIjk.k - startIjk.k) / (float)distance : 0;
+
+    CoordIJK currentIjk = {startIjk.i, startIjk.j, startIjk.k};
+    for (int n = 0; n <= distance; n++) {
+        cubeRound((float)startIjk.i + iStep * n, (float)startIjk.j + jStep * n,
+                  (float)startIjk.k + kStep * n, &currentIjk);
+        // Convert cube -> ijk -> h3 index
+        cubeToIjk(&currentIjk);
+        localIjkToH3(start, &currentIjk, &out[n]);
+    }
+
+    return 0;
 }

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -183,6 +183,11 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
         if (originOnPent) {
             int originLeadingDigit = _h3LeadingNonZeroDigit(origin);
 
+            // TODO: This previously included the Class III-based checks
+            // as in the index-on-pentagon case below, but these were
+            // removed due to some failure cases. It is possible that we
+            // could restrict this error to a narrower set of cases.
+            // https://github.com/uber/h3/issues/163
             if (FAILED_DIRECTIONS_III[originLeadingDigit][dir] ||
                 FAILED_DIRECTIONS_II[originLeadingDigit][dir]) {
                 // TODO this part of the pentagon might not be unfolded

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -594,6 +594,15 @@ static void cubeRound(float i, float j, float k, CoordIJK* ijk) {
  * example if they are very far apart. It may also fail when finding
  * distances for indexes on opposite sides of a pentagon.
  *
+ * Notes:
+ *
+ *  - The specific output of this function should not be considered stable
+ *    across library versions. The only guarantees the library provides are
+ *    that the line length will be `h3Distance(start, end) + 1` and that
+ *    every index in the line will be a neighbor of the preceding index.
+ *  - Lines are drawn in grid space, and may not correspond exactly to either
+ *    Cartesian lines or great arcs.
+ *
  * @param start Start index of the line
  * @param end End index of the line
  * @param out Output array, which must be of size h3LineSize(start, end)

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -557,21 +557,21 @@ int H3_EXPORT(h3LineSize)(H3Index start, H3Index end) {
 }
 
 /**
- * Given cube coords as floats, round to valid integer coordinates. Algorithm
+ * Given cube coords as doubles, round to valid integer coordinates. Algorithm
  * from https://www.redblobgames.com/grids/hexagons/#rounding
  * @param i   Floating-point I coord
  * @param j   Floating-point J coord
  * @param k   Floating-point K coord
  * @param ijk IJK coord struct, modified in place
  */
-static void cubeRound(float i, float j, float k, CoordIJK* ijk) {
+static void cubeRound(double i, double j, double k, CoordIJK* ijk) {
     int ri = round(i);
     int rj = round(j);
     int rk = round(k);
 
-    float iDiff = fabs((float)ri - i);
-    float jDiff = fabs((float)rj - j);
-    float kDiff = fabs((float)rk - k);
+    double iDiff = fabs((double)ri - i);
+    double jDiff = fabs((double)rj - j);
+    double kDiff = fabs((double)rk - k);
 
     // Round, maintaining valid cube coords
     if (iDiff > jDiff && iDiff > kDiff) {
@@ -628,17 +628,18 @@ int H3_EXPORT(h3Line)(H3Index start, H3Index end, H3Index* out) {
     ijkToCube(&startIjk);
     ijkToCube(&endIjk);
 
-    float iStep =
-        distance ? (float)(endIjk.i - startIjk.i) / (float)distance : 0;
-    float jStep =
-        distance ? (float)(endIjk.j - startIjk.j) / (float)distance : 0;
-    float kStep =
-        distance ? (float)(endIjk.k - startIjk.k) / (float)distance : 0;
+    double iStep =
+        distance ? (double)(endIjk.i - startIjk.i) / (double)distance : 0;
+    double jStep =
+        distance ? (double)(endIjk.j - startIjk.j) / (double)distance : 0;
+    double kStep =
+        distance ? (double)(endIjk.k - startIjk.k) / (double)distance : 0;
 
     CoordIJK currentIjk = {startIjk.i, startIjk.j, startIjk.k};
     for (int n = 0; n <= distance; n++) {
-        cubeRound((float)startIjk.i + iStep * n, (float)startIjk.j + jStep * n,
-                  (float)startIjk.k + kStep * n, &currentIjk);
+        cubeRound((double)startIjk.i + iStep * n,
+                  (double)startIjk.j + jStep * n,
+                  (double)startIjk.k + kStep * n, &currentIjk);
         // Convert cube -> ijk -> h3 index
         cubeToIjk(&currentIjk);
         localIjkToH3(start, &currentIjk, &out[n]);


### PR DESCRIPTION
* Adds the `hexLine` function and exposes it in the API. 
* Adds property-based tests for all hexagons in res 0-2 and some base cells in res 3.
* Adds `ijkToCube` and `cubeToIjk` helpers to translate from IJK to cube coordinate space

<img width="950" alt="screen shot 2018-12-13 at 11 25 35 am" src="https://user-images.githubusercontent.com/163940/49962711-d4182080-feca-11e8-9ebe-132f5a08240a.png">

This uses the algorithm described on the [Red Blob Games site](https://www.redblobgames.com/grids/hexagons/#line-drawing), converting IJK to cube coordinates in order to use the `cubeRound` algo.

TODO:
- [x] Add to CHANGELOG
- [x] Add to docs

Fixes #163 
Closes #162 