### PR TITLE
Add second postgresql binding

### DIFF
--- a/docs/community/bindings.md
+++ b/docs/community/bindings.md
@@ -34,6 +34,7 @@ As a C library, bindings can be made to call H3 functions from different program
 ## PostgreSQL
 
 - [dlr-eoc/pgh3](https://github.com/dlr-eoc/pgh3)
+- [bytesandbrains/h3-pg](https://github.com/bytesandbrains/h3-pg)
 
 ## Python
 


### PR DESCRIPTION
Hi we've implemented bindings for the full h3 API in a postgresql extension in collaboration with a client.

Our approach is similar to that of @nmandery with some implementation differences.