### PR TITLE
Fix binding-functions when building out of source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
         # Intentionally failing the build to check the test
         #- make binding-functions
         # Check that the file exists and has contents
-        - [ -s binding-functions ]
+        - test -s binding-functions
 
 # Configure the build script, out of source.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,12 @@ matrix:
         - coveralls --lcov-file coverage.cleaned.info --verbose
     - env: NAME="Mac OSX (Xcode 8)"
       os: osx
+    - env: NAME="binding-functions target"
+      script:
+        # Intentionally failing the build to check the test
+        #- make binding-functions
+        # Check that the file exists and has contents
+        - [ -s binding-functions ]
 
 # Configure the build script, out of source.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,7 @@ matrix:
       os: osx
     - env: NAME="binding-functions target"
       script:
-        # Intentionally failing the build to check the test
-        #- make binding-functions
+        - make binding-functions
         # Check that the file exists and has contents
         - test -s binding-functions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- `binding-functions` build target fixed when running the build out of source 
 
 ## [3.4.0] - 2019-01-23
 ### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,10 +39,12 @@ environment:
 build_script:
   - cmake "-G%GENERATOR%" -H. -Bbuild
   - cmake --build build --config "%CONFIG%"
-  # Intentionally failing the build to check the test
-  #- cmake --build build --config "%CONFIG%" binding-functions
+  - cmake --build build --config "%CONFIG%" --target binding-functions
 
 test_script:
   - ps: cd build
   - ctest -VV -C "%CONFIG%"
-  - ps: (Get-Item "binding-functions").Length -gt 10
+  # Check that binding-functions was generated and has content
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      if ((Get-Item "binding-functions").Length -lt 10) { $host.SetShouldExit(1) }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,10 @@ environment:
 build_script:
   - cmake "-G%GENERATOR%" -H. -Bbuild
   - cmake --build build --config "%CONFIG%"
+  # Intentionally failing the build to check the test
+  #- cmake --build build --config "%CONFIG%" binding-functions
 
 test_script:
   - ps: cd build
   - ctest -VV -C "%CONFIG%"
+  - ps: (Get-Item "binding-functions").Length -gt 10

--- a/scripts/binding_functions.ps1
+++ b/scripts/binding_functions.ps1
@@ -16,5 +16,4 @@
 # by bindings of the H3 library. It is invoked by the `binding-functions`
 # make target and produces a file `binding-functions`.
 
-$scriptDir = Split-Path -parent $PSCommandPath
-Get-Content "$scriptDir/../src/h3lib/include/h3api.h" | Where-Object {$_ -match "@defgroup ([A-Za-z0-9_]*)"} | Foreach {$Matches[1]} > binding-functions
+Get-Content "src/h3lib/include/h3api.h" | Where-Object {$_ -match "@defgroup ([A-Za-z0-9_]*)"} | Foreach {$Matches[1]} > binding-functions

--- a/scripts/binding_functions.sh
+++ b/scripts/binding_functions.sh
@@ -17,5 +17,6 @@
 # by bindings of the H3 library. It is invoked by the `binding-functions`
 # make target and produces a file `binding-functions`.
 
-SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-cat "$SCRIPT_DIR/../src/h3lib/include/h3api.h" | sed -n '/@defgroup/s/.*@defgroup \([A-Za-z0-9_]*\) .*/\1/gp' > binding-functions
+set -eo pipefail
+
+cat "src/h3lib/include/h3api.h" | sed -n '/@defgroup/s/.*@defgroup \([A-Za-z0-9_]*\) .*/\1/gp' > binding-functions


### PR DESCRIPTION
The binding functions scripts were looking in the original source directory, rather than for the generated `h3api.h` which is now under the binary directory. Also updated `binding_functions.sh` to fail the build when the file it expects is not found.