### PR TITLE
binding-functions encoded in ASCII on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Changed
+- `binding-functions` build target generates an ASCII file on Windows
 
 ## [3.4.1] - 2019-02-15
 ### Fixed
-- `binding-functions` build target fixed when running the build out of source 
+- `binding-functions` build target fixed when running the build out of source (#188)
 
 ## [3.4.0] - 2019-01-23
 ### Added

--- a/scripts/binding_functions.ps1
+++ b/scripts/binding_functions.ps1
@@ -16,4 +16,4 @@
 # by bindings of the H3 library. It is invoked by the `binding-functions`
 # make target and produces a file `binding-functions`.
 
-Get-Content "src/h3lib/include/h3api.h" | Where-Object {$_ -match "@defgroup ([A-Za-z0-9_]*)"} | Foreach {$Matches[1]} > binding-functions
+Get-Content "src/h3lib/include/h3api.h" | Where-Object {$_ -match "@defgroup ([A-Za-z0-9_]*)"} | Foreach {$Matches[1]} | Out-File -FilePath binding-functions -Encoding ASCII


### PR DESCRIPTION
The default is for Powershell to generate UTF-16 with BOM, and setting to UTF-8
also generates a BOM. (I understand newer versions of Powershell have a UTF8
with no BOM option, but that wasn't available for me.) The BOM is a problem
because Java for example does not discard the BOM, requiring workarounds like
Commons IO.

This limits function names in the C API to the ASCII character set, which
currently appears to be a reasonable limitation.