### PR TITLE
Allocate memory for benchmarkPolyfill on the heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- `benchmarkPolyfill` allocates its memory on the heap (#198)
 
 ## [3.4.2] - 2019-02-21
 ### Changed

--- a/src/apps/benchmarks/benchmarkPolyfill.c
+++ b/src/apps/benchmarks/benchmarkPolyfill.c
@@ -16,7 +16,6 @@
 #include "algos.h"
 #include "benchmark.h"
 #include "h3api.h"
-#include "stackAlloc.h"
 
 // Fixtures
 GeoCoord sfVerts[] = {
@@ -120,23 +119,27 @@ southernGeofence.verts = southernVerts;
 southernGeoPolygon.geofence = southernGeofence;
 
 int numHexagons;
+H3Index* hexagons;
 
 BENCHMARK(polyfillSF, 500, {
     numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-    STACK_ARRAY_CALLOC(H3Index, hexagons, numHexagons);
+    hexagons = calloc(numHexagons, sizeof(H3Index));
     H3_EXPORT(polyfill)(&sfGeoPolygon, 9, hexagons);
+    free(hexagons);
 });
 
 BENCHMARK(polyfillAlameda, 500, {
     numHexagons = H3_EXPORT(maxPolyfillSize)(&alamedaGeoPolygon, 9);
-    STACK_ARRAY_CALLOC(H3Index, hexagons, numHexagons);
+    hexagons = calloc(numHexagons, sizeof(H3Index));
     H3_EXPORT(polyfill)(&alamedaGeoPolygon, 9, hexagons);
+    free(hexagons);
 });
 
 BENCHMARK(polyfillSouthernExpansion, 10, {
     numHexagons = H3_EXPORT(maxPolyfillSize)(&southernGeoPolygon, 9);
-    STACK_ARRAY_CALLOC(H3Index, hexagons, numHexagons);
+    hexagons = calloc(numHexagons, sizeof(H3Index));
     H3_EXPORT(polyfill)(&southernGeoPolygon, 9, hexagons);
+    free(hexagons);
 });
 
 END_BENCHMARKS();


### PR DESCRIPTION
Fixes #197 

It looks like it's failing as it allocates something on the stack (usually for procedure entry, in this case for stack allocation), pointing to a problem with `STACK_ARRAY_CALLOC`. I changed the benchmark to allocate on the heap instead. This does mean the benchmark now also covers allocating the memory on the heap, that could be removed from the benchmark by moving the call to `maxPolyfillSize` outside the benchmark.