### PR TITLE
Disable very verbose output in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ build_script:
 
 test_script:
   - ps: cd build
-  - ctest -VV -C "%CONFIG%"
+  - ctest -C "%CONFIG%"
   # Check that binding-functions was generated and has content
   - ps: |
       $ErrorActionPreference = "Stop"


### PR DESCRIPTION
I assume this is part of why the Appveyor build takes so long (regularly 20 minutes per configuration), hopefully this will at least reduce it a little. Jenkins runs the tests with `make test`, which does not enable very verbose output.