### PR TITLE
Constrain `coslon` in `_geoAzDistanceRads`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Fixed
 - `benchmarkPolyfill` allocates its memory on the heap (#198)
+- Fixed constraints of vertex longitudes (#213)
 
 ## [3.4.2] - 2019-02-21
 ### Changed

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -79,6 +79,26 @@ SUITE(h3Api) {
         t_assertBoundary(h3, &boundary);
     }
 
+    TEST(h3ToGeoBoundary_coslonConstrain) {
+        // Bug test for https://github.com/uber/h3/issues/212
+        H3Index h3 = 0x87dc6d364ffffffL;
+        GeoBoundary boundary;
+        boundary.numVerts = 6;
+        setGeoDegs(&boundary.verts[0], -52.0130533678236091,
+                   -34.6232931343713091);
+        setGeoDegs(&boundary.verts[1], -52.0041156384652012,
+                   -34.6096733160584549);
+        setGeoDegs(&boundary.verts[2], -51.9929610229502472,
+                   -34.6165157145896387);
+        setGeoDegs(&boundary.verts[3], -51.9907410568096608,
+                   -34.6369680004259877);
+        setGeoDegs(&boundary.verts[4], -51.9996738734672377,
+                   -34.6505896528323660);
+        setGeoDegs(&boundary.verts[5], -52.0108315681413629,
+                   -34.6437571897165668);
+        t_assertBoundary(h3, &boundary);
+    }
+
     TEST(version) {
         t_assert(H3_VERSION_MAJOR >= 0, "major version is set");
         t_assert(H3_VERSION_MINOR >= 0, "minor version is set");

--- a/src/h3lib/lib/geoCoord.c
+++ b/src/h3lib/lib/geoCoord.c
@@ -221,36 +221,36 @@ void _geoAzDistanceRads(const GeoCoord* p1, double az, double distance,
         if (fabs(p2->lat - M_PI_2) < EPSILON)  // north pole
         {
             p2->lat = M_PI_2;
-            p2->lon = 0.0L;
+            p2->lon = 0.0;
         } else if (fabs(p2->lat + M_PI_2) < EPSILON)  // south pole
         {
             p2->lat = -M_PI_2;
-            p2->lon = 0.0L;
+            p2->lon = 0.0;
         } else
             p2->lon = constrainLng(p1->lon);
     } else  // not due north or south
     {
         sinlat = sin(p1->lat) * cos(distance) +
                  cos(p1->lat) * sin(distance) * cos(az);
-        if (sinlat > 1.0L) sinlat = 1.0L;
-        if (sinlat < -1.0L) sinlat = -1.0L;
+        if (sinlat > 1.0) sinlat = 1.0;
+        if (sinlat < -1.0) sinlat = -1.0;
         p2->lat = asin(sinlat);
         if (fabs(p2->lat - M_PI_2) < EPSILON)  // north pole
         {
             p2->lat = M_PI_2;
-            p2->lon = 0.0L;
+            p2->lon = 0.0;
         } else if (fabs(p2->lat + M_PI_2) < EPSILON)  // south pole
         {
             p2->lat = -M_PI_2;
-            p2->lon = 0.0L;
+            p2->lon = 0.0;
         } else {
             sinlon = sin(az) * sin(distance) / cos(p2->lat);
             coslon = (cos(distance) - sin(p1->lat) * sin(p2->lat)) /
                      cos(p1->lat) / cos(p2->lat);
-            if (sinlon > 1.0L) sinlon = 1.0L;
-            if (sinlon < -1.0L) sinlon = -1.0L;
-            if (coslon > 1.0L) sinlon = 1.0L;
-            if (coslon < -1.0L) sinlon = -1.0L;
+            if (sinlon > 1.0) sinlon = 1.0;
+            if (sinlon < -1.0) sinlon = -1.0;
+            if (coslon > 1.0) coslon = 1.0;
+            if (coslon < -1.0) coslon = -1.0;
             p2->lon = constrainLng(p1->lon + atan2(sinlon, coslon));
         }
     }


### PR DESCRIPTION
#212 

This needs additional tests to cover all the branches in this function. Lcov doesn't report it, but the branches around lines 250~253 are uncovered. Lcov only reports lines, so we don't know about untested code like this. If we can't have the coverage tool we use report branch coverage, we should consider setting the formatter to put the branch condition always on a new line.

It looks like the vertex issue is likely a copy+paste error resulting in `coslon` being tested but `sinlon` being constrained. After fixing the index `87dc6d364ffffff` and it's neighbors look right.

Unrelated to this, I noticed that we are using long double constants in this file, which I don't think is necessary since the library was changed to use doubles. I changed the constants in this function but not the other places in the library.