### PR TITLE
Add branch coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ if(BUILD_TESTING)
             COMMAND bash "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/scripts/coverage.sh" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
         add_custom_target(clean-coverage
             # Before running coverage, clear all counters
-            COMMAND lcov --directory '${CMAKE_CURRENT_BINARY_DIR}' --zerocounters
+            COMMAND lcov --rc lcov_branch_coverage=1 --directory '${CMAKE_CURRENT_BINARY_DIR}' --zerocounters
             COMMENT "Zeroing counters"
             )
     endif()

--- a/scripts/coverage.sh.in
+++ b/scripts/coverage.sh.in
@@ -45,6 +45,6 @@ src_dir=${1:-"Missing source directory"}
 binary_dir=${2:-"Missing binary directory"}
 
 cd "${binary_dir}"
-lcov --directory . --capture --output-file coverage.info
-lcov --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
-genhtml -o coverage coverage.cleaned.info --title 'h3 coverage'
+lcov --rc lcov_branch_coverage=1 --directory . --capture --output-file coverage.info
+lcov --rc lcov_branch_coverage=1 --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
+genhtml --branch-coverage -o coverage coverage.cleaned.info --title 'h3 coverage'


### PR DESCRIPTION
See #214

This change makes `lcov`/`genhtml` report the branch coverage. Currently it reports 92.0% (971 of 1056 branches) locally. From taking a look at `linkedGeo.c` it seems to be reporting non-hit assertions as uncovered, which may be something we want to fix up later. `geoCoord.c` correctly shows some of the reachable branches as uncovered.