### PR TITLE
cython bindings

### DIFF
--- a/docs/community/bindings.md
+++ b/docs/community/bindings.md
@@ -43,6 +43,7 @@ As a C library, bindings can be made to call H3 functions from different program
 ## Python
 
 - [uber/h3-py](https://github.com/uber/h3-py)
+- [kwmsmith/h3-cython](https://github.com/kwmsmith/h3-cython)
 
 ## R
 


### PR DESCRIPTION
In-progress cython bindings. Current version is 0.0.* while developing. Runs and passes the current h3-py testsuite. As far as I can tell implements the full 3.4.2 H3 API, but would appreciate input and
feedback before cutting the 3.4.2 release.

Mac / Linux wheels available on PyPI for testing:

```
pip install h3cy
```