### PR TITLE
Add local IJ filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Added
+- `localIjToH3` filter application (#222)
+- An option to print distances in the `kRing` filter application (#222)
 ### Fixed
 - `benchmarkPolyfill` allocates its memory on the heap (#198)
 - Fixed constraints of vertex longitudes (#213)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(EXAMPLE_SOURCE_FILES
 set(OTHER_SOURCE_FILES
     src/apps/filters/h3ToGeo.c
     src/apps/filters/h3ToLocalIj.c
+    src/apps/filters/localIjToH3.c
     src/apps/filters/h3ToComponents.c
     src/apps/filters/geoToH3.c
     src/apps/filters/h3ToGeoBoundary.c
@@ -310,6 +311,7 @@ add_h3_executable(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToLocalIj src/apps/filters/h3ToLocalIj.c ${APP_SOURCE_FILES})
+add_h3_executable(localIjToH3 src/apps/filters/localIjToH3.c ${APP_SOURCE_FILES})
 add_h3_executable(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
 add_h3_executable(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
 add_h3_executable(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})

--- a/src/apps/filters/h3ToLocalIj.c
+++ b/src/apps/filters/h3ToLocalIj.c
@@ -21,13 +21,13 @@
  *
  *  The program reads H3 indexes from stdin and outputs the corresponding
  *  IJ coordinates to stdout, until EOF is encountered. `NA` is printed if the
- * IJ coordinates could not be obtained.
+ *  IJ coordinates could not be obtained.
  *
  *  `origin` indicates the origin (or anchoring) index for the IJ coordinate
  *  space.
  *
  *  This program has the same limitations as the `experimentalH3ToLocalIj`
- * function.
+ *  function.
  */
 
 #include <inttypes.h>

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2017, 2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,43 +17,57 @@
  * @brief stdin/stdout filter that converts from integer H3 indexes to
  * k-rings
  *
- *  usage: `kRing [k]`
+ *  usage: `kRing [k] [printDistances]`
  *
  *  The program reads H3 indexes from stdin until EOF and outputs
  *  the H3 indexes within k-ring `k` to stdout.
+ *
+ *  `printDistances` may be specified to also print the grid distance
+ *  from the origin index. Valid values are 0 to not print distances
+ *  (default) or 1 to print distances.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "algos.h"
-#include "h3Index.h"
-#include "stackAlloc.h"
+#include "h3api.h"
 #include "utility.h"
 
-void doCell(H3Index h, int k) {
+void doCell(H3Index h, int k, int printDistances) {
     int maxSize = H3_EXPORT(maxKringSize)(k);
     H3Index* rings = calloc(maxSize, sizeof(H3Index));
-    H3_EXPORT(kRing)(h, k, rings);
+    int* distances = calloc(maxSize, sizeof(int));
+    H3_EXPORT(kRingDistances)(h, k, rings, distances);
 
     for (int i = 0; i < maxSize; i++) {
         if (rings[i] != 0) {
-            h3Println(rings[i]);
+            h3Print(rings[i]);
+            if (printDistances) {
+                printf(" %d\n", distances[i]);
+            } else {
+                printf("\n");
+            }
         }
     }
 
+    free(distances);
     free(rings);
 }
 
 int main(int argc, char* argv[]) {
     // check command line args
-    if (argc != 2) {
-        fprintf(stderr, "usage: %s [k]\n", argv[0]);
+    if (argc != 2 && argc != 3) {
+        fprintf(stderr, "usage: %s [k] [printDistances]\n", argv[0]);
         exit(1);
     }
 
     int k = 0;
-    if (argc > 1) {
-        if (!sscanf(argv[1], "%d", &k)) error("k must be an integer");
+    if (!sscanf(argv[1], "%d", &k)) error("k must be an integer");
+
+    int printDistances = 0;
+    if (argc > 2) {
+        if (!sscanf(argv[2], "%d", &printDistances))
+            error("printDistances must be an integer");
     }
 
     // process the indexes on stdin
@@ -68,6 +82,6 @@ int main(int argc, char* argv[]) {
         }
 
         H3Index h3 = H3_EXPORT(stringToH3)(buff);
-        doCell(h3, k);
+        doCell(h3, k, printDistances);
     }
 }

--- a/src/apps/filters/localIjToH3.c
+++ b/src/apps/filters/localIjToH3.c
@@ -19,7 +19,9 @@
  *
  *  usage: `localIjToH3 [origin]`
  *
- *  The program reads IJ coordinates (in the format `i j` separated by newlines) from stdin and outputs the corresponding H3 indexes to stdout, until EOF is encountered. `NA` is printed if the H3 index could not be obtained.
+ *  The program reads IJ coordinates (in the format `i j` separated by newlines)
+ *  from stdin and outputs the corresponding H3 indexes to stdout, until EOF is
+ *  encountered. `NA` is printed if the H3 index could not be obtained.
  *
  *  `origin` indicates the origin (or anchoring) index for the IJ coordinate
  *  space.

--- a/src/apps/filters/localIjToH3.c
+++ b/src/apps/filters/localIjToH3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Uber Technologies, Inc.
+ * Copyright 2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,34 @@
  * limitations under the License.
  */
 /** @file
- * @brief stdin/stdout filter that converts from H3 indexes to local IJ
- * coordinates. This is experimental.
+ * @brief stdin/stdout filter that converts from local IJ coordinates to
+ * H3 indexes. This is experimental.
  *
- *  usage: `h3ToLocalIj [origin]`
+ *  usage: `localIjToH3 [origin]`
  *
- *  The program reads H3 indexes from stdin and outputs the corresponding
- *  IJ coordinates to stdout, until EOF is encountered. `NA` is printed if the
- * IJ coordinates could not be obtained.
+ *  The program reads IJ coordinates from stdin and outputs the corresponding
+ *  H3 indexes to stdout, until EOF is encountered. `NA` is printed if the H3
+ * index could not be obtained.
  *
  *  `origin` indicates the origin (or anchoring) index for the IJ coordinate
  *  space.
  *
- *  This program has the same limitations as the `experimentalH3ToLocalIj`
+ *  This program has the same limitations as the `experimentalLocalIjToH3`
  * function.
  */
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "coordijk.h"
-#include "h3Index.h"
 #include "h3api.h"
 #include "utility.h"
 
-void doCell(H3Index h, H3Index origin) {
-    CoordIJ ij;
-    if (H3_EXPORT(experimentalH3ToLocalIj)(origin, h, &ij)) {
+void doCell(const CoordIJ *ij, H3Index origin) {
+    H3Index h;
+    if (H3_EXPORT(experimentalLocalIjToH3)(origin, ij, &h)) {
         printf("NA\n");
     } else {
-        printf("%d %d\n", ij.i, ij.j);
+        h3Println(h);
     }
 }
 
@@ -61,18 +59,21 @@ int main(int argc, char *argv[]) {
 
     if (!H3_EXPORT(h3IsValid)(origin)) error("origin is invalid");
 
-    // process the indexes on stdin
+    // process the coordinates on stdin
     char buff[BUFF_SIZE];
     while (1) {
-        // get an index from stdin
+        // get coordinates from stdin
         if (!fgets(buff, BUFF_SIZE, stdin)) {
             if (feof(stdin))
                 break;
             else
-                error("reading H3 index from stdin");
+                error("reading IJ coordinates from stdin");
         }
 
-        H3Index h3 = H3_EXPORT(stringToH3)(buff);
-        doCell(h3, origin);
+        CoordIJ ij;
+        if (!sscanf(buff, "%d %d", &ij.i, &ij.j))
+            error("parsing IJ coordinates");
+
+        doCell(&ij, origin);
     }
 }

--- a/src/apps/filters/localIjToH3.c
+++ b/src/apps/filters/localIjToH3.c
@@ -19,15 +19,13 @@
  *
  *  usage: `localIjToH3 [origin]`
  *
- *  The program reads IJ coordinates from stdin and outputs the corresponding
- *  H3 indexes to stdout, until EOF is encountered. `NA` is printed if the H3
- * index could not be obtained.
+ *  The program reads IJ coordinates (in the format `i j` separated by newlines) from stdin and outputs the corresponding H3 indexes to stdout, until EOF is encountered. `NA` is printed if the H3 index could not be obtained.
  *
  *  `origin` indicates the origin (or anchoring) index for the IJ coordinate
  *  space.
  *
  *  This program has the same limitations as the `experimentalLocalIjToH3`
- * function.
+ *  function.
  */
 
 #include <inttypes.h>
@@ -52,11 +50,7 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
-    H3Index origin;
-
-    if (!sscanf(argv[1], "%" PRIx64, &origin))
-        error("origin could not be read");
-
+    H3Index origin = H3_EXPORT(stringToH3(argv[1]));
     if (!H3_EXPORT(h3IsValid)(origin)) error("origin is invalid");
 
     // process the coordinates on stdin
@@ -72,7 +66,7 @@ int main(int argc, char *argv[]) {
 
         CoordIJ ij;
         if (!sscanf(buff, "%d %d", &ij.i, &ij.j))
-            error("parsing IJ coordinates");
+            error("Parsing IJ coordinates. Expected `i j`.");
 
         doCell(&ij, origin);
     }

--- a/src/apps/miscapps/generateBaseCellNeighbors.c
+++ b/src/apps/miscapps/generateBaseCellNeighbors.c
@@ -161,7 +161,7 @@ static void generate() {
                         if (dir == K_AXES_DIGIT) {
                             // 4 and 117 are 'polar' type pentagons, which have
                             // some different behavior.
-                            if (i == 4 || i == 117) {
+                            if (_isBaseCellPentagon(i)) {
                                 _ijkRotate60cw(&ijk);
                                 _ijkRotate60cw(&ijk);
                             } else {
@@ -172,7 +172,7 @@ static void generate() {
 
                         // Adjust for the deleted k-subsequence distortion
                         int rotAdj = 0;
-                        if (i == 4 || i == 117) {
+                        if (_isBaseCellPolarPentagon(i)) {
                             // 'polar' type pentagon with all faces pointing
                             // towards i
                             if (dir == IK_AXES_DIGIT) {


### PR DESCRIPTION
This PR adds a new filter application, and adds a new option to `kRing` filter (to cover the `kRingDistances` function).

We should begin thinking about how to better handle command line arguments and help texts. We might want to consider either adding our own simple options library or depending on another one.

There's also a small code cleanup to not hard code the polar pentagon base cell identifiers.