### PR TITLE
Begin improving branch coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/testH3Distance.c
     src/apps/testapps/testH3Line.c
     src/apps/testapps/testCoordIj.c
+    src/apps/testapps/testCoordIjk.c
     src/apps/miscapps/h3ToGeoBoundaryHier.c
     src/apps/miscapps/h3ToGeoHier.c
     src/apps/miscapps/generateBaseCellNeighbors.c
@@ -485,6 +486,7 @@ if(BUILD_TESTING)
     add_h3_test(testH3Distance src/apps/testapps/testH3Distance.c)
     add_h3_test(testH3Line src/apps/testapps/testH3Line.c)
     add_h3_test(testCoordIj src/apps/testapps/testCoordIj.c)
+    add_h3_test(testCoordIjk src/apps/testapps/testCoordIjk.c)
     add_h3_test(testBaseCells src/apps/testapps/testBaseCells.c)
 
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 0)

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -232,9 +232,9 @@ SUITE(BBox) {
         west.west += 0.1;
 
         t_assert(bboxEquals(&bbox, &bbox), "Equals self");
-        t_assert(!bboxEquals(&bbox, &north), "Equals different north");
-        t_assert(!bboxEquals(&bbox, &south), "Equals different south");
-        t_assert(!bboxEquals(&bbox, &east), "Equals different east");
-        t_assert(!bboxEquals(&bbox, &west), "Equals different west");
+        t_assert(!bboxEquals(&bbox, &north), "Not equals different north");
+        t_assert(!bboxEquals(&bbox, &south), "Not equals different south");
+        t_assert(!bboxEquals(&bbox, &east), "Not equals different east");
+        t_assert(!bboxEquals(&bbox, &west), "Not equals different west");
     }
 }

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -219,4 +219,22 @@ SUITE(BBox) {
         t_assert(bboxIsTransmeridian(&bboxTransmeridian),
                  "Transmeridian bbox is transmeridian");
     }
+
+    TEST(bboxEquals) {
+        BBox bbox = {1.0, 0.0, 1.0, 0.0};
+        BBox north = bbox;
+        north.north += 0.1;
+        BBox south = bbox;
+        south.south += 0.1;
+        BBox east = bbox;
+        east.east += 0.1;
+        BBox west = bbox;
+        west.west += 0.1;
+
+        t_assert(bboxEquals(&bbox, &bbox), "Equals self");
+        t_assert(!bboxEquals(&bbox, &north), "Equals different north");
+        t_assert(!bboxEquals(&bbox, &south), "Equals different south");
+        t_assert(!bboxEquals(&bbox, &east), "Equals different east");
+        t_assert(!bboxEquals(&bbox, &west), "Equals different west");
+    }
 }

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -23,6 +23,8 @@ H3Index sunnyvale = 0x89283470c27ffff;
 
 H3Index uncompactable[] = {0x89283470803ffff, 0x8928347081bffff,
                            0x8928347080bffff};
+H3Index uncompactableWithZero[] = {0x89283470803ffff, 0x8928347081bffff, 0,
+                                   0x8928347080bffff};
 
 SUITE(compact) {
     TEST(roundtrip) {
@@ -205,6 +207,45 @@ SUITE(compact) {
 
         free(children);
         free(result);
+    }
+
+    TEST(uncompact_onlyZero) {
+        // maxUncompactSize and uncompact both permit 0 indexes
+        // in the input array, and skip them. When only a zero is
+        // given, it's a no-op.
+
+        H3Index origin = 0;
+
+        int childrenSz = H3_EXPORT(maxUncompactSize)(&origin, 1, 2);
+        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        int uncompactResult =
+            H3_EXPORT(uncompact)(&origin, 1, children, childrenSz, 2);
+        t_assert(uncompactResult == 0, "uncompact only zero success");
+
+        free(children);
+    }
+
+    TEST(uncompactZero) {
+        // maxUncompactSize and uncompact both permit 0 indexes
+        // in the input array, and skip them.
+
+        int childrenSz =
+            H3_EXPORT(maxUncompactSize)(uncompactableWithZero, 4, 10);
+        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        int uncompactResult = H3_EXPORT(uncompact)(&uncompactableWithZero, 4,
+                                                   children, childrenSz, 10);
+        t_assert(uncompactResult == 0, "uncompact with zero succeeds");
+
+        int found = 0;
+        for (int i = 0; i < childrenSz; i++) {
+            if (children[i] != 0) {
+                found++;
+            }
+        }
+        t_assert(found == childrenSz,
+                 "uncompacted with zero to expected number of hexagons");
+
+        free(children);
     }
 
     TEST(pentagon) {

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -232,7 +232,7 @@ SUITE(compact) {
         int childrenSz =
             H3_EXPORT(maxUncompactSize)(uncompactableWithZero, 4, 10);
         H3Index* children = calloc(childrenSz, sizeof(H3Index));
-        int uncompactResult = H3_EXPORT(uncompact)(&uncompactableWithZero, 4,
+        int uncompactResult = H3_EXPORT(uncompact)(uncompactableWithZero, 4,
                                                    children, childrenSz, 10);
         t_assert(uncompactResult == 0, "uncompact with zero succeeds");
 

--- a/src/apps/testapps/testCoordIjk.c
+++ b/src/apps/testapps/testCoordIjk.c
@@ -34,7 +34,7 @@ SUITE(coordIjk) {
         t_assert(_unitIjkToDigit(&outOfRange) == INVALID_DIGIT,
                  "Unit IJK out of range");
         t_assert(_unitIjkToDigit(&unnormalizedZero) == CENTER_DIGIT,
-                 "Unit IJK to zero");
+                 "Unnormalized unit IJK to zero");
     }
 
     TEST(_neighbor) {

--- a/src/apps/testapps/testCoordIjk.c
+++ b/src/apps/testapps/testCoordIjk.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief tests IJK grid functions
+ *
+ *  usage: `testCoordIjk`
+ */
+
+#include "coordijk.h"
+#include "test.h"
+
+SUITE(coordIjk) {
+    TEST(_unitIjkToDigit) {
+        CoordIJK zero = {0};
+        CoordIJK i = {1, 0, 0};
+        CoordIJK outOfRange = {2, 0, 0};
+        CoordIJK unnormalizedZero = {2, 2, 2};
+
+        t_assert(_unitIjkToDigit(&zero) == CENTER_DIGIT, "Unit IJK to zero");
+        t_assert(_unitIjkToDigit(&i) == I_AXES_DIGIT, "Unit IJK to I axis");
+        t_assert(_unitIjkToDigit(&outOfRange) == INVALID_DIGIT,
+                 "Unit IJK out of range");
+        t_assert(_unitIjkToDigit(&unnormalizedZero) == CENTER_DIGIT,
+                 "Unit IJK to zero");
+    }
+
+    TEST(_neighbor) {
+        CoordIJK ijk = {0};
+
+        CoordIJK zero = {0};
+        CoordIJK i = {1, 0, 0};
+
+        _neighbor(&ijk, CENTER_DIGIT);
+        t_assert(_ijkMatches(&ijk, &zero), "Center neighbor is self");
+        _neighbor(&ijk, I_AXES_DIGIT);
+        t_assert(_ijkMatches(&ijk, &i), "I neighbor as expected");
+        _neighbor(&ijk, INVALID_DIGIT);
+        t_assert(_ijkMatches(&ijk, &i), "Invalid neighbor is self");
+    }
+}

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -64,6 +64,8 @@ SUITE(h3UniEdge) {
         H3_SET_MODE(sfBroken, H3_UNIEDGE_MODE);
         t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBroken) == 0,
                  "broken H3Indexes can't be neighbors");
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sfBroken, sf) == 0,
+                 "broken H3Indexes can't be neighbors (reversed)");
 
         H3Index sfBigger = H3_EXPORT(geoToH3)(&sfGeo, 7);
         t_assert(H3_EXPORT(h3IndexesAreNeighbors)(sf, sfBigger) == 0,
@@ -147,6 +149,11 @@ SUITE(h3UniEdge) {
         H3_SET_MODE(fakeEdge, H3_UNIEDGE_MODE);
         t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(fakeEdge) == 0,
                  "edges without an edge specified don't work");
+        H3Index invalidEdge = sf;
+        H3_SET_MODE(invalidEdge, H3_UNIEDGE_MODE);
+        H3_SET_RESERVED_BITS(invalidEdge, INVALID_DIGIT);
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(invalidEdge) == 0,
+                 "edges with an invalid edge specified don't work");
 
         H3Index pentagon = 0x821c07fffffffff;
         H3Index goodPentagonalEdge = pentagon;

--- a/src/apps/testapps/testHexRanges.c
+++ b/src/apps/testapps/testHexRanges.c
@@ -25,6 +25,7 @@ SUITE(hexRanges) {
 
     H3Index k1[] = {0x89283080ddbffff, 0x89283080c37ffff, 0x89283080c27ffff,
                     0x89283080d53ffff, 0x89283080dcfffff, 0x89283080dc3ffff};
+    H3Index withPentagon[] = {0x8029fffffffffff, 0x801dfffffffffff};
 
     TEST(identityKRing) {
         int err;
@@ -73,5 +74,14 @@ SUITE(hexRanges) {
             }
         }
         free(allKrings2);
+    }
+
+    TEST(failed) {
+        int err;
+        H3Index* allKrings = calloc(2 * (1 + 6), sizeof(H3Index));
+        err = H3_EXPORT(hexRanges)(withPentagon, 2, 1, allKrings);
+
+        t_assert(err != 0, "Error on hexRanges");
+        free(allKrings);
     }
 }

--- a/src/apps/testapps/testHexRanges.c
+++ b/src/apps/testapps/testHexRanges.c
@@ -81,7 +81,7 @@ SUITE(hexRanges) {
         H3Index* allKrings = calloc(2 * (1 + 6), sizeof(H3Index));
         err = H3_EXPORT(hexRanges)(withPentagon, 2, 1, allKrings);
 
-        t_assert(err != 0, "Error on hexRanges");
+        t_assert(err != 0, "Expected error on hexRanges");
         free(allKrings);
     }
 }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -388,11 +388,11 @@ int H3_EXPORT(uncompact)(const H3Index* compactedSet, const int numHexes,
                          H3Index* h3Set, const int maxHexes, const int res) {
     int outOffset = 0;
     for (int i = 0; i < numHexes; i++) {
+        if (compactedSet[i] == 0) continue;
         if (outOffset >= maxHexes) {
             // We went too far, abort!
             return -1;
         }
-        if (compactedSet[i] == 0) continue;
         int currentRes = H3_GET_RESOLUTION(compactedSet[i]);
         if (currentRes > res) {
             // Nonsensical. Abort.


### PR DESCRIPTION
Begin adding additional branch coverage.

```
Now
Overall coverage rate:
  lines......: 100.0% (1866 of 1866 lines)
  functions..: 100.0% (163 of 163 functions)
  branches...: 92.9% (981 of 1056 branches)

Previous
Overall coverage rate:
  lines......: 100.0% (1866 of 1866 lines)
  functions..: 100.0% (163 of 163 functions)
  branches...: 92.0% (971 of 1056 branches)
```

A few things I noted:
* Some branches may be unreachable, e.g. because you couldn't construct an H3Index with a resolution below 0. Similar for assertions.
* LCov looks inside macros like `isfinite`, which is implementation defined and may contain branches. This can cause differences in reported coverage.
* LCOV_EXCL_LINE doesn't also exclude the branch leading to it.