### PR TITLE
Add argument parsing

### DIFF
--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -105,4 +105,11 @@ void iterateAllIndexesAtRes(int res, void (*callback)(H3Index));
 void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
                                    int maxBaseCell);
 
+int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
+                   const Arg* helpArg, const char** errorMessage,
+                   const char** errorDetail);
+void _printHelp(FILE* out, const char* programName, const char* helpText,
+                int numArgs, Arg* args[], const char* errorMessage,
+                const char* errorDetails);
+
 #endif

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -86,11 +86,7 @@ typedef struct {
 // prototypes
 
 int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
-              char** errorMessage, char** errorDetail);
-
-void printHelp(FILE* out, const char* programName, const char* helpText,
-               int numArgs, const Arg* args[], const char* errorMessage,
-               const char* errorDetails);
+              const Arg* helpArg, const char* helpText);
 
 void error(const char* msg);
 void h3Print(H3Index h);    // prints as integer

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -50,11 +50,6 @@ typedef struct {
     const bool required;
 
     /**
-     * If true, this argument suppresses checking for required arguments.
-     */
-    const bool isHelp;
-
-    /**
      * Scan format for the argument, which will be passed to sscanf. May be null
      * to indicate the argument does not take a value.
      */

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -41,46 +41,46 @@ typedef struct {
      * Both short and long names of the argument. A name may be null, but the
      * first name must be non-null.
      */
-    const char* names[NUM_ARG_NAMES];
+    const char* const names[NUM_ARG_NAMES];
 
     /**
      * If true, this argument must be specified. If the argument is not
      * specified, argument parsing will fail.
      */
-    bool required;
+    const bool required;
 
     /**
      * If true, this argument suppresses checking for required arguments.
      */
-    bool isHelp;
+    const bool isHelp;
 
     /**
      * Scan format for the argument, which will be passed to sscanf. May be null
      * to indicate the argument does not take a value.
      */
-    const char* scanFormat;
+    const char* const scanFormat;
 
     /**
      * Name to present the value as when printing help.
      */
-    const char* valueName;
+    const char* const valueName;
 
     /**
      * Value will be placed here if the argument is present and scanFormat is
      * not null.
      */
-    void* value;
+    void* const value;
 
     /**
      * Will be set to true if the argument is present and the pointer is not
      * null.
      */
-    bool* valuePresent;
+    bool* const valuePresent;
 
     /**
      * Help text for this argument.
      */
-    const char* helpText;
+    const char* const helpText;
 } Arg;
 
 // prototypes

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -29,7 +29,68 @@
 /** Macro: Get the size of a fixed-size array */
 #define ARRAY_SIZE(x) sizeof(x) / sizeof(x[0])
 
+/** Maximum number of names an argument may have. */
+#define NUM_ARG_NAMES 2
+
+/**
+ * An argument accepted by on the command line of an H3 application. Specifies how the argument is presented, parsed, and where parsed values are stored.
+ */
+typedef struct {
+    /**
+     * Both short and long names of the argument. A name may be null, but the
+     * first name must be non-null.
+     */
+    const char* names[NUM_ARG_NAMES];
+
+    /**
+     * If true, this argument must be specified. If the argument is not
+     * specified, argument parsing will fail.
+     */
+    bool required;
+
+    /**
+     * If true, this argument suppresses checking for required arguments.
+     */
+    bool isHelp;
+
+    /**
+     * Scan format for the argument, which will be passed to sscanf. May be null
+     * to indicate the argument does not take a value.
+     */
+    const char* scanFormat;
+
+    /**
+     * Name to present the value as when printing help.
+     */
+    const char* valueName;
+
+    /**
+     * Value will be placed here if the argument is present and scanFormat is
+     * not null.
+     */
+    void* value;
+
+    /**
+     * Will be set to true if the argument is present and the pointer is not
+     * null.
+     */
+    bool* valuePresent;
+
+    /**
+     * Help text for this argument.
+     */
+    const char* helpText;
+} Arg;
+
 // prototypes
+
+int parseArgs(int argc, char* argv[], int numArgs, const Arg* args,
+              char** errorMessage, char** errorDetail);
+
+void printHelp(FILE* out, const char* programName, const char* helpText,
+               int numArgs, const Arg* args, const char* errorMessage,
+               const char* errorDetails);
+
 void error(const char* msg);
 void h3Print(H3Index h);    // prints as integer
 void h3Println(H3Index h);  // prints as integer

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -72,10 +72,10 @@ typedef struct {
     void* const value;
 
     /**
-     * Will be set to true if the argument is present and the pointer is not
-     * null.
+     * Will be set to true if the argument is present. Should be false when
+     * passed in to parseArgs.
      */
-    bool* const valuePresent;
+    bool found;
 
     /**
      * Help text for this argument.
@@ -85,11 +85,11 @@ typedef struct {
 
 // prototypes
 
-int parseArgs(int argc, char* argv[], int numArgs, const Arg* args,
+int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
               char** errorMessage, char** errorDetail);
 
 void printHelp(FILE* out, const char* programName, const char* helpText,
-               int numArgs, const Arg* args, const char* errorMessage,
+               int numArgs, const Arg* args[], const char* errorMessage,
                const char* errorDetails);
 
 void error(const char* msg);

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -33,7 +33,8 @@
 #define NUM_ARG_NAMES 2
 
 /**
- * An argument accepted by on the command line of an H3 application. Specifies how the argument is presented, parsed, and where parsed values are stored.
+ * An argument accepted by on the command line of an H3 application. Specifies
+ * how the argument is presented, parsed, and where parsed values are stored.
  */
 typedef struct {
     /**

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -52,7 +52,7 @@
  * than once.
  *
  * Help is printed to stdout if a argument with isHelp = true is found, and help
- * si printed to stderr if argument parsing fails.
+ * is printed to stderr if argument parsing fails.
  *
  * @param argc argc from main
  * @param argv argv from main

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -35,7 +35,8 @@
  * Uses the provided arguments to populate argument values.
  *
  * Returns non-zero if all required arguments are not present, an argument fails
- * to parse, is missing its associated value, or arguments are specified more than once.
+ * to parse, is missing its associated value, or arguments are specified more
+ * than once.
  *
  * @param argc argc from main
  * @param argv argv from main

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -54,13 +54,16 @@
  * @param argv argv from main
  * @param numArgs Number of elements in the args array
  * @param args Pointer to each argument to parse.
+ * @param helpArg Pointer to the argument for "--help" that suppresses checking
+ * for required arguments.
  * @param errorMessage Error message to display, if returning non-zero.
  * @param errorDetail Additional error details, if returning non-zero. May be
  * null, and may be a pointer from `argv` or `args`.
  * @return 0 if argument parsing succeeded, otherwise non-0.
  */
 int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
-                   const char** errorMessage, const char** errorDetail) {
+                   const Arg* helpArg, const char** errorMessage,
+                   const char** errorDetail) {
     // Whether help was found and required arguments do not need to be checked
     bool foundHelp = false;
 
@@ -106,7 +109,7 @@ int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
                 }
             }
 
-            if (args[j]->isHelp) {
+            if (args[j] == helpArg) {
                 foundHelp = true;
             }
 
@@ -206,8 +209,8 @@ int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
     const char* errorMessage = NULL;
     const char* errorDetails = NULL;
 
-    int failed =
-        _parseArgsList(argc, argv, 4, args, &errorMessage, &errorDetails);
+    int failed = _parseArgsList(argc, argv, 4, args, helpArg, &errorMessage,
+                                &errorDetails);
 
     if (failed || helpArg->found) {
         _printHelp(helpArg->found ? stdout : stderr, argv[0], helpText, numArgs,

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -42,6 +42,44 @@
 #define PARSE_ARGS_MISSING_REQUIRED 6
 
 /**
+ * Parse command line arguments and prints help, if needed.
+ *
+ * Uses the provided arguments to populate argument values and records in the
+ * argument if it is found.
+ *
+ * Returns non-zero if all required arguments are not present, an argument fails
+ * to parse, is missing its associated value, or arguments are specified more
+ * than once.
+ *
+ * Help is printed to stdout if a argument with isHelp = true is found, and help
+ * si printed to stderr if argument parsing fails.
+ *
+ * @param argc argc from main
+ * @param argv argv from main
+ * @param numArgs Number of elements in the args array
+ * @param args Pointer to each argument to parse
+ * @param helpArg Pointer to the argument for "--help"
+ * @param helpText Explanatory text for this program printed with help
+ * @return 0 if argument parsing succeeded, otherwise non-0. If help is printed,
+ * return value is non-0.
+ */
+int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
+              const Arg* helpArg, const char* helpText) {
+    const char* errorMessage = NULL;
+    const char* errorDetails = NULL;
+
+    int failed = _parseArgsList(argc, argv, 4, args, helpArg, &errorMessage,
+                                &errorDetails);
+
+    if (failed || helpArg->found) {
+        _printHelp(helpArg->found ? stdout : stderr, argv[0], helpText, numArgs,
+                   args, errorMessage, errorDetails);
+        return failed != PARSE_ARGS_SUCCESS ? failed : PARSE_ARGS_HELP;
+    }
+    return PARSE_ARGS_SUCCESS;
+}
+
+/**
  * Parse command line arguments.
  *
  * Uses the provided arguments to populate argument values.
@@ -180,44 +218,6 @@ void _printHelp(FILE* out, const char* programName, const char* helpText,
         }
         fprintf(out, "%s\n", args[i]->helpText);
     }
-}
-
-/**
- * Parse command line arguments and prints help, if needed.
- *
- * Uses the provided arguments to populate argument values and records in the
- * argument if it is found.
- *
- * Returns non-zero if all required arguments are not present, an argument fails
- * to parse, is missing its associated value, or arguments are specified more
- * than once.
- *
- * Help is printed to stdout if a argument with isHelp = true is found, and help
- * si printed to stderr if argument parsing fails.
- *
- * @param argc argc from main
- * @param argv argv from main
- * @param numArgs Number of elements in the args array
- * @param args Pointer to each argument to parse
- * @param helpArg Pointer to the argument for "--help"
- * @param helpText Explanatory text for this program printed with help
- * @return 0 if argument parsing succeeded, otherwise non-0. If help is printed,
- * return value is non-0.
- */
-int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
-              const Arg* helpArg, const char* helpText) {
-    const char* errorMessage = NULL;
-    const char* errorDetails = NULL;
-
-    int failed = _parseArgsList(argc, argv, 4, args, helpArg, &errorMessage,
-                                &errorDetails);
-
-    if (failed || helpArg->found) {
-        _printHelp(helpArg->found ? stdout : stderr, argv[0], helpText, numArgs,
-                   args, errorMessage, errorDetails);
-        return failed != PARSE_ARGS_SUCCESS ? failed : PARSE_ARGS_HELP;
-    }
-    return PARSE_ARGS_SUCCESS;
 }
 
 void error(const char* msg) {

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -59,7 +59,6 @@ int main(int argc, char* argv[]) {
     H3Index origin = 0;
 
     Arg helpArg = {.names = {"-h", "--help"},
-                   .isHelp = true,
                    .helpText = "Show this help message"};
     Arg kArg = {.names = {"-k", NULL},
                 .required = true,

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -17,16 +17,16 @@
  * @brief stdin/stdout filter that converts from integer H3 indexes to
  * k-rings
  *
- *  usage: `kRing [k] [printDistances]`
+ *  usage: `kRing -k <k> [--print-distances] [--origin origin]`
  *
  *  The program reads H3 indexes from stdin until EOF and outputs
  *  the H3 indexes within k-ring `k` to stdout.
  *
- *  `printDistances` may be specified to also print the grid distance
- *  from the origin index. Valid values are 0 to not print distances
- *  (default) or 1 to print distances.
+ *  --print-distances may be specified to also print the grid distance
+ *  from the origin index.
  */
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -55,33 +55,61 @@ void doCell(H3Index h, int k, int printDistances) {
 }
 
 int main(int argc, char* argv[]) {
-    // check command line args
-    if (argc != 2 && argc != 3) {
-        fprintf(stderr, "usage: %s [k] [printDistances]\n", argv[0]);
-        exit(1);
-    }
-
+    bool helpArg = false;
     int k = 0;
-    if (!sscanf(argv[1], "%d", &k)) error("k must be an integer");
+    bool printDistances = false;
+    H3Index origin = 0;
+    bool originPresent;
+    Arg args[] = {
+        {.names = {"-h", "--help"},
+         .isHelp = true,
+         .valuePresent = &helpArg,
+         .helpText = "Show this help message"},
+        {.names = {"-k", NULL},
+         .required = true,
+         .scanFormat = "%d",
+         .valueName = "k",
+         .value = &k,
+         .helpText = "Radius of hexagons"},
+        {.names = {"-d", "--print-distances"},
+         .valuePresent = &printDistances,
+         .helpText = "Print distance from origin after index"},
+        {.names = {"-o", "--origin"},
+         .scanFormat = "%" PRIx64,
+         .valueName = "origin",
+         .value = &origin,
+         .valuePresent = &originPresent,
+         .helpText =
+             "Origin, or not specified to read origins from standard in"}};
 
-    int printDistances = 0;
-    if (argc > 2) {
-        if (!sscanf(argv[2], "%d", &printDistances))
-            error("printDistances must be an integer");
+    char* errorMessage = NULL;
+    char* errorDetails = NULL;
+    if (parseArgs(argc, argv, 4, args, &errorMessage, &errorDetails) ||
+        helpArg) {
+        printHelp(helpArg ? stdout : stderr, argv[0],
+                  "Print indexes k distance away from the origin", 4, args,
+                  errorMessage, errorDetails);
+        free(errorMessage);
+        free(errorDetails);
+        return helpArg ? 0 : 1;
     }
 
-    // process the indexes on stdin
-    char buff[BUFF_SIZE];
-    while (1) {
-        // get an index from stdin
-        if (!fgets(buff, BUFF_SIZE, stdin)) {
-            if (feof(stdin))
-                break;
-            else
-                error("reading H3 index from stdin");
-        }
+    if (originPresent) {
+        doCell(origin, k, printDistances);
+    } else {
+        // process the indexes on stdin
+        char buff[BUFF_SIZE];
+        while (1) {
+            // get an index from stdin
+            if (!fgets(buff, BUFF_SIZE, stdin)) {
+                if (feof(stdin))
+                    break;
+                else
+                    error("reading H3 index from stdin");
+            }
 
-        H3Index h3 = H3_EXPORT(stringToH3)(buff);
-        doCell(h3, k, printDistances);
+            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            doCell(h3, k, printDistances);
+        }
     }
 }

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -80,15 +80,8 @@ int main(int argc, char* argv[]) {
 
     Arg* args[] = {&helpArg, &kArg, &printDistancesArg, &originArg};
 
-    char* errorMessage = NULL;
-    char* errorDetails = NULL;
-    if (parseArgs(argc, argv, 4, args, &errorMessage, &errorDetails) ||
-        helpArg.found) {
-        printHelp(helpArg.found ? stdout : stderr, argv[0],
-                  "Print indexes k distance away from the origin", 4, args,
-                  errorMessage, errorDetails);
-        free(errorMessage);
-        free(errorDetails);
+    if (parseArgs(argc, argv, 4, args, &helpArg,
+                  "Print indexes k distance away from the origin")) {
         return helpArg.found ? 0 : 1;
     }
 

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -55,47 +55,45 @@ void doCell(H3Index h, int k, int printDistances) {
 }
 
 int main(int argc, char* argv[]) {
-    bool helpArg = false;
     int k = 0;
-    bool printDistances = false;
     H3Index origin = 0;
-    bool originPresent = false;
-    Arg args[] = {
-        {.names = {"-h", "--help"},
-         .isHelp = true,
-         .valuePresent = &helpArg,
-         .helpText = "Show this help message"},
-        {.names = {"-k", NULL},
-         .required = true,
-         .scanFormat = "%d",
-         .valueName = "k",
-         .value = &k,
-         .helpText = "Radius of hexagons"},
-        {.names = {"-d", "--print-distances"},
-         .valuePresent = &printDistances,
-         .helpText = "Print distance from origin after index"},
-        {.names = {"-o", "--origin"},
-         .scanFormat = "%" PRIx64,
-         .valueName = "origin",
-         .value = &origin,
-         .valuePresent = &originPresent,
-         .helpText =
-             "Origin, or not specified to read origins from standard in"}};
+
+    Arg helpArg = {.names = {"-h", "--help"},
+                   .isHelp = true,
+                   .helpText = "Show this help message"};
+    Arg kArg = {.names = {"-k", NULL},
+                .required = true,
+                .scanFormat = "%d",
+                .valueName = "k",
+                .value = &k,
+                .helpText = "Radius of hexagons"};
+    Arg printDistancesArg = {
+        .names = {"-d", "--print-distances"},
+        .helpText = "Print distance from origin after index"};
+    Arg originArg = {
+        .names = {"-o", "--origin"},
+        .scanFormat = "%" PRIx64,
+        .valueName = "origin",
+        .value = &origin,
+        .helpText =
+            "Origin, or not specified to read origins from standard in"};
+
+    Arg* args[] = {&helpArg, &kArg, &printDistancesArg, &originArg};
 
     char* errorMessage = NULL;
     char* errorDetails = NULL;
     if (parseArgs(argc, argv, 4, args, &errorMessage, &errorDetails) ||
-        helpArg) {
-        printHelp(helpArg ? stdout : stderr, argv[0],
+        helpArg.found) {
+        printHelp(helpArg.found ? stdout : stderr, argv[0],
                   "Print indexes k distance away from the origin", 4, args,
                   errorMessage, errorDetails);
         free(errorMessage);
         free(errorDetails);
-        return helpArg ? 0 : 1;
+        return helpArg.found ? 0 : 1;
     }
 
-    if (originPresent) {
-        doCell(origin, k, printDistances);
+    if (originArg.found) {
+        doCell(origin, k, printDistancesArg.found);
     } else {
         // process the indexes on stdin
         char buff[BUFF_SIZE];
@@ -109,7 +107,7 @@ int main(int argc, char* argv[]) {
             }
 
             H3Index h3 = H3_EXPORT(stringToH3)(buff);
-            doCell(h3, k, printDistances);
+            doCell(h3, k, printDistancesArg.found);
         }
     }
 }

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
     int k = 0;
     bool printDistances = false;
     H3Index origin = 0;
-    bool originPresent;
+    bool originPresent = false;
     Arg args[] = {
         {.names = {"-h", "--help"},
          .isHelp = true,


### PR DESCRIPTION
Changes the `kRing` filter to use a new options parsing function. This is only applied to `kRing` at first to discuss the argument parsing itself, once this is OK'd it can be expanded to the other filter applications.