### PR TITLE
Note that only zero input to uncompact is no longer an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The public API of this library consists of the functions declared in file
 ### Fixed
 - `benchmarkPolyfill` allocates its memory on the heap (#198)
 - Fixed constraints of vertex longitudes (#213)
+- Zero only input to `uncompact` does not produce an error (#223)
 
 ## [3.4.2] - 2019-02-21
 ### Changed


### PR DESCRIPTION
Unfortunately this wasn't listed in the `v3.4.3` tag, but it is a user visible change that uber/h3-java#44 needed to be updated for.