### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ before_script:
   - mkdir build
   - cd build
   - cmake -DWARNINGS_AS_ERRORS=ON ..
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 
 # Build and test the library, then build and test the examples.
 script:
@@ -79,3 +80,4 @@ script:
   - cmake ../../examples
   - make
   - make test
+  - fossa


### PR DESCRIPTION
Hello, I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.

I noticed that this project is predominantly C. How are you vendoring third-party code for this project? Is all the third-party code placed in a subdirectory?