### PR TITLE
Add release script to prompt for changelog entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,12 @@ else()
         )
 endif()
 
+# Release publishing
+add_custom_target(update-version
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/update_version.sh
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
 # Website publishing
 add_custom_target(publish-website
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/publish_website.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 1. Create a PR "Preparing for release X.Y.Z" against master branch
     * Alter CHANGELOG.md from `[Unreleased]` to `[X.Y.Z] YYYY-MM-DD`
-    * Run `scripts/update_version.sh` and give `X.Y.Z` when prompted
+    * Run `make update-version` and give `X.Y.Z` when prompted
     * Check that all merges that need to be in the changelog are present
 
 2. Create a release "Release X.Y.Z" on Github

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 # Release Process
 
 1. Create a PR "Preparing for release X.Y.Z" against master branch
-    * Update VERSION to `X.Y.Z`
     * Alter CHANGELOG.md from `[Unreleased]` to `[X.Y.Z] YYYY-MM-DD`
+    * Run `scripts/update_version.sh` and give `X.Y.Z` when prompted
+    * Check that all merges that need to be in the changelog are present
 
 2. Create a release "Release X.Y.Z" on Github
     * Create Tag `vX.Y.Z`

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -16,7 +16,7 @@
 # This script is used interactively as part of the H3 release process 
 # (RELEASE.md) to update the version number in the VERSION file. Before
 # writing the new version to the file, changelog information is presented
-# for verification.
+# for verification. It is invoked by the make target `update-version`.
 
 set -eo pipefail
 
@@ -45,5 +45,6 @@ if [ "y" = "$CHANGELOG_OK" ] || [ "Y" = "$CHANGELOG_OK" ]; then
     echo "Wrote $NEXT_VERSION to the VERSION file"
 else
     echo "Cancelled - did not write VERSION file"
+    echo "Please update the CHANGELOG with the appropriate entries before bumping the version."
     exit 2
 fi

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used interactively as part of the H3 release process 
+# (RELEASE.md) to update the version number in the VERSION file. Before
+# writing the new version to the file, changelog information is presented
+# for verification.
+
+set -eo pipefail
+
+CURRENT_VERSION=$(<VERSION)
+echo "Current version: $CURRENT_VERSION"
+CURRENT_TAG="v$CURRENT_VERSION"
+
+if ! git rev-parse $CURRENT_TAG -- > /dev/null 2>&1; then
+    echo "Could not locate $CURRENT_TAG as a Git revision."
+    exit 1
+fi
+
+REVISION_RANGE="$CURRENT_TAG..HEAD"
+
+read -p "Next version: " NEXT_VERSION
+
+echo -e "\n * Changelog entries *"
+git diff $REVISION_RANGE -- CHANGELOG.md
+echo -e "\n * Committed merges *"
+git log --merges --oneline $REVISION_RANGE
+
+echo
+read -p "Are all changes in the changelog [y/N]? " CHANGELOG_OK
+if [ "y" = "$CHANGELOG_OK" ] || [ "Y" = "$CHANGELOG_OK" ]; then
+    echo $NEXT_VERSION > VERSION
+    echo "Wrote $NEXT_VERSION to the VERSION file"
+else
+    echo "Cancelled - did not write VERSION file"
+    exit 2
+fi


### PR DESCRIPTION
Change the release process to use this script, which prompts the user to review CHANGELOG.md and any merge commits, that is any PRs merged, before writing the new version number.