### PR TITLE
Add BUILD_BENCHMARKS, BUILD_FILTERS to CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The public API of this library consists of the functions declared in file
 
 ## [Unreleased]
 ### Added
-- CMake options for excluding filter applications or benchmarks from the build.
+- CMake options for excluding filter applications or benchmarks from the build. (#247)
 
 ## [3.4.4] - 2019-05-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Added
+- CMake options for excluding filter applications or benchmarks from the build.
 
 ## [3.4.4] - 2019-05-30
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017, 2018 Uber Technologies, Inc.
+# Copyright 2017-2019 Uber Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
     "Toolchain to use for building this project")
 
 option(ENABLE_COVERAGE "Enable compiling tests with coverage." ON)
+option(BUILD_BENCHMARKS "Build benchmarking applications." ON)
+option(BUILD_FILTERS "Build filter applications." ON)
 
 if(WIN32)
     set(SHELL PowerShell -Command)
@@ -301,43 +303,45 @@ macro(add_h3_executable name)
     endif()
 endmacro()
 
-add_h3_executable(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToLocalIj src/apps/filters/h3ToLocalIj.c ${APP_SOURCE_FILES})
-add_h3_executable(localIjToH3 src/apps/filters/localIjToH3.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
-add_h3_executable(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
-add_h3_executable(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})
-add_h3_executable(generateBaseCellNeighbors src/apps/miscapps/generateBaseCellNeighbors.c ${APP_SOURCE_FILES})
-add_h3_executable(generateNumHexagons src/apps/miscapps/generateNumHexagons.c ${APP_SOURCE_FILES})
-add_h3_executable(generateFaceCenterPoint src/apps/miscapps/generateFaceCenterPoint.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToGeoBoundaryHier src/apps/miscapps/h3ToGeoBoundaryHier.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToGeoHier src/apps/miscapps/h3ToGeoHier.c ${APP_SOURCE_FILES})
-add_h3_executable(h3ToHier src/apps/miscapps/h3ToHier.c ${APP_SOURCE_FILES})
+if(BUILD_FILTERS)
+    add_h3_executable(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToLocalIj src/apps/filters/h3ToLocalIj.c ${APP_SOURCE_FILES})
+    add_h3_executable(localIjToH3 src/apps/filters/localIjToH3.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
+    add_h3_executable(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
+    add_h3_executable(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})
+    add_h3_executable(generateBaseCellNeighbors src/apps/miscapps/generateBaseCellNeighbors.c ${APP_SOURCE_FILES})
+    add_h3_executable(generateNumHexagons src/apps/miscapps/generateNumHexagons.c ${APP_SOURCE_FILES})
+    add_h3_executable(generateFaceCenterPoint src/apps/miscapps/generateFaceCenterPoint.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToGeoBoundaryHier src/apps/miscapps/h3ToGeoBoundaryHier.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToGeoHier src/apps/miscapps/h3ToGeoHier.c ${APP_SOURCE_FILES})
+    add_h3_executable(h3ToHier src/apps/miscapps/h3ToHier.c ${APP_SOURCE_FILES})
 
-# Generate KML files for visualizing the H3 grid
-add_custom_target(create-kml-dir
-    COMMAND ${CMAKE_COMMAND} -E make_directory KML)
-add_custom_target(kml)
+    # Generate KML files for visualizing the H3 grid
+    add_custom_target(create-kml-dir
+        COMMAND ${CMAKE_COMMAND} -E make_directory KML)
+    add_custom_target(kml)
 
-# Only the first 3 resolution grids are generated. The others can be generated,
-# but the file sizes would be very, very large.
-foreach(resolution RANGE 3)
-    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "KML/res${resolution}cells.kml")
-    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "KML/res${resolution}centers.kml")
-    add_custom_target(kml_cells_${resolution}
-        COMMAND ${SHELL} "$<TARGET_FILE:h3ToHier> ${resolution} | $<TARGET_FILE:h3ToGeoBoundary> 1 res${resolution}cells.kml \"Res ${resolution} Cells\" > KML/res${resolution}cells.kml"
-        VERBATIM
-        DEPENDS create-kml-dir)
-    add_custom_target(kml_centers_${resolution}
-        COMMAND ${SHELL} "$<TARGET_FILE:h3ToHier> ${resolution} | $<TARGET_FILE:h3ToGeo> 1 res${resolution}centers.kml \"Res ${resolution} Centers\" > KML/res${resolution}centers.kml"
-        VERBATIM
-        DEPENDS create-kml-dir)
-    add_dependencies(kml
-        kml_cells_${resolution}
-        kml_centers_${resolution})
-endforeach()
+    # Only the first 3 resolution grids are generated. The others can be generated,
+    # but the file sizes would be very, very large.
+    foreach(resolution RANGE 3)
+        set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "KML/res${resolution}cells.kml")
+        set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "KML/res${resolution}centers.kml")
+        add_custom_target(kml_cells_${resolution}
+            COMMAND ${SHELL} "$<TARGET_FILE:h3ToHier> ${resolution} | $<TARGET_FILE:h3ToGeoBoundary> 1 res${resolution}cells.kml \"Res ${resolution} Cells\" > KML/res${resolution}cells.kml"
+            VERBATIM
+            DEPENDS create-kml-dir)
+        add_custom_target(kml_centers_${resolution}
+            COMMAND ${SHELL} "$<TARGET_FILE:h3ToHier> ${resolution} | $<TARGET_FILE:h3ToGeo> 1 res${resolution}centers.kml \"Res ${resolution} Centers\" > KML/res${resolution}centers.kml"
+            VERBATIM
+            DEPENDS create-kml-dir)
+        add_dependencies(kml
+            kml_cells_${resolution}
+            kml_centers_${resolution})
+    endforeach()
+endif()
 
 if(BUILD_TESTING)
     option(PRINT_TEST_FILES "Print which test files correspond to which tests" OFF)
@@ -491,7 +495,9 @@ if(BUILD_TESTING)
     # Miscellaneous testing applications
     add_h3_executable(mkRandGeo src/apps/testapps/mkRandGeo.c ${APP_SOURCE_FILES})
     add_h3_executable(mkRandGeoBoundary src/apps/testapps/mkRandGeoBoundary.c ${APP_SOURCE_FILES})
+endif()
 
+if(BUILD_BENCHMARKS)
     # Benchmarks
     add_custom_target(benchmarks)
 
@@ -551,9 +557,14 @@ configure_package_config_file(
 #   * header location after install: <prefix>/include/h3/h3api.h
 #   * headers can be included by C++ code `#include <h3/h3api.h>`
 # Installing the library and filters system-wide.
+set(INSTALL_TARGETS h3)
+if(BUILD_FILTERS)
+   list(APPEND INSTALL_TARGETS geoToH3 h3ToComponents h3ToGeo h3ToGeoBoundary hexRange
+                               kRing h3ToGeoBoundaryHier h3ToGeoHier h3ToHier
+       )
+endif()
 install(
-    TARGETS h3 geoToH3 h3ToComponents h3ToGeo h3ToGeoBoundary hexRange
-            kRing h3ToGeoBoundaryHier h3ToGeoHier h3ToHier
+    TARGETS ${INSTALL_TARGETS}
     EXPORT "${TARGETS_EXPORT_NAME}"
     LIBRARY DESTINATION "lib"
     ARCHIVE DESTINATION "lib"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
 option(ENABLE_COVERAGE "Enable compiling tests with coverage." ON)
 option(BUILD_BENCHMARKS "Build benchmarking applications." ON)
 option(BUILD_FILTERS "Build filter applications." ON)
+option(BUILD_GENERATORS "Build code generation applications." ON)
 
 if(WIN32)
     set(SHELL PowerShell -Command)
@@ -188,6 +189,8 @@ set(UNCONFIGURED_API_HEADER src/h3lib/include/h3api.h.in)
 set(CONFIGURED_API_HEADER src/h3lib/include/h3api.h)
 configure_file(${UNCONFIGURED_API_HEADER} ${CONFIGURED_API_HEADER})
 
+set(INSTALL_TARGETS h3)
+
 # Build the H3 library
 add_library(h3 ${LIB_SOURCE_FILES} ${CONFIGURED_API_HEADER})
 
@@ -304,20 +307,22 @@ macro(add_h3_executable name)
 endmacro()
 
 if(BUILD_FILTERS)
-    add_h3_executable(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToLocalIj src/apps/filters/h3ToLocalIj.c ${APP_SOURCE_FILES})
-    add_h3_executable(localIjToH3 src/apps/filters/localIjToH3.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
-    add_h3_executable(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
-    add_h3_executable(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})
-    add_h3_executable(generateBaseCellNeighbors src/apps/miscapps/generateBaseCellNeighbors.c ${APP_SOURCE_FILES})
-    add_h3_executable(generateNumHexagons src/apps/miscapps/generateNumHexagons.c ${APP_SOURCE_FILES})
-    add_h3_executable(generateFaceCenterPoint src/apps/miscapps/generateFaceCenterPoint.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToGeoBoundaryHier src/apps/miscapps/h3ToGeoBoundaryHier.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToGeoHier src/apps/miscapps/h3ToGeoHier.c ${APP_SOURCE_FILES})
-    add_h3_executable(h3ToHier src/apps/miscapps/h3ToHier.c ${APP_SOURCE_FILES})
+    macro(add_h3_filter name)
+        add_h3_executable(${ARGV})
+        list(APPEND INSTALL_TARGETS ${name})
+    endmacro()
+
+    add_h3_filter(geoToH3 src/apps/filters/geoToH3.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToComponents src/apps/filters/h3ToComponents.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToGeo src/apps/filters/h3ToGeo.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToLocalIj src/apps/filters/h3ToLocalIj.c ${APP_SOURCE_FILES})
+    add_h3_filter(localIjToH3 src/apps/filters/localIjToH3.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToGeoBoundary src/apps/filters/h3ToGeoBoundary.c ${APP_SOURCE_FILES})
+    add_h3_filter(hexRange src/apps/filters/hexRange.c ${APP_SOURCE_FILES})
+    add_h3_filter(kRing src/apps/filters/kRing.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToGeoBoundaryHier src/apps/miscapps/h3ToGeoBoundaryHier.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToGeoHier src/apps/miscapps/h3ToGeoHier.c ${APP_SOURCE_FILES})
+    add_h3_filter(h3ToHier src/apps/miscapps/h3ToHier.c ${APP_SOURCE_FILES})
 
     # Generate KML files for visualizing the H3 grid
     add_custom_target(create-kml-dir
@@ -341,6 +346,17 @@ if(BUILD_FILTERS)
             kml_cells_${resolution}
             kml_centers_${resolution})
     endforeach()
+endif()
+
+if(BUILD_GENERATORS)
+    # Code generation
+    add_h3_executable(generateBaseCellNeighbors src/apps/miscapps/generateBaseCellNeighbors.c ${APP_SOURCE_FILES})
+    add_h3_executable(generateNumHexagons src/apps/miscapps/generateNumHexagons.c ${APP_SOURCE_FILES})
+    add_h3_executable(generateFaceCenterPoint src/apps/miscapps/generateFaceCenterPoint.c ${APP_SOURCE_FILES})
+
+    # Miscellaneous testing applications - generating random data
+    add_h3_executable(mkRandGeo src/apps/testapps/mkRandGeo.c ${APP_SOURCE_FILES})
+    add_h3_executable(mkRandGeoBoundary src/apps/testapps/mkRandGeoBoundary.c ${APP_SOURCE_FILES})
 endif()
 
 if(BUILD_TESTING)
@@ -491,10 +507,6 @@ if(BUILD_TESTING)
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 0)
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 1)
     add_h3_test_with_arg(testH3NeighborRotations src/apps/testapps/testH3NeighborRotations.c 2)
-
-    # Miscellaneous testing applications
-    add_h3_executable(mkRandGeo src/apps/testapps/mkRandGeo.c ${APP_SOURCE_FILES})
-    add_h3_executable(mkRandGeoBoundary src/apps/testapps/mkRandGeoBoundary.c ${APP_SOURCE_FILES})
 endif()
 
 if(BUILD_BENCHMARKS)
@@ -557,12 +569,6 @@ configure_package_config_file(
 #   * header location after install: <prefix>/include/h3/h3api.h
 #   * headers can be included by C++ code `#include <h3/h3api.h>`
 # Installing the library and filters system-wide.
-set(INSTALL_TARGETS h3)
-if(BUILD_FILTERS)
-   list(APPEND INSTALL_TARGETS geoToH3 h3ToComponents h3ToGeo h3ToGeoBoundary hexRange
-                               kRing h3ToGeoBoundaryHier h3ToGeoHier h3ToHier
-       )
-endif()
 install(
     TARGETS ${INSTALL_TARGETS}
     EXPORT "${TARGETS_EXPORT_NAME}"


### PR DESCRIPTION
This is intended to help with #243, so that just the core library and its tests can be built, e.g. by running CMake with `cmake -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF .`.