### PR TITLE
Implement h3GetFaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Added
 - CMake options for excluding filter applications or benchmarks from the build. (#247)
+- `h3GetFaces` function to find icosahedron faces for an index, and helper function `maxFaceCount` (#253)
 ### Changed
 - Argument parsing for all filter applications is more flexible. (#238)
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/testHexRanges.c
     src/apps/testapps/testH3ToGeo.c
     src/apps/testapps/testH3ToChildren.c
+    src/apps/testapps/testH3GetFaces.c
     src/apps/testapps/testGeoCoord.c
     src/apps/testapps/testHexRing.c
     src/apps/testapps/testH3SetToVertexGraph.c
@@ -491,6 +492,7 @@ if(BUILD_TESTING)
     add_h3_test(testHexRanges src/apps/testapps/testHexRanges.c)
     add_h3_test(testH3ToParent src/apps/testapps/testH3ToParent.c)
     add_h3_test(testH3ToChildren src/apps/testapps/testH3ToChildren.c)
+    add_h3_test(testH3GetFaces src/apps/testapps/testH3GetFaces.c)
     add_h3_test(testMaxH3ToChildrenSize src/apps/testapps/testMaxH3ToChildrenSize.c)
     add_h3_test(testH3Index src/apps/testapps/testH3Index.c)
     add_h3_test(testH3Api src/apps/testapps/testH3Api.c)

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -52,5 +52,7 @@ void randomGeo(GeoCoord* p);
 void iterateAllIndexesAtRes(int res, void (*callback)(H3Index));
 void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
                                    int maxBaseCell);
+void iterateBaseCellIndexesAtRes(int res, void (*callback)(H3Index),
+                                 int baseCell);
 
 #endif

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -190,22 +190,31 @@ void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
                                    int baseCells) {
     assert(baseCells <= NUM_BASE_CELLS);
     for (int i = 0; i < baseCells; i++) {
-        H3Index bc;
-        setH3Index(&bc, 0, i, 0);
-        int childrenSz = H3_EXPORT(maxUncompactSize)(&bc, 1, res);
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
-        H3_EXPORT(uncompact)(&bc, 1, children, childrenSz, res);
+        iterateBaseCellIndexesAtRes(res, callback, i);
+    }
+}
 
-        for (int j = 0; j < childrenSz; j++) {
-            if (children[j] == 0) {
-                continue;
-            }
+/**
+ * Call the callback for every index at the given resolution in a
+ * specific base cell
+ */
+void iterateBaseCellIndexesAtRes(int res, void (*callback)(H3Index),
+                                 int baseCell) {
+    H3Index bc;
+    setH3Index(&bc, 0, baseCell, 0);
+    int childrenSz = H3_EXPORT(maxUncompactSize)(&bc, 1, res);
+    H3Index* children = calloc(childrenSz, sizeof(H3Index));
+    H3_EXPORT(uncompact)(&bc, 1, children, childrenSz, res);
 
-            (*callback)(children[j]);
+    for (int j = 0; j < childrenSz; j++) {
+        if (children[j] == 0) {
+            continue;
         }
 
-        free(children);
+        (*callback)(children[j]);
     }
+
+    free(children);
 }
 
 /**

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -97,6 +97,12 @@ SUITE(h3GetFaces) {
         assertPentagonFaces(pentagon);
     }
 
+    TEST(res15Pentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 15, 4, 0);
+        assertPentagonFaces(pentagon);
+    }
+
     TEST(baseCellHexagons) {
         int singleCount = 0;
         int multipleCount = 0;

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief tests H3 distance function.
+ *
+ *  usage: `testH3Distance`
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "baseCells.h"
+#include "h3Index.h"
+#include "h3api.h"
+#include "test.h"
+#include "utility.h"
+
+static int countFaces(h3, expectedMax) {
+    int sz = H3_EXPORT(maxFaceCount)(h3);
+    t_assert(sz == expectedMax, "got expected max face count");
+    int *faces = calloc(sz, sizeof(int));
+
+    H3_EXPORT(h3GetFaces)(h3, faces);
+
+    int validCount = 0;
+    for (int i = 0; i < sz; i++) {
+        if (faces[i] >= 0 && faces[i] <= 19) validCount++;
+    }
+
+    free(faces);
+    return validCount;
+}
+
+static void assertSingleHexFace(H3Index h3) {
+    int validCount = countFaces(h3, 2);
+    t_assert(validCount == 1, "got a single valid face");
+}
+
+static void assertMultipleHexFaces(H3Index h3) {
+    int validCount = countFaces(h3, 2);
+    t_assert(validCount == 2, "got multiple valid faces for a hexagon");
+}
+
+static void assertPentagonFaces(H3Index h3) {
+    int validCount = countFaces(h3, 5);
+    t_assert(validCount == 5, "got 5 valid faces for a pentagon");
+}
+
+SUITE(h3GetFaces) {
+    TEST(singleFaceHexes) {
+        // base cell 16 is at the center of an icosahedron face,
+        // so all children should have the same face
+        iterateBaseCellIndexesAtRes(2, assertSingleHexFace, 16);
+        iterateBaseCellIndexesAtRes(3, assertSingleHexFace, 16);
+    }
+
+    TEST(hexagonWithEdgeVertices) {
+        // Class II pentagon neighbor - one face, two adjacent vertices on edge
+        H3Index h3 = 0x821c37fffffffff;
+        assertSingleHexFace(h3);
+    }
+
+    TEST(hexagonWithDistortion) {
+        // Class III pentagon neighbor
+        H3Index h3 = 0x831c06fffffffff;
+        assertMultipleHexFaces(h3);
+    }
+
+    TEST(hexagonCrossingFaces) {
+        // Class II hex with two non-adjacent vertices on edge
+        H3Index h3 = 0x821ce7fffffffff;
+        assertMultipleHexFaces(h3);
+    }
+
+    TEST(hexagonCrossingFaces) {
+        // Class II hex with two vertices on edge
+        H3Index h3 = 0x821ce7fffffffff;
+        assertMultipleHexFaces(h3);
+    }
+
+    TEST(classIIIPentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 1, 4, 0);
+        assertPentagonFaces(pentagon);
+    }
+
+    // TEST(classIIPentagon) {
+    //     H3Index pentagon;
+    //     setH3Index(&pentagon, 2, 4, 0);
+    //     assertPentagonFaces(pentagon);
+    // }
+
+    TEST(baseCellHexagons) {
+        int singleCount = 0;
+        int multipleCount = 0;
+        for (int i = 0; i < NUM_BASE_CELLS; i++) {
+            if (!_isBaseCellPentagon(i)) {
+                // Make the base cell index
+                H3Index baseCell = H3_INIT;
+                H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
+                H3_SET_BASE_CELL(baseCell, i);
+                int validCount = countFaces(baseCell, 2);
+                t_assert(validCount > 0, "got at least one face");
+                if (validCount == 1)
+                    singleCount++;
+                else
+                    multipleCount++;
+            }
+        }
+        t_assert(singleCount == 4 * 20,
+                 "got single face for 4 face-aligned hex base cells");
+        t_assert(multipleCount == 1.5 * 20,
+                 "got multiple faces for non-face-aligned hex base cells");
+    }
+
+    // TEST(baseCellPentagons) {
+    //     for (int i = 0; i < NUM_BASE_CELLS; i++) {
+    //         if (_isBaseCellPentagon(i)) {
+    //             // Make the base cell index
+    //             H3Index baseCell = H3_INIT;
+    //             H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
+    //             H3_SET_BASE_CELL(baseCell, i);
+    //             assertPentagonFaces(baseCell);
+    //         }
+    //     }
+    // }
+}

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -27,7 +27,7 @@
 #include "test.h"
 #include "utility.h"
 
-static int countFaces(h3, expectedMax) {
+static int countFaces(H3Index h3, int expectedMax) {
     int sz = H3_EXPORT(maxFaceCount)(h3);
     t_assert(sz == expectedMax, "got expected max face count");
     int *faces = calloc(sz, sizeof(int));
@@ -54,6 +54,7 @@ static void assertMultipleHexFaces(H3Index h3) {
 }
 
 static void assertPentagonFaces(H3Index h3) {
+    t_assert(H3_EXPORT(h3IsPentagon)(h3), "got a pentagon");
     int validCount = countFaces(h3, 5);
     t_assert(validCount == 5, "got 5 valid faces for a pentagon");
 }
@@ -73,14 +74,8 @@ SUITE(h3GetFaces) {
     }
 
     TEST(hexagonWithDistortion) {
-        // Class III pentagon neighbor
+        // Class III pentagon neighbor, distortion across faces
         H3Index h3 = 0x831c06fffffffff;
-        assertMultipleHexFaces(h3);
-    }
-
-    TEST(hexagonCrossingFaces) {
-        // Class II hex with two non-adjacent vertices on edge
-        H3Index h3 = 0x821ce7fffffffff;
         assertMultipleHexFaces(h3);
     }
 
@@ -96,11 +91,11 @@ SUITE(h3GetFaces) {
         assertPentagonFaces(pentagon);
     }
 
-    // TEST(classIIPentagon) {
-    //     H3Index pentagon;
-    //     setH3Index(&pentagon, 2, 4, 0);
-    //     assertPentagonFaces(pentagon);
-    // }
+    TEST(classIIPentagon) {
+        H3Index pentagon;
+        setH3Index(&pentagon, 2, 4, 0);
+        assertPentagonFaces(pentagon);
+    }
 
     TEST(baseCellHexagons) {
         int singleCount = 0;
@@ -120,20 +115,20 @@ SUITE(h3GetFaces) {
             }
         }
         t_assert(singleCount == 4 * 20,
-                 "got single face for 4 face-aligned hex base cells");
+                 "got single face for 4 aligned hex base cells per face");
         t_assert(multipleCount == 1.5 * 20,
-                 "got multiple faces for non-face-aligned hex base cells");
+                 "got multiple faces for non-aligned hex base cells");
     }
 
-    // TEST(baseCellPentagons) {
-    //     for (int i = 0; i < NUM_BASE_CELLS; i++) {
-    //         if (_isBaseCellPentagon(i)) {
-    //             // Make the base cell index
-    //             H3Index baseCell = H3_INIT;
-    //             H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
-    //             H3_SET_BASE_CELL(baseCell, i);
-    //             assertPentagonFaces(baseCell);
-    //         }
-    //     }
-    // }
+    TEST(baseCellPentagons) {
+        for (int i = 0; i < NUM_BASE_CELLS; i++) {
+            if (_isBaseCellPentagon(i)) {
+                // Make the base cell index
+                H3Index baseCell = H3_INIT;
+                H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
+                H3_SET_BASE_CELL(baseCell, i);
+                assertPentagonFaces(baseCell);
+            }
+        }
+    }
 }

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 /** @file
- * @brief tests H3 distance function.
- *
- *  usage: `testH3Distance`
+ * @brief tests the h3GetFaces function
  */
 
 #include <stdio.h>
@@ -109,9 +107,8 @@ SUITE(h3GetFaces) {
         for (int i = 0; i < NUM_BASE_CELLS; i++) {
             if (!_isBaseCellPentagon(i)) {
                 // Make the base cell index
-                H3Index baseCell = H3_INIT;
-                H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
-                H3_SET_BASE_CELL(baseCell, i);
+                H3Index baseCell;
+                setH3Index(&baseCell, 0, i, 0);
                 int validCount = countFaces(baseCell, 2);
                 t_assert(validCount > 0, "got at least one face");
                 if (validCount == 1)
@@ -130,9 +127,8 @@ SUITE(h3GetFaces) {
         for (int i = 0; i < NUM_BASE_CELLS; i++) {
             if (_isBaseCellPentagon(i)) {
                 // Make the base cell index
-                H3Index baseCell = H3_INIT;
-                H3_SET_MODE(baseCell, H3_HEXAGON_MODE);
-                H3_SET_BASE_CELL(baseCell, i);
+                H3Index baseCell;
+                setH3Index(&baseCell, 0, i, 0);
                 assertPentagonFaces(baseCell);
             }
         }

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Uber Technologies, Inc.
+ * Copyright 2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -50,16 +50,15 @@ typedef struct {
 extern const GeoCoord faceCenterGeo[NUM_ICOSA_FACES];
 
 // indexes for faceNeighbors table
-/** Invalid faceNeighbors table direction */
-#define INVALID -1
-/** Center faceNeighbors table direction */
-#define CENTER 0
 /** IJ quadrant faceNeighbors table direction */
 #define IJ 1
 /** KI quadrant faceNeighbors table direction */
 #define KI 2
 /** JK quadrant faceNeighbors table direction */
 #define JK 3
+
+/** Invalid face index */
+#define INVALID_FACE -1
 
 // Internal functions
 

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Uber Technologies, Inc.
+ * Copyright 2016-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -69,8 +69,11 @@ void _faceIjkToGeo(const FaceIJK* h, int res, GeoCoord* g);
 void _faceIjkToGeoBoundary(const FaceIJK* h, int res, int isPentagon,
                            GeoBoundary* g);
 void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g);
+void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
+void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
 void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate, GeoCoord* g);
 int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
                           int substrate);
+int _adjustPentVertOverage(FaceIJK* fijk, int res);
 
 #endif

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -60,6 +60,16 @@ extern const GeoCoord faceCenterGeo[NUM_ICOSA_FACES];
 /** Invalid face index */
 #define INVALID_FACE -1
 
+/** Digit representing overage type */
+typedef enum {
+    /** No overage (on original face) */
+    NO_OVERAGE = 0,
+    /** On face edge (only occurs on substrate grids) */
+    FACE_EDGE = 1,
+    /** Overage on new face interior */
+    NEW_FACE = 2
+} Overage;
+
 // Internal functions
 
 void _geoToFaceIjk(const GeoCoord* g, int res, FaceIJK* h);
@@ -71,8 +81,8 @@ void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g);
 void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
 void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
 void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate, GeoCoord* g);
-int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
-                          int substrate);
-int _adjustPentVertOverage(FaceIJK* fijk, int res);
+Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
+                              int substrate);
+Overage _adjustPentVertOverage(FaceIJK* fijk, int res);
 
 #endif

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -394,6 +394,17 @@ int H3_EXPORT(h3IsResClassIII)(H3Index h);
 int H3_EXPORT(h3IsPentagon)(H3Index h);
 /** @} */
 
+/** @defgroup h3GetFaces h3GetFaces
+ * Functions for h3GetFaces
+ * @{
+ */
+/** @brief Max number of icosahedron faces intersected by an index */
+int H3_EXPORT(maxFaceCount)(H3Index h3);
+
+/** @brief Find all icosahedron faces intersected by a given  H3 index */
+void H3_EXPORT(h3GetFaces)(H3Index h3, int *out);
+/** @} */
+
 /** @defgroup h3IndexesAreNeighbors h3IndexesAreNeighbors
  * Functions for h3IndexesAreNeighbors
  * @{

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Uber Technologies, Inc.
+ * Copyright 2016-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 Uber Technologies, Inc.
+ * Copyright 2016-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -917,10 +917,9 @@ Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
  */
 Overage _adjustPentVertOverage(FaceIJK* fijk, int res) {
     int pentLeading4 = 0;
-    Overage overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
-    while (overage == NEW_FACE) {
-        // in a different triangle
+    Overage overage;
+    do {
         overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
-    }
+    } while (overage == NEW_FACE);
     return overage;
 }

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -502,60 +502,10 @@ void _faceIjkToGeo(const FaceIJK* h, int res, GeoCoord* g) {
  * @param g The spherical coordinates of the cell boundary.
  */
 void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g) {
-    // the vertexes of an origin-centered pentagon in a Class II resolution on a
-    // substrate grid with aperture sequence 33r. The aperture 3 gets us the
-    // vertices, and the 3r gets us back to Class II.
-    // vertices listed ccw from the i-axes
-    CoordIJK vertsCII[NUM_PENT_VERTS] = {
-        {2, 1, 0},  // 0
-        {1, 2, 0},  // 1
-        {0, 2, 1},  // 2
-        {0, 1, 2},  // 3
-        {1, 0, 2},  // 4
-    };
-
-    // the vertexes of an origin-centered pentagon in a Class III resolution on
-    // a substrate grid with aperture sequence 33r7r. The aperture 3 gets us the
-    // vertices, and the 3r7r gets us to Class II. vertices listed ccw from the
-    // i-axes
-    CoordIJK vertsCIII[NUM_PENT_VERTS] = {
-        {5, 4, 0},  // 0
-        {1, 5, 0},  // 1
-        {0, 5, 4},  // 2
-        {0, 1, 5},  // 3
-        {4, 0, 5},  // 4
-    };
-
-    // get the correct set of substrate vertices for this resolution
-    CoordIJK* verts;
-    if (isResClassIII(res))
-        verts = vertsCIII;
-    else
-        verts = vertsCII;
-
-    // adjust the center point to be in an aperture 33r substrate grid
-    // these should be composed for speed
-    FaceIJK centerIJK = *h;
-    _downAp3(&centerIJK.coord);
-    _downAp3r(&centerIJK.coord);
-
-    // if res is Class III we need to add a cw aperture 7 to get to
-    // icosahedral Class II
     int adjRes = res;
-    if (isResClassIII(res)) {
-        _downAp7r(&centerIJK.coord);
-        adjRes++;
-    }
-
-    // The center point is now in the same substrate grid as the origin
-    // cell vertices. Add the center point substate coordinates
-    // to each vertex to translate the vertices to that cell.
+    FaceIJK centerIJK = *h;
     FaceIJK fijkVerts[NUM_PENT_VERTS];
-    for (int v = 0; v < NUM_PENT_VERTS; v++) {
-        fijkVerts[v].face = centerIJK.face;
-        _ijkAdd(&centerIJK.coord, &verts[v], &fijkVerts[v].coord);
-        _ijkNormalize(&fijkVerts[v].coord);
-    }
+    _faceIjkPentToVerts(&centerIJK, &adjRes, fijkVerts);
 
     // convert each vertex to lat/lon
     // adjust the face of each vertex as appropriate and introduce
@@ -567,16 +517,7 @@ void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g) {
 
         FaceIJK fijk = fijkVerts[v];
 
-        int pentLeading4 = 0;
-        int overage = _adjustOverageClassII(&fijk, adjRes, pentLeading4, 1);
-        if (overage == 2)  // in a different triangle
-        {
-            while (1) {
-                overage = _adjustOverageClassII(&fijk, adjRes, pentLeading4, 1);
-                if (overage != 2)  // not in a different triangle
-                    break;
-            }
-        }
+        _adjustPentVertOverage(&fijk, adjRes);
 
         // all Class III pentagon edges cross icosa edges
         // note that Class II pentagons have vertices on the edge,
@@ -656,6 +597,68 @@ void _faceIjkPentToGeoBoundary(const FaceIJK* h, int res, GeoBoundary* g) {
 }
 
 /**
+ * Get the vertices of a pentagon cell as substrate FaceIJK addresses
+ *
+ * @param fijk The FaceIJK address of the cell.
+ * @param res The H3 resolution of the cell. This may be adjusted if
+ *            necessary for the substrate grid resolution.
+ * @param fijkVerts Output array for the vertices
+ */
+void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
+    // the vertexes of an origin-centered pentagon in a Class II resolution on a
+    // substrate grid with aperture sequence 33r. The aperture 3 gets us the
+    // vertices, and the 3r gets us back to Class II.
+    // vertices listed ccw from the i-axes
+    CoordIJK vertsCII[NUM_PENT_VERTS] = {
+        {2, 1, 0},  // 0
+        {1, 2, 0},  // 1
+        {0, 2, 1},  // 2
+        {0, 1, 2},  // 3
+        {1, 0, 2},  // 4
+    };
+
+    // the vertexes of an origin-centered pentagon in a Class III resolution on
+    // a substrate grid with aperture sequence 33r7r. The aperture 3 gets us the
+    // vertices, and the 3r7r gets us to Class II. vertices listed ccw from the
+    // i-axes
+    CoordIJK vertsCIII[NUM_PENT_VERTS] = {
+        {5, 4, 0},  // 0
+        {1, 5, 0},  // 1
+        {0, 5, 4},  // 2
+        {0, 1, 5},  // 3
+        {4, 0, 5},  // 4
+    };
+
+    // get the correct set of substrate vertices for this resolution
+    CoordIJK* verts;
+    if (isResClassIII(*res))
+        verts = vertsCIII;
+    else
+        verts = vertsCII;
+
+    // adjust the center point to be in an aperture 33r substrate grid
+    // these should be composed for speed
+    _downAp3(&fijk->coord);
+    _downAp3r(&fijk->coord);
+
+    // if res is Class III we need to add a cw aperture 7 to get to
+    // icosahedral Class II
+    if (isResClassIII(*res)) {
+        _downAp7r(&fijk->coord);
+        *res += 1;
+    }
+
+    // The center point is now in the same substrate grid as the origin
+    // cell vertices. Add the center point substate coordinates
+    // to each vertex to translate the vertices to that cell.
+    for (int v = 0; v < NUM_PENT_VERTS; v++) {
+        fijkVerts[v].face = fijk->face;
+        _ijkAdd(&fijk->coord, &verts[v], &fijkVerts[v].coord);
+        _ijkNormalize(&fijkVerts[v].coord);
+    }
+}
+
+/**
  * Generates the cell boundary in spherical coordinates for a cell given by a
  * FaceIJK address at a specified resolution.
  *
@@ -671,62 +674,10 @@ void _faceIjkToGeoBoundary(const FaceIJK* h, int res, int isPentagon,
         return;
     }
 
-    // the vertexes of an origin-centered cell in a Class II resolution on a
-    // substrate grid with aperture sequence 33r. The aperture 3 gets us the
-    // vertices, and the 3r gets us back to Class II.
-    // vertices listed ccw from the i-axes
-    CoordIJK vertsCII[NUM_HEX_VERTS] = {
-        {2, 1, 0},  // 0
-        {1, 2, 0},  // 1
-        {0, 2, 1},  // 2
-        {0, 1, 2},  // 3
-        {1, 0, 2},  // 4
-        {2, 0, 1}   // 5
-    };
-
-    // the vertexes of an origin-centered cell in a Class III resolution on a
-    // substrate grid with aperture sequence 33r7r. The aperture 3 gets us the
-    // vertices, and the 3r7r gets us to Class II.
-    // vertices listed ccw from the i-axes
-    CoordIJK vertsCIII[NUM_HEX_VERTS] = {
-        {5, 4, 0},  // 0
-        {1, 5, 0},  // 1
-        {0, 5, 4},  // 2
-        {0, 1, 5},  // 3
-        {4, 0, 5},  // 4
-        {5, 0, 1}   // 5
-    };
-
-    // get the correct set of substrate vertices for this resolution
-    CoordIJK* verts;
-    if (isResClassIII(res))
-        verts = vertsCIII;
-    else
-        verts = vertsCII;
-
-    // adjust the center point to be in an aperture 33r substrate grid
-    // these should be composed for speed
-    FaceIJK centerIJK = *h;
-    _downAp3(&centerIJK.coord);
-    _downAp3r(&centerIJK.coord);
-
-    // if res is Class III we need to add a cw aperture 7 to get to
-    // icosahedral Class II
     int adjRes = res;
-    if (isResClassIII(res)) {
-        _downAp7r(&centerIJK.coord);
-        adjRes++;
-    }
-
-    // The center point is now in the same substrate grid as the origin
-    // cell vertices. Add the center point substate coordinates
-    // to each vertex to translate the vertices to that cell.
+    FaceIJK centerIJK = *h;
     FaceIJK fijkVerts[NUM_HEX_VERTS];
-    for (int v = 0; v < NUM_HEX_VERTS; v++) {
-        fijkVerts[v].face = centerIJK.face;
-        _ijkAdd(&centerIJK.coord, &verts[v], &fijkVerts[v].coord);
-        _ijkNormalize(&fijkVerts[v].coord);
-    }
+    _faceIjkToVerts(&centerIJK, &adjRes, fijkVerts);
 
     // convert each vertex to lat/lon
     // adjust the face of each vertex as appropriate and introduce
@@ -820,6 +771,70 @@ void _faceIjkToGeoBoundary(const FaceIJK* h, int res, int isPentagon,
 }
 
 /**
+ * Get the vertices of a cell as substrate FaceIJK addresses
+ *
+ * @param fijk The FaceIJK address of the cell.
+ * @param res The H3 resolution of the cell. This may be adjusted if
+ *            necessary for the substrate grid resolution.
+ * @param fijkVerts Output array for the vertices
+ */
+void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
+    // the vertexes of an origin-centered cell in a Class II resolution on a
+    // substrate grid with aperture sequence 33r. The aperture 3 gets us the
+    // vertices, and the 3r gets us back to Class II.
+    // vertices listed ccw from the i-axes
+    CoordIJK vertsCII[NUM_HEX_VERTS] = {
+        {2, 1, 0},  // 0
+        {1, 2, 0},  // 1
+        {0, 2, 1},  // 2
+        {0, 1, 2},  // 3
+        {1, 0, 2},  // 4
+        {2, 0, 1}   // 5
+    };
+
+    // the vertexes of an origin-centered cell in a Class III resolution on a
+    // substrate grid with aperture sequence 33r7r. The aperture 3 gets us the
+    // vertices, and the 3r7r gets us to Class II.
+    // vertices listed ccw from the i-axes
+    CoordIJK vertsCIII[NUM_HEX_VERTS] = {
+        {5, 4, 0},  // 0
+        {1, 5, 0},  // 1
+        {0, 5, 4},  // 2
+        {0, 1, 5},  // 3
+        {4, 0, 5},  // 4
+        {5, 0, 1}   // 5
+    };
+
+    // get the correct set of substrate vertices for this resolution
+    CoordIJK* verts;
+    if (isResClassIII(*res))
+        verts = vertsCIII;
+    else
+        verts = vertsCII;
+
+    // adjust the center point to be in an aperture 33r substrate grid
+    // these should be composed for speed
+    _downAp3(&fijk->coord);
+    _downAp3r(&fijk->coord);
+
+    // if res is Class III we need to add a cw aperture 7 to get to
+    // icosahedral Class II
+    if (isResClassIII(*res)) {
+        _downAp7r(&fijk->coord);
+        *res += 1;
+    }
+
+    // The center point is now in the same substrate grid as the origin
+    // cell vertices. Add the center point substate coordinates
+    // to each vertex to translate the vertices to that cell.
+    for (int v = 0; v < NUM_HEX_VERTS; v++) {
+        fijkVerts[v].face = fijk->face;
+        _ijkAdd(&fijk->coord, &verts[v], &fijkVerts[v].coord);
+        _ijkNormalize(&fijkVerts[v].coord);
+    }
+}
+
+/**
  * Adjusts a FaceIJK address in place so that the resulting cell address is
  * relative to the correct icosahedral face.
  *
@@ -889,5 +904,27 @@ int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
             overage = 1;
     }
 
+    return overage;
+}
+
+/**
+ * Adjusts a FaceIJK address for a pentagon vertex in a substrate grid in
+ * place so that the resulting cell address is relative to the correct
+ * icosahedral face.
+ *
+ * @param fijk The FaceIJK address of the cell.
+ * @param res The H3 resolution of the cell.
+ */
+int _adjustPentVertOverage(FaceIJK* fijk, int res) {
+    int pentLeading4 = 0;
+    int overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
+    if (overage == 2) {
+        // in a different triangle
+        while (1) {
+            overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
+            if (overage != 2)  // not in a different triangle
+                break;
+        }
+    }
     return overage;
 }

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -918,13 +918,9 @@ int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
 int _adjustPentVertOverage(FaceIJK* fijk, int res) {
     int pentLeading4 = 0;
     int overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
-    if (overage == 2) {
+    while (overage == 2) {
         // in a different triangle
-        while (1) {
-            overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
-            if (overage != 2)  // not in a different triangle
-                break;
-        }
+        overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
     }
     return overage;
 }

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -846,9 +846,9 @@ void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
  * @return 0 if on original face (no overage); 1 if on face edge (only occurs
  *         on substrate grids); 2 if overage on new face interior
  */
-int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
-                          int substrate) {
-    int overage = 0;
+Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
+                              int substrate) {
+    Overage overage = NO_OVERAGE;
 
     CoordIJK* ijk = &fijk->coord;
 
@@ -858,10 +858,10 @@ int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
 
     // check for overage
     if (substrate && ijk->i + ijk->j + ijk->k == maxDim)  // on edge
-        overage = 1;
+        overage = FACE_EDGE;
     else if (ijk->i + ijk->j + ijk->k > maxDim)  // overage
     {
-        overage = 2;
+        overage = NEW_FACE;
 
         const FaceOrientIJK* fijkOrient;
         if (ijk->k > 0) {
@@ -901,7 +901,7 @@ int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
 
         // overage points on pentagon boundaries can end up on edges
         if (substrate && ijk->i + ijk->j + ijk->k == maxDim)  // on edge
-            overage = 1;
+            overage = FACE_EDGE;
     }
 
     return overage;
@@ -915,10 +915,10 @@ int _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
  * @param fijk The FaceIJK address of the cell.
  * @param res The H3 resolution of the cell.
  */
-int _adjustPentVertOverage(FaceIJK* fijk, int res) {
+Overage _adjustPentVertOverage(FaceIJK* fijk, int res) {
     int pentLeading4 = 0;
-    int overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
-    while (overage == 2) {
+    Overage overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
+    while (overage == NEW_FACE) {
         // in a different triangle
         overage = _adjustOverageClassII(fijk, res, pentLeading4, 1);
     }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -818,7 +818,7 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
     // Get all vertices as FaceIJK addresses. For simplicity, always
     // initialize the array with 6 verts, ignoring the last one for pentagons
-    FaceIJK fijkVerts[NUM_HEX_VERTS] = {0};
+    FaceIJK fijkVerts[NUM_HEX_VERTS] = {};
     int vertexCount;
 
     if (isPentagon) {

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -818,7 +818,7 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
     // Get all vertices as FaceIJK addresses. For simplicity, always
     // initialize the array with 6 verts, ignoring the last one for pentagons
-    FaceIJK fijkVerts[NUM_HEX_VERTS] = {};
+    FaceIJK fijkVerts[NUM_HEX_VERTS];
     int vertexCount;
 
     if (isPentagon) {

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -739,12 +739,12 @@ void _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
     // a pentagon base cell with a leading 4 digit requires special handling
     int pentLeading4 =
         (_isBaseCellPentagon(baseCell) && _h3LeadingNonZeroDigit(h) == 4);
-    if (_adjustOverageClassII(fijk, res, pentLeading4, 0)) {
+    if (_adjustOverageClassII(fijk, res, pentLeading4, 0) != NO_OVERAGE) {
         // if the base cell is a pentagon we have the potential for secondary
         // overages
         if (_isBaseCellPentagon(baseCell)) {
             while (1) {
-                if (!_adjustOverageClassII(fijk, res, 0, 0)) break;
+                if (_adjustOverageClassII(fijk, res, 0, 0) == NO_OVERAGE) break;
             }
         }
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -851,10 +851,10 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
         // Save the face to the output array
         int face = vert->face;
-        int pos = face % faceCount;
-        while (out[pos] != INVALID_FACE && out[pos] != face) {
-            pos = (pos + 1) % faceCount;
-        }
+        int pos = 0;
+        // Find the first empty output position, or the first position
+        // matching the current face
+        while (out[pos] != INVALID_FACE && out[pos] != face) pos++;
         out[pos] = face;
     }
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -818,7 +818,7 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
     // Get all vertices as FaceIJK addresses. For simplicity, always
     // initialize the array with 6 verts, ignoring the last one for pentagons
-    FaceIJK* fijkVerts = malloc(NUM_HEX_VERTS * sizeof(FaceIJK));
+    FaceIJK fijkVerts[NUM_HEX_VERTS] = {0};
     int vertexCount;
 
     if (isPentagon) {
@@ -856,8 +856,6 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
         while (out[pos] != INVALID_FACE && out[pos] != face) pos++;
         out[pos] = face;
     }
-
-    free(fijkVerts);
 }
 
 /**

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 Uber Technologies, Inc.
+ * Copyright 2016-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -743,9 +743,8 @@ void _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
         // if the base cell is a pentagon we have the potential for secondary
         // overages
         if (_isBaseCellPentagon(baseCell)) {
-            while (1) {
-                if (_adjustOverageClassII(fijk, res, 0, 0) == NO_OVERAGE) break;
-            }
+            while (_adjustOverageClassII(fijk, res, 0, 0) != NO_OVERAGE)
+                continue;
         }
 
         if (res != H3_GET_RESOLUTION(h)) _upAp7r(&fijk->coord);

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -819,7 +819,7 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
     // Get all vertices as FaceIJK addresses. For simplicity, always
     // initialize the array with 6 verts, ignoring the last one for pentagons
-    FaceIJK fijkVerts[NUM_HEX_VERTS];
+    FaceIJK* fijkVerts = malloc(NUM_HEX_VERTS * sizeof(FaceIJK));
     int vertexCount;
 
     if (isPentagon) {
@@ -839,24 +839,26 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
 
     // add each vertex face, using the output array as a hash set
     for (int i = 0; i < vertexCount; i++) {
-        FaceIJK vert = fijkVerts[i];
+        FaceIJK* vert = &fijkVerts[i];
 
         // Adjust overage, determining whether this vertex is
         // on another face
         if (isPentagon) {
-            _adjustPentVertOverage(&vert, res);
+            _adjustPentVertOverage(vert, res);
         } else {
-            _adjustOverageClassII(&vert, res, 0, 1);
+            _adjustOverageClassII(vert, res, 0, 1);
         }
 
         // Save the face to the output array
-        int face = vert.face;
+        int face = vert->face;
         int pos = face % faceCount;
         while (out[pos] != INVALID_FACE && out[pos] != face) {
             pos = (pos + 1) % faceCount;
         }
         out[pos] = face;
     }
+
+    free(fijkVerts);
 }
 
 /**

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -807,6 +807,8 @@ void H3_EXPORT(h3GetFaces)(H3Index h3, int* out) {
     // because all their vertices are on the icosahedron edges. Their
     // direct child pentagons cross the same faces, so use those instead.
     if (isPentagon && !isResClassIII(res)) {
+        // Note that this would not work for res 15, but this is only run on
+        // Class II pentagons, it should never be invoked for a res 15 index.
         H3Index childPentagon = makeDirectChild(h3, 0);
         H3_EXPORT(h3GetFaces)(childPentagon, out);
         return;


### PR DESCRIPTION
Implements `h3GetFaces` per the discussion in #236, as well as the helper function `maxFaceCount` (using the same pattern as `maxKRingSize` etc). The `h3GetFaces` function takes an H3 index and an output array and fills the output array with all the icosahedron faces the index intersects. It returns 1 or 2 faces for hexagons and 5 faces for pentagons.

Implementing this required breaking up `_faceIjkToGeoBoundary` and `_faceIjkPentToGeoBoundary` in order to reuse the logic for getting the FaceIJK coords of the vertices - I've checked the benchmark locally and don't see any difference in `h3ToGeoBoundary` performance.

Also adds the test helper `iterateBaseCellIndexesAtRes` to iterate over a single specified base cell.

Closes #236