### PR TITLE
Use `argv[0]` for the program name in h3ToHier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Changed
 - Argument parsing for all filter applications is more flexible. (#238)
+### Fixed
+- Fix printing program name in `h3ToHier` error messages. (#254)
 
 ## [3.4.4] - 2019-05-30
 ### Changed

--- a/src/apps/miscapps/h3ToHier.c
+++ b/src/apps/miscapps/h3ToHier.c
@@ -84,13 +84,13 @@ int main(int argc, char *argv[]) {
     }
 
     if (res > MAX_H3_RES) {
-        printHelp(stderr, argv[1], helpText, numArgs, args,
+        printHelp(stderr, argv[0], helpText, numArgs, args,
                   "Resolution exceeds maximum resolution.", NULL);
         return 1;
     }
 
     if (parentArg.found && !H3_EXPORT(h3IsValid)(parentIndex)) {
-        printHelp(stderr, argv[1], helpText, numArgs, args,
+        printHelp(stderr, argv[0], helpText, numArgs, args,
                   "Parent index is invalid.", NULL);
         return 1;
     }


### PR DESCRIPTION
This would print one of the arguments as the program name when printing some error messages.