### PR TITLE
Handle empty (zero length) input to `compact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- `compact` handles zero length input correctly.
 
 ## [3.6.0] - 2019-08-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The public API of this library consists of the functions declared in file
 
 ## [Unreleased]
 ### Fixed
-- `compact` handles zero length input correctly.
+- `compact` handles zero length input correctly. (#278)
 
 ## [3.6.0] - 2019-08-12
 ### Added

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Uber Technologies, Inc.
+ * Copyright 2017-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,31 @@ SUITE(compact) {
                  "compact fails on duplicate input");
     }
 
+    TEST(compact_empty) {
+        t_assert(H3_EXPORT(compact)(NULL, NULL, 0) == 0,
+                 "compact succeeds on empty input");
+    }
+
+    TEST(compact_disparate) {
+        // Exercises a case where compaction needs to be tested but none is
+        // possible
+        const int numHex = 7;
+        H3Index disparate[numHex] = {0};
+        for (int i = 0; i < numHex; i++) {
+            setH3Index(&disparate[i], 1, i, CENTER_DIGIT);
+        }
+        H3Index output[numHex] = {0};
+
+        t_assert(H3_EXPORT(compact)(disparate, output, numHex) == 0,
+                 "compact succeeds on disparate input");
+
+        // Assumes that `output` is an exact copy of `disparate`, including
+        // the ordering (which may not necessarily be the case)
+        for (int i = 0; i < numHex; i++) {
+            t_assert(disparate[i] == output[i], "output set equals input set");
+        }
+    }
+
     TEST(uncompact_wrongRes) {
         int numHex = 3;
         H3Index someHexagons[] = {0, 0, 0};
@@ -221,6 +246,13 @@ SUITE(compact) {
         free(result);
     }
 
+    TEST(uncompact_empty) {
+        int uncompactSz = H3_EXPORT(maxUncompactSize)(NULL, 0, 0);
+        t_assert(uncompactSz == 0, "maxUncompactSize accepts empty input");
+        t_assert(H3_EXPORT(uncompact)(NULL, 0, NULL, 0, 0) == 0,
+                 "uncompact accepts empty input");
+    }
+
     TEST(uncompact_onlyZero) {
         // maxUncompactSize and uncompact both permit 0 indexes
         // in the input array, and skip them. When only a zero is
@@ -237,7 +269,7 @@ SUITE(compact) {
         free(children);
     }
 
-    TEST(uncompactZero) {
+    TEST(uncompact_withZero) {
         // maxUncompactSize and uncompact both permit 0 indexes
         // in the input array, and skip them.
 

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -161,11 +161,11 @@ SUITE(compact) {
         // Exercises a case where compaction needs to be tested but none is
         // possible
         const int numHex = 7;
-        H3Index disparate[numHex] = {0};
+        H3Index disparate[] = {0, 0, 0, 0, 0, 0, 0};
         for (int i = 0; i < numHex; i++) {
             setH3Index(&disparate[i], 1, i, CENTER_DIGIT);
         }
-        H3Index output[numHex] = {0};
+        H3Index output[] = {0, 0, 0, 0, 0, 0, 0};
 
         t_assert(H3_EXPORT(compact)(disparate, output, numHex) == 0,
                  "compact succeeds on disparate input");

--- a/src/apps/testapps/testGeoCoord.c
+++ b/src/apps/testapps/testGeoCoord.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Uber Technologies, Inc.
+ * Copyright 2017-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,6 +166,18 @@ SUITE(geoCoord) {
         _geoAzDistanceRads(&start2, azimuth + degrees180, distance, &out);
         // TODO: Epsilon is relatively large
         t_assert(_geoDistRads(&start, &out) < 0.01, "moved back to origin");
+    }
+
+    TEST(_geoDistRads_wrappedLongitude) {
+        const GeoCoord negativeLongitude = {.lat = 0, .lon = -(M_PI + M_PI_2)};
+        const GeoCoord zero = {.lat = 0, .lon = 0};
+
+        t_assert(fabs(M_PI_2 - _geoDistRads(&negativeLongitude, &zero)) <
+                     EPSILON_RAD,
+                 "Distance with wrapped longitude");
+        t_assert(fabs(M_PI_2 - _geoDistRads(&zero, &negativeLongitude)) <
+                     EPSILON_RAD,
+                 "Distance with wrapped longitude and swapped arguments");
     }
 
     TEST(doubleConstants) {

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -86,10 +86,12 @@ SUITE(h3ToLocalIj) {
     }
 
     TEST(ijOutOfRange) {
-        const int numCoords = 5;
-        const CoordIJ coords[] = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
+        const int numCoords = 7;
+        const CoordIJ coords[] = {{0, 0}, {1, 0},  {2, 0}, {3, 0},
+                                  {4, 0}, {-4, 0}, {0, 4}};
         const H3Index expected[] = {0x81283ffffffffff, 0x81293ffffffffff,
                                     0x8150bffffffffff, 0x8151bffffffffff,
+                                    H3_INVALID_INDEX,  H3_INVALID_INDEX,
                                     H3_INVALID_INDEX};
 
         for (int i = 0; i < numCoords; i++) {

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -576,11 +576,6 @@ SUITE(polygon) {
         t_assert(result == NORMALIZATION_ERR_UNASSIGNED_HOLES,
                  "Expected error code returned");
 
-        t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
-        t_assert(countLinkedLoops(&polygon) == 1,
-                 "Loop count on first polygon correct");
-        t_assert(polygon.first == outer, "Got expected outer loop");
-
         H3_EXPORT(destroyLinkedPolygon)(&polygon);
     }
 }

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Uber Technologies, Inc.
+ * Copyright 2017-2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -550,6 +550,36 @@ SUITE(polygon) {
         t_assert(countLinkedLoops(polygon.next) == 1,
                  "Loop count on second polygon correct");
         t_assert(polygon.next->first == outer2, "Got expected outer loop");
+
+        H3_EXPORT(destroyLinkedPolygon)(&polygon);
+    }
+
+    TEST(normalizeMultiPolygon_unassignedHole) {
+        GeoCoord verts[] = {{0, 0}, {0, 1}, {1, 1}, {1, 0}};
+
+        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        assert(outer != NULL);
+        createLinkedLoop(outer, &verts[0], 4);
+
+        GeoCoord verts2[] = {{2, 2}, {3, 3}, {2, 3}};
+
+        LinkedGeoLoop* inner = malloc(sizeof(*inner));
+        assert(inner != NULL);
+        createLinkedLoop(inner, &verts2[0], 3);
+
+        LinkedGeoPolygon polygon = {0};
+        addLinkedLoop(&polygon, inner);
+        addLinkedLoop(&polygon, outer);
+
+        int result = normalizeMultiPolygon(&polygon);
+
+        t_assert(result == NORMALIZATION_ERR_UNASSIGNED_HOLES,
+                 "Expected error code returned");
+
+        t_assert(countLinkedPolygons(&polygon) == 1, "Polygon count correct");
+        t_assert(countLinkedLoops(&polygon) == 1,
+                 "Loop count on first polygon correct");
+        t_assert(polygon.first == outer, "Got expected outer loop");
 
         H3_EXPORT(destroyLinkedPolygon)(&polygon);
     }

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -266,6 +266,9 @@ H3Index H3_EXPORT(h3ToCenterChild)(H3Index h, int childRes) {
  */
 int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                        const int numHexes) {
+    if (numHexes == 0) {
+        return 0;
+    }
     int res = H3_GET_RESOLUTION(h3Set[0]);
     if (res == 0) {
         // No compaction possible, just copy the set to output


### PR DESCRIPTION
`compact`, `maxUncompactSize`, and `uncompact` should handle the
case where empty input is provided. In this case the arrays
should not be dereferenced, since the first index is already out
of range.

This also adds tests for some uncovered branches.