### PR TITLE
Improved breadth-first 'spidering' polyfill algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The public API of this library consists of the functions declared in file
 ### Fixed
 - `compact` handles zero length input correctly. (#278)
 - `bboxHexRadius` scaling factor adjusted to guarantee containment for `polyfill`. (#279)
+- `polyfill` new algorithm for up to 3x perf boost. (#282)
 
 ## [3.6.0] - 2019-08-12
 ### Added

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -64,10 +64,10 @@ SUITE(polyfill) {
 
     TEST(maxPolyfillSize) {
         int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-        t_assert(numHexagons == 7057, "got expected max polyfill size");
+        t_assert(numHexagons == 3457, "got expected max polyfill size");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-        t_assert(numHexagons == 7057, "got expected max polyfill size (hole)");
+        t_assert(numHexagons == 3457, "got expected max polyfill size (hole)");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
         t_assert(numHexagons == 1, "got expected max polyfill size (empty)");

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -70,7 +70,7 @@ SUITE(polyfill) {
         t_assert(numHexagons == 3457, "got expected max polyfill size (hole)");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
-        t_assert(numHexagons == 1, "got expected max polyfill size (empty)");
+        t_assert(numHexagons == 3, "got expected max polyfill size (empty)");
     }
 
     TEST(polyfill) {

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -41,9 +41,9 @@ void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
 void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
 
 // Internal functions for polyfill
-int _get_edge_hexagons(const Geofence* geofence, int numHexagons, int res,
-                       int* numSearchHexes, H3Index* search, H3Index* found);
+int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
+                     int* numSearchHexes, H3Index* search, H3Index* found);
 
-int _polyfill_internal(const GeoPolygon* geoPolygon, int res, H3Index* out);
+int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out);
 
 #endif

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -40,10 +40,12 @@ void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
 // Create a LinkedGeoPolygon from a vertex graph
 void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
 
-// Internal functions for polyfill
+// Internal function for polyfill that traces a geofence with hexagons of a
+// specific size
 int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
                      int* numSearchHexes, H3Index* search, H3Index* found);
 
+// The new polyfill algorithm. Separated out because it can theoretically fail
 int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out);
 
 #endif

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -40,4 +40,10 @@ void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
 // Create a LinkedGeoPolygon from a vertex graph
 void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
 
+// Internal functions for polyfill
+int _get_edge_hexagons(const Geofence* geofence, int numHexagons, int res,
+                       int* numSearchHexes, H3Index* search, H3Index* found);
+
+int _polyfill_internal(const GeoPolygon* geoPolygon, int res, H3Index* out);
+
 #endif

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -37,6 +37,6 @@ bool bboxIsTransmeridian(const BBox* bbox);
 void bboxCenter(const BBox* bbox, GeoCoord* center);
 bool bboxContains(const BBox* bbox, const GeoCoord* point);
 bool bboxEquals(const BBox* b1, const BBox* b2);
-int bboxHexRadius(const BBox* bbox, int res);
+int bboxHexEstimate(const BBox* bbox, int res);
 
 #endif

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -38,5 +38,7 @@ void bboxCenter(const BBox* bbox, GeoCoord* center);
 bool bboxContains(const BBox* bbox, const GeoCoord* point);
 bool bboxEquals(const BBox* b1, const BBox* b2);
 int bboxHexEstimate(const BBox* bbox, int res);
+int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
+                    int res);
 
 #endif

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -221,7 +221,7 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index *out);
 int H3_EXPORT(maxPolyfillSize)(const GeoPolygon *geoPolygon, int res);
 
 /** @brief hexagons within the given geofence */
-int H3_EXPORT(polyfill)(const GeoPolygon *geoPolygon, int res, H3Index *out);
+void H3_EXPORT(polyfill)(const GeoPolygon *geoPolygon, int res, H3Index *out);
 /** @} */
 
 /** @defgroup h3SetToMultiPolygon h3SetToMultiPolygon

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -221,7 +221,7 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index *out);
 int H3_EXPORT(maxPolyfillSize)(const GeoPolygon *geoPolygon, int res);
 
 /** @brief hexagons within the given geofence */
-void H3_EXPORT(polyfill)(const GeoPolygon *geoPolygon, int res, H3Index *out);
+int H3_EXPORT(polyfill)(const GeoPolygon *geoPolygon, int res, H3Index *out);
 /** @} */
 
 /** @defgroup h3SetToMultiPolygon h3SetToMultiPolygon

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -653,9 +653,10 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
  * zeroed memory, and fills it with the hexagons that are contained by
  * the GeoJSON-like data structure.
  *
- * This implementation traces the GeoJSON geofence(s) with hexagons, tests
- * them and their neighbors to be contained by the geofence(s), and then any
- * newly found hexagons are used to test again until no new hexagons are found.
+ * This implementation traces the GeoJSON geofence(s) in cartesian space with
+ * hexagons, tests them and their neighbors to be contained by the geofence(s),
+ * and then any newly found hexagons are used to test again until no new hexagons
+ * are found.
  *
  * @param geoPolygon The geofence and holes defining the relevant area
  * @param res The Hexagon resolution (0-15)

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -800,7 +800,7 @@ int _polyfill_internal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
                 // A simple hash to store the hexagon, or move to another place
                 // if needed. This MUST be done before the point-in-poly check
                 // since that's far more expensive
-                int loc = (int)(hex % numHexagons);
+                int loc = (int)(hex % (numHexagons - 1));
                 int loopCount = 0;
                 while (out[loc] != 0) {
                     if (loopCount > numHexagons) {

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -663,10 +663,12 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
 void H3_EXPORT(polyfill)(const GeoPolygon* geoPolygon, int res, H3Index* out) {
     // TODO: Eliminate this wrapper with the H3 4.0.0 release
     int failure = _polyfillInternal(geoPolygon, res, out);
+    // LCOV_EXCL_START
     if (failure) {
         int numHexagons = H3_EXPORT(maxPolyfillSize)(geoPolygon, res);
         for (int i = 0; i < numHexagons; i++) out[i] = H3_INVALID_INDEX;
     }
+    // LCOV_EXCL_STOP
 }
 
 /**
@@ -710,9 +712,7 @@ int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
             int loc = (int)(pointHex % numHexagons);
             int loopCount = 0;
             while (found[loc] != 0) {
-                if (loopCount > numHexagons) {
-                    return -1;
-                }
+                if (loopCount > numHexagons) return -1;  // LCOV_EXCL_LINE
                 if (found[loc] == pointHex)
                     break;  // At least two points of the geofence index to the
                             // same cell
@@ -788,12 +788,14 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
     const Geofence geofence = geoPolygon->geofence;
     int failure = _getEdgeHexagons(&geofence, numHexagons, res, &numSearchHexes,
                                    search, found);
+    // LCOV_EXCL_START
     if (failure) {
         free(search);
         free(found);
         free(bboxes);
         return failure;
     }
+    // LCOV_EXCL_STOP
 
     // 2. Iterate over all holes, trace the polygons defining the holes with
     // hexagons and add to only the search hash. We're going to temporarily use
@@ -804,12 +806,14 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
         Geofence* hole = &(geoPolygon->holes[i]);
         failure = _getEdgeHexagons(hole, numHexagons, res, &numSearchHexes,
                                    search, found);
+        // LCOV_EXCL_START
         if (failure) {
             free(search);
             free(found);
             free(bboxes);
             return failure;
         }
+        // LCOV_EXCL_STOP
     }
 
     // 3. Re-zero the found hash so it can be used in the main loop below
@@ -840,12 +844,14 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
                 int loc = (int)(hex % numHexagons);
                 int loopCount = 0;
                 while (out[loc] != 0) {
+                    // LCOV_EXCL_START
                     if (loopCount > numHexagons) {
                         free(search);
                         free(found);
                         free(bboxes);
                         return -1;
                     }
+                    // LCOV_EXCL_STOP
                     if (out[loc] == hex) break;  // Skip duplicates found
                     loc = (loc + 1) % numHexagons;
                     loopCount++;

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -655,8 +655,8 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
  *
  * This implementation traces the GeoJSON geofence(s) in cartesian space with
  * hexagons, tests them and their neighbors to be contained by the geofence(s),
- * and then any newly found hexagons are used to test again until no new hexagons
- * are found.
+ * and then any newly found hexagons are used to test again until no new
+ * hexagons are found.
  *
  * @param geoPolygon The geofence and holes defining the relevant area
  * @param res The Hexagon resolution (0-15)

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -640,11 +640,11 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
     // This algorithm assumes that the number of vertices is usually less than
     // the number of hexagons, but when it's wrong, this will keep it from
     // failing
-    int numVerts = geofence.numVerts;
+    int totalVerts = geofence.numVerts;
     for (int i = 0; i < geoPolygon->numHoles; i++) {
-        numVerts += geoPolygon->holes[i].numVerts;
+        totalVerts += geoPolygon->holes[i].numVerts;
     }
-    if (numHexagons < numVerts) numHexagons = numVerts;
+    if (numHexagons < totalVerts) numHexagons = totalVerts;
     return numHexagons;
 }
 

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -41,6 +41,7 @@
 #define HEX_RANGE_SUCCESS 0
 #define HEX_RANGE_PENTAGON 1
 #define HEX_RANGE_K_SUBSEQUENCE 2
+#define MAX_ONE_RING_SIZE 7
 
 /**
  * Directions used for traversing a hexagonal ring counterclockwise around
@@ -824,13 +825,13 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
         // Iterate through all hexagons in the current search hash, then loop
         // through all neighbors and test Point-in-Poly, if point-in-poly
         // succeeds, add to out and found hashes if not already there.
-        H3Index ring[7] = {0};
         int currentSearchNum = 0;
         int i = 0;
         while (currentSearchNum < numSearchHexes) {
+            H3Index ring[MAX_ONE_RING_SIZE] = {0};
             H3Index searchHex = search[i];
             H3_EXPORT(kRing)(searchHex, 1, ring);
-            for (int j = 0; j < 7; j++) {
+            for (int j = 0; j < MAX_ONE_RING_SIZE; j++) {
                 if (ring[j] == H3_INVALID_INDEX) {
                     continue;  // Skip if this was a pentagon and only had 5
                                // neighbors
@@ -878,7 +879,6 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
                 // Wipe the current hex ring value back out
                 ring[j] = 0;
             }
-            ring[0] = 0;
             currentSearchNum++;
             i++;
         }

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -90,7 +90,7 @@ double _hexRadiusKm(H3Index h3Index) {
 int bboxHexEstimate(const BBox* bbox, int res) {
     // Get the area of the pentagon as the maximally-distored area possible
     H3Index pentagons[12] = {0};
-    getPentagonIndexes(res, pentagons);
+    H3_EXPORT(getPentagonIndexes)(res, pentagons);
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
     // Area of a regular hexagon is 3/2*sqrt(3) * r * r
     double pentagonAreaKm2 =

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -94,7 +94,7 @@ int bboxHexEstimate(const BBox* bbox, int res) {
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
     // Area of a regular hexagon is 3/2*sqrt(3) * r * r
     // The pentagon has the most distortion (smallest edges) and shares its
-    // edges with hexagons, so the most-distored hexagons have this area
+    // edges with hexagons, so the most-distorted hexagons have this area
     double pentagonAreaKm2 =
         2.59807621135 * pentagonRadiusKm * pentagonRadiusKm;
 
@@ -117,7 +117,7 @@ int bboxHexEstimate(const BBox* bbox, int res) {
 
 int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
                     int res) {
-    // Get the area of the pentagon as the maximally-distored area possible
+    // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     H3_EXPORT(getPentagonIndexes)(res, pentagons);
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -87,6 +87,14 @@ double _hexRadiusKm(H3Index h3Index) {
     return _geoDistKm(&h3Center, h3Boundary.verts);
 }
 
+/**
+ * bboxHexEstimate returns an estimated number of hexagons that fit
+ *                 within the cartesian-projected bounding box
+ *
+ * @param bbox the bounding box to estimate the hexagon fill level
+ * @param res the resolution of the H3 hexagons to fill the bounding box
+ * @return the estimated number of hexagons to fill the bounding box
+ */
 int bboxHexEstimate(const BBox* bbox, int res) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
@@ -115,6 +123,15 @@ int bboxHexEstimate(const BBox* bbox, int res) {
     return estimate;
 }
 
+/**
+ * lineHexEstimate returns an estimated number of hexagons that trace
+ *                 the cartesian-projected line
+ *
+ *  @param origin the origin coordinates
+ *  @param destination the destination coordinates
+ *  @param res the resolution of the H3 hexagons to trace the line
+ *  @return the estimated number of hexagons required to trace the line
+ */
 int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
                     int res) {
     // Get the area of the pentagon as the maximally-distorted area possible

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -112,3 +112,16 @@ int bboxHexEstimate(const BBox* bbox, int res) {
     if (estimate == 0) estimate = 1;
     return estimate;
 }
+
+int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
+                    int res) {
+    // Get the area of the pentagon as the maximally-distored area possible
+    H3Index pentagons[12] = {0};
+    H3_EXPORT(getPentagonIndexes)(res, pentagons);
+    double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
+
+    double dist = _geoDistKm(origin, destination);
+    int estimate = (int)ceil(dist / (2 * pentagonRadiusKm));
+    if (estimate == 0) estimate = 1;
+    return estimate;
+}

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -88,11 +88,13 @@ double _hexRadiusKm(H3Index h3Index) {
 }
 
 int bboxHexEstimate(const BBox* bbox, int res) {
-    // Get the area of the pentagon as the maximally-distored area possible
+    // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     H3_EXPORT(getPentagonIndexes)(res, pentagons);
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
     // Area of a regular hexagon is 3/2*sqrt(3) * r * r
+    // The pentagon has the most distortion (smallest edges) and shares its
+    // edges with hexagons, so the most-distored hexagons have this area
     double pentagonAreaKm2 =
         2.59807621135 * pentagonRadiusKm * pentagonRadiusKm;
 


### PR DESCRIPTION
This is mostly complete (I still need to review some of the comments to make sure they're up-to-date, update the CHANGELOG, etc) but I wanted to get it going through the CI systems to make sure there's not any platform-dependent bug (I doubt it, but...)

This took a little bit longer than I hoped because the performance with my first attempt was actually worse than before and I had to figure out why -- eliminating as many of the point-in-poly operations as possible is the most important thing. Now the performance is much better than before:

Master:

```
[ 54%] Built target benchmarkPolyfill
        -- polyfillSF: 6562.680264 microseconds per iteration (500 iterations)
        -- polyfillAlameda: 11169.898362 microseconds per iteration (500 iterations)
        -- polyfillSouthernExpansion: 507985.009400 microseconds per iteration (10 iterations)
```

This branch:

```
[ 54%] Built target benchmarkPolyfill
        -- polyfillSF: 2170.498146 microseconds per iteration (500 iterations)
        -- polyfillAlameda: 2927.510110 microseconds per iteration (500 iterations)
        -- polyfillSouthernExpansion: 125272.485300 microseconds per iteration (10 iterations)
```

That's 3x, 3.8x, and 4x faster, respectively, which means it's better than the earlier, partially incorrect algorithm.

I have a suspicion that I can get this even better and will be trying my idea out shortly, but this works and I got all tests to pass, so this is the 90% complete version that is already ready for review, I think.