### PR TITLE
Detect and fail on duplicate input to `compact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
-- `compact` detects and fails on cases with duplicated input indexes.
+### Fixed
+- `compact` detects and fails on cases with duplicated input indexes. (#299)
 
 ## [3.6.2] - 2019-12-9
 - Revert new `polyfill` algorithm until reported issues are fixed. (#293)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+- `compact` detects and fails on cases with duplicated input indexes.
 
 ## [3.6.2] - 2019-12-9
 - Revert new `polyfill` algorithm until reported issues are fixed. (#293)

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -152,6 +152,52 @@ SUITE(compact) {
                  "compact fails on duplicate input");
     }
 
+    TEST(compact_duplicateMinimum) {
+        // Test that the minimum number of duplicate hexagons causes failure
+        H3Index h3;
+        // Arbitrary index
+        setH3Index(&h3, 5, 0, 2);
+
+        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, 11) + 1;
+        H3Index* children = calloc(arrSize, sizeof(H3Index));
+
+        H3_EXPORT(h3ToChildren)(h3, 11, children);
+        // duplicate one index
+        children[arrSize - 1] = children[0];
+
+        H3Index* output = calloc(arrSize, sizeof(H3Index));
+
+        int compactResult = H3_EXPORT(compact)(children, output, arrSize);
+        t_assert(compactResult != 0,
+                 "compact fails on duplicate input (single duplicate)");
+
+        free(output);
+        free(children);
+    }
+
+    TEST(compact_duplicatePentagonLimit) {
+        // Test that the minimum number of duplicate hexagons causes failure
+        H3Index h3;
+        // Arbitrary pentagon parent cell
+        setH3Index(&h3, 5, 4, 0);
+
+        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, 11) + 1;
+        H3Index* children = calloc(arrSize, sizeof(H3Index));
+
+        H3_EXPORT(h3ToChildren)(h3, 11, children);
+        // duplicate one index
+        children[arrSize - 1] = H3_EXPORT(h3ToCenterChild)(h3, 11);
+
+        H3Index* output = calloc(arrSize, sizeof(H3Index));
+
+        int compactResult = H3_EXPORT(compact)(children, output, arrSize);
+        t_assert(compactResult != 0,
+                 "compact fails on duplicate input (pentagon parent)");
+
+        free(output);
+        free(children);
+    }
+
     TEST(compact_empty) {
         t_assert(H3_EXPORT(compact)(NULL, NULL, 0) == 0,
                  "compact succeeds on empty input");

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -155,20 +155,21 @@ SUITE(compact) {
     TEST(compact_duplicateMinimum) {
         // Test that the minimum number of duplicate hexagons causes failure
         H3Index h3;
+        int res = 10;
         // Arbitrary index
-        setH3Index(&h3, 5, 0, 2);
+        setH3Index(&h3, res, 0, 2);
 
-        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, 11) + 1;
+        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, res + 1) + 1;
         H3Index* children = calloc(arrSize, sizeof(H3Index));
 
-        H3_EXPORT(h3ToChildren)(h3, 11, children);
+        H3_EXPORT(h3ToChildren)(h3, res + 1, children);
         // duplicate one index
         children[arrSize - 1] = children[0];
 
         H3Index* output = calloc(arrSize, sizeof(H3Index));
 
         int compactResult = H3_EXPORT(compact)(children, output, arrSize);
-        t_assert(compactResult != 0,
+        t_assert(compactResult == COMPACT_DUPLICATE,
                  "compact fails on duplicate input (single duplicate)");
 
         free(output);
@@ -178,21 +179,48 @@ SUITE(compact) {
     TEST(compact_duplicatePentagonLimit) {
         // Test that the minimum number of duplicate hexagons causes failure
         H3Index h3;
+        int res = 10;
         // Arbitrary pentagon parent cell
-        setH3Index(&h3, 5, 4, 0);
+        setH3Index(&h3, res, 4, 0);
 
-        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, 11) + 1;
+        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, res + 1) + 1;
         H3Index* children = calloc(arrSize, sizeof(H3Index));
 
-        H3_EXPORT(h3ToChildren)(h3, 11, children);
+        H3_EXPORT(h3ToChildren)(h3, res + 1, children);
         // duplicate one index
-        children[arrSize - 1] = H3_EXPORT(h3ToCenterChild)(h3, 11);
+        children[arrSize - 1] = H3_EXPORT(h3ToCenterChild)(h3, res + 1);
 
         H3Index* output = calloc(arrSize, sizeof(H3Index));
 
         int compactResult = H3_EXPORT(compact)(children, output, arrSize);
-        t_assert(compactResult != 0,
+        t_assert(compactResult == COMPACT_DUPLICATE,
                  "compact fails on duplicate input (pentagon parent)");
+
+        free(output);
+        free(children);
+    }
+
+    TEST(compact_duplicateIgnored) {
+        // Test that duplicated cells are not rejected by compact.
+        // This is not necessarily desired - just asserting the
+        // existing behavior.
+        H3Index h3;
+        int res = 10;
+        // Arbitrary index
+        setH3Index(&h3, res, 0, 2);
+
+        int arrSize = H3_EXPORT(maxH3ToChildrenSize)(h3, res + 1);
+        H3Index* children = calloc(arrSize, sizeof(H3Index));
+
+        H3_EXPORT(h3ToChildren)(h3, res + 1, children);
+        // duplicate one index
+        children[arrSize - 1] = children[0];
+
+        H3Index* output = calloc(arrSize, sizeof(H3Index));
+
+        int compactResult = H3_EXPORT(compact)(children, output, arrSize);
+        t_assert(compactResult == COMPACT_SUCCESS,
+                 "compact succeeds on duplicate input (correct count)");
 
         free(output);
         free(children);

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -147,6 +147,14 @@
  */
 #define H3_INVALID_INDEX 0
 
+/*
+ * Return codes for compact
+ */
+
+#define COMPACT_SUCCESS 0
+#define COMPACT_LOOP_EXCEEDED -1
+#define COMPACT_DUPLICATE -2
+
 void setH3Index(H3Index* h, int res, int baseCell, Direction initDigit);
 int isResClassIII(int res);
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -314,7 +314,15 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                         hashSetArray[loc] & H3_RESERVED_MASK_NEGATIVE;
                     if (tempIndex == parent) {
                         int count = H3_GET_RESERVED_BITS(hashSetArray[loc]) + 1;
-                        if (count > 7) {
+                        int limitCount = 7;
+                        if (H3_EXPORT(h3IsPentagon)(
+                                tempIndex & H3_RESERVED_MASK_NEGATIVE)) {
+                            limitCount--;
+                        }
+                        // One is added to count for this check to match one
+                        // being added to count later in this function when
+                        // checking for all children being present.
+                        if (count + 1 > limitCount) {
                             // Only possible on duplicate input
                             free(remainingHexes);
                             free(hashSetArray);

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -271,7 +271,7 @@ H3Index H3_EXPORT(h3ToCenterChild)(H3Index h, int childRes) {
 int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                        const int numHexes) {
     if (numHexes == 0) {
-        return 0;
+        return COMPACT_SUCCESS;
     }
     int res = H3_GET_RESOLUTION(h3Set[0]);
     if (res == 0) {
@@ -279,7 +279,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
         for (int i = 0; i < numHexes; i++) {
             compactedSet[i] = h3Set[i];
         }
-        return 0;
+        return COMPACT_SUCCESS;
     }
     H3Index* remainingHexes = malloc(numHexes * sizeof(H3Index));
     memcpy(remainingHexes, h3Set, numHexes * sizeof(H3Index));
@@ -307,7 +307,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                         // numRemainingHexes.
                         free(remainingHexes);
                         free(hashSetArray);
-                        return -1;
+                        return COMPACT_LOOP_EXCEEDED;
                         // LCOV_EXCL_STOP
                     }
                     H3Index tempIndex =
@@ -326,7 +326,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                             // Only possible on duplicate input
                             free(remainingHexes);
                             free(hashSetArray);
-                            return -2;
+                            return COMPACT_DUPLICATE;
                         }
                         H3_SET_RESERVED_BITS(parent, count);
                         hashSetArray[loc] = H3_INVALID_INDEX;
@@ -391,7 +391,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
                         free(compactableHexes);
                         free(remainingHexes);
                         free(hashSetArray);
-                        return -1;  // Only possible on duplicate input
+                        return COMPACT_LOOP_EXCEEDED;
                         // LCOV_EXCL_STOP
                     }
                     H3Index tempIndex =
@@ -423,7 +423,7 @@ int H3_EXPORT(compact)(const H3Index* h3Set, H3Index* compactedSet,
     }
     free(remainingHexes);
     free(hashSetArray);
-    return 0;
+    return COMPACT_SUCCESS;
 }
 
 /**


### PR DESCRIPTION
See #298.

There was an off by one error in detecting duplicate inputs to `compact`. All the comparisons assumed one-indexed counts, but only the second comparison (checking for whether all children were present in order to replace the parent) added one to the count. The first comparison (checking for duplicates) used the count directly from the array, which was zero-indexed.