### PR TITLE
Clarify that the reserved bits must be 0 for cell (mode 1) indexes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ The public API of this library consists of the functions declared in file
 ### Fixed
 - `compact` detects and fails on cases with duplicated input indexes. (#299)
 ### Changed
-- Clarify that the reserved bits of H3 cell (mode 1) indexes must be 0 to be valid.
-- Clarify that the high bit of all `H3Index`es must be 0.
-- `h3IsValid` rejects indexes that have non-zero reserved bits.
-- `h3IsValid` and `h3UnidirectionalEdgeIsValid` rejects indexes with the high bit set.
+- `h3IsValid` rejects indexes that have non-zero reserved bits. (#300)
+- `h3IsValid` and `h3UnidirectionalEdgeIsValid` rejects indexes with the high bit set. (#300)
 
 ## [3.6.2] - 2019-12-9
 - Revert new `polyfill` algorithm until reported issues are fixed. (#293)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Fixed
 - `compact` detects and fails on cases with duplicated input indexes. (#299)
+### Changed
+- Clarify that the reserved bits of H3 cell (mode 1) indexes must be 0 to be valid.
+- Clarify that the high bit of all `H3Index`es must be 0.
+- `h3IsValid` rejects indexes that have non-zero reserved bits.
+- `h3IsValid` and `h3UnidirectionalEdgeIsValid` rejects indexes with the high bit set.
 
 ## [3.6.2] - 2019-12-9
 - Revert new `polyfill` algorithm until reported issues are fixed. (#293)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The public API of this library consists of the functions declared in file
 ### Fixed
 - `compact` detects and fails on cases with duplicated input indexes. (#299)
 ### Changed
-- `h3IsValid` rejects indexes that have non-zero reserved bits. (#300)
-- `h3IsValid` and `h3UnidirectionalEdgeIsValid` rejects indexes with the high bit set. (#300)
+- `h3IsValid` returns false for indexes that have non-zero reserved bits. (#300)
+- `h3IsValid` and `h3UnidirectionalEdgeIsValid` return false for indexes with the high bit set. (#300)
 
 ## [3.6.2] - 2019-12-9
 - Revert new `polyfill` algorithm until reported issues are fixed. (#293)

--- a/docs/core-library/h3indexing.md
+++ b/docs/core-library/h3indexing.md
@@ -18,27 +18,27 @@ H3Index Representation
 
 The **H3Index** is the integer representation of an **H3** index, which can be placed into multiple modes to indicate the kind of concept being indexed. Mode 1 is an **H3** Cell (Hexagon) Index, mode 2 is an **H3** Unidirectional Edge (Hexagon A -> Hexagon B) Index, mode 3 is planned to be a bidirectional edge (Hexagon A <-> Hexagon B). Mode 0 is reserved and indicates an invalid **H3** index.
 
-The components of the **H3** cell index (mode 1) are packed into the lowest order 63 bits of a 64-bit integer in order as follows:
+The components of the **H3** cell index (mode 1) are packed into a 64-bit integer in order, highest bit first, as follows:
 
+* 1 bit reserved and set to 0,
 * 4 bits to indicate the index mode,
 * 3 bits reserved and set to 0,
 * 4 bits to indicate the cell resolution 0-15,
 * 7 bits to indicate the base cell 0-121, and
-* 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total is reserved for resolutions 1-15)
+* 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total are reserved for resolutions 1-15)
 
-The components of the **H3** unidirectional edge index (mode 2) are packed into the lowest order 63 bits of a 64-bit integer in order as follows:
+The components of the **H3** unidirectional edge index (mode 2) are packed into a 64-bit integer in order, highest bit first, as follows:
 
+* 1 bit reserved and set to 0,
 * 4 bits to indicate the index mode,
 * 3 bits to indicate the edge 1-6 of the cell to traverse,
 * 4 bits to indicate the cell resolution 0-15,
 * 7 bits to indicate the base cell 0-121, and
-* 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total is reserved for resolutions 1-15)
+* 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total are reserved for resolutions 1-15)
 
-The canonical string representation of an **H3Index** is the hexadecimal representation of the integer, using lowercase letters.
+The canonical string representation of an **H3Index** is the hexadecimal representation of the integer, using lowercase letters. The string representation is variable length (no zero padding) and is not prefixed or suffixed.
 
 The three bits for each unused digit are set to 7.
-
-The highest order bit of an **H3Index** must be set to 0.
 
 Bit layout of H3Index
 ---
@@ -67,7 +67,7 @@ The layout of an **H3Index** is shown below in table form. The interpretation of
 </tr>
 <tr>
   <th>0x30</th>
-  <td></td>
+  <td>Reserved</td>
   <td colspan="4">Mode</td>
   <td colspan="3">Reserved/edge</td>
   <td colspan="4">Resolution</td>

--- a/docs/core-library/h3indexing.md
+++ b/docs/core-library/h3indexing.md
@@ -21,7 +21,7 @@ The **H3Index** is the integer representation of an **H3** index, which can be p
 The components of the **H3** cell index (mode 1) are packed into the lowest order 63 bits of a 64-bit integer in order as follows:
 
 * 4 bits to indicate the index mode,
-* 3 bits reserved,
+* 3 bits reserved and set to 0,
 * 4 bits to indicate the cell resolution 0-15,
 * 7 bits to indicate the base cell 0-121, and
 * 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total is reserved for resolutions 1-15)
@@ -34,9 +34,11 @@ The components of the **H3** unidirectional edge index (mode 2) are packed into 
 * 7 bits to indicate the base cell 0-121, and
 * 3 bits to indicate each subsequent digit 0-6 from resolution 1 up to the resolution of the cell (45 bits total is reserved for resolutions 1-15)
 
-The canonical string representation of an **H3Index** is the hexadecimal representation of the integer.
+The canonical string representation of an **H3Index** is the hexadecimal representation of the integer, using lowercase letters.
 
 The three bits for each unused digit are set to 7.
+
+The highest order bit of an **H3Index** must be set to 0.
 
 Bit layout of H3Index
 ---

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -111,8 +111,27 @@ SUITE(h3Index) {
             H3_SET_MODE(h, i);
             char failureMessage[BUFF_SIZE];
             sprintf(failureMessage, "h3IsValid failed on mode %d", i);
-            t_assert(!H3_EXPORT(h3IsValid)(h) || i == 1, failureMessage);
+            t_assert(!H3_EXPORT(h3IsValid)(h) || i == H3_HEXAGON_MODE,
+                     failureMessage);
         }
+    }
+
+    TEST(h3IsValidReservedBits) {
+        for (int i = 0; i < 8; i++) {
+            H3Index h = H3_INIT;
+            H3_SET_MODE(h, H3_HEXAGON_MODE);
+            H3_SET_RESERVED_BITS(h, i);
+            char failureMessage[BUFF_SIZE];
+            sprintf(failureMessage, "h3IsValid failed on reserved bits %d", i);
+            t_assert(!H3_EXPORT(h3IsValid)(h) || i == 0, failureMessage);
+        }
+    }
+
+    TEST(h3IsValidHighBit) {
+        H3Index h = H3_INIT;
+        H3_SET_MODE(h, H3_HEXAGON_MODE);
+        H3_SET_HIGH_BIT(h, 1);
+        t_assert(!H3_EXPORT(h3IsValid)(h), "h3IsValid failed on high bit");
     }
 
     TEST(h3BadDigitInvalid) {

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -109,10 +109,14 @@ SUITE(h3Index) {
         for (int i = 0; i <= 0xf; i++) {
             H3Index h = H3_INIT;
             H3_SET_MODE(h, i);
-            char failureMessage[BUFF_SIZE];
-            sprintf(failureMessage, "h3IsValid failed on mode %d", i);
-            t_assert(!H3_EXPORT(h3IsValid)(h) || i == H3_HEXAGON_MODE,
-                     failureMessage);
+            if (i == H3_HEXAGON_MODE) {
+                t_assert(H3_EXPORT(h3IsValid)(h),
+                         "h3IsValid succeeds on valid mode");
+            } else {
+                char failureMessage[BUFF_SIZE];
+                sprintf(failureMessage, "h3IsValid failed on mode %d", i);
+                t_assert(!H3_EXPORT(h3IsValid)(h), failureMessage);
+            }
         }
     }
 
@@ -121,9 +125,15 @@ SUITE(h3Index) {
             H3Index h = H3_INIT;
             H3_SET_MODE(h, H3_HEXAGON_MODE);
             H3_SET_RESERVED_BITS(h, i);
-            char failureMessage[BUFF_SIZE];
-            sprintf(failureMessage, "h3IsValid failed on reserved bits %d", i);
-            t_assert(!H3_EXPORT(h3IsValid)(h) || i == 0, failureMessage);
+            if (i == 0) {
+                t_assert(H3_EXPORT(h3IsValid)(h),
+                         "h3IsValid succeeds on valid reserved bits");
+            } else {
+                char failureMessage[BUFF_SIZE];
+                sprintf(failureMessage, "h3IsValid failed on reserved bits %d",
+                        i);
+                t_assert(!H3_EXPORT(h3IsValid)(h), failureMessage);
+            }
         }
     }
 

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -166,6 +166,11 @@ SUITE(h3UniEdge) {
         H3_SET_RESERVED_BITS(badPentagonalEdge, 1);
         t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(badPentagonalEdge) == 0,
                  "missing pentagonal edge does not validate");
+
+        H3Index highBitEdge = edge;
+        H3_SET_HIGH_BIT(highBitEdge, 1);
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(highBitEdge) == 0,
+                 "high bit set edge does not validate");
     }
 
     TEST(getH3UnidirectionalEdgesFromHexagon) {

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -49,7 +49,7 @@
 /** 1 in the highest bit, 0's everywhere else. */
 #define H3_HIGH_BIT_MASK ((uint64_t)(1) << H3_MAX_OFFSET)
 
-/** 1 in the highest bit, 0's everywhere else. */
+/** 0 in the highest bit, 1's everywhere else. */
 #define H3_HIGH_BIT_MASK_NEGATIVE (~H3_HIGH_BIT_MASK)
 
 /** 1's in the 4 mode bits, 0's everywhere else. */

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -46,6 +46,12 @@
 /** The number of bits in a single H3 resolution digit. */
 #define H3_PER_DIGIT_OFFSET 3
 
+/** 1 in the highest bit, 0's everywhere else. */
+#define H3_HIGH_BIT_MASK ((uint64_t)(1) << H3_MAX_OFFSET)
+
+/** 1 in the highest bit, 0's everywhere else. */
+#define H3_HIGH_BIT_MASK_NEGATIVE (~H3_HIGH_BIT_MASK)
+
 /** 1's in the 4 mode bits, 0's everywhere else. */
 #define H3_MODE_MASK ((uint64_t)(15) << H3_MODE_OFFSET)
 
@@ -78,6 +84,18 @@
 
 /** H3 index with mode 0, res 0, base cell 0, and 7 for all index digits. */
 #define H3_INIT (UINT64_C(35184372088831))
+
+/**
+ * Gets the highest bit of the H3 index.
+ */
+#define H3_GET_HIGH_BIT(h3) ((int)((((h3)&H3_HIGH_BIT_MASK) >> H3_MAX_OFFSET)))
+
+/**
+ * Sets the highest bit of the h3 to v.
+ */
+#define H3_SET_HIGH_BIT(h3, v)                 \
+    (h3) = (((h3)&H3_HIGH_BIT_MASK_NEGATIVE) | \
+            (((uint64_t)(v)) << H3_MAX_OFFSET))
 
 /**
  * Gets the integer mode of h3.

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -79,7 +79,12 @@ void H3_EXPORT(h3ToString)(H3Index h, char* str, size_t sz) {
  * @return 1 if the H3 index if valid, and 0 if it is not.
  */
 int H3_EXPORT(h3IsValid)(H3Index h) {
+    if (H3_GET_HIGH_BIT(h) != 0) return 0;
+
     if (H3_GET_MODE(h) != H3_HEXAGON_MODE) return 0;
+
+    int reservedBits = H3_GET_RESERVED_BITS(h);
+    if (reservedBits != 0) return 0;
 
     int baseCell = H3_GET_BASE_CELL(h);
     if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) return 0;

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -83,8 +83,7 @@ int H3_EXPORT(h3IsValid)(H3Index h) {
 
     if (H3_GET_MODE(h) != H3_HEXAGON_MODE) return 0;
 
-    int reservedBits = H3_GET_RESERVED_BITS(h);
-    if (reservedBits != 0) return 0;
+    if (H3_GET_RESERVED_BITS(h) != 0) return 0;
 
     int baseCell = H3_GET_BASE_CELL(h);
     if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) return 0;

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -179,7 +179,7 @@ int H3_EXPORT(h3UnidirectionalEdgeIsValid)(H3Index edge) {
         return 0;
     }
 
-    return H3_EXPORT(h3IsValid)(origin);
+    return H3_EXPORT(h3IsValid)(origin & H3_RESERVED_MASK_NEGATIVE);
 }
 
 /**

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -179,7 +179,7 @@ int H3_EXPORT(h3UnidirectionalEdgeIsValid)(H3Index edge) {
         return 0;
     }
 
-    return H3_EXPORT(h3IsValid)(origin & H3_RESERVED_MASK_NEGATIVE);
+    return H3_EXPORT(h3IsValid)(origin);
 }
 
 /**


### PR DESCRIPTION
Clarify the documentation and validation functions that the reserved
bits must be 0 for a cell index to be valid. This is done to prevent
valid indexes being different but refering to the same cell.

The high bit of an H3Index is also treated as a reserved bit
(previously documentation was silent on it.)

See #297.