### PR TITLE
Revive the faster polyfill algorithm

### DIFF
--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -121,13 +121,13 @@ SUITE(polyfill) {
 
     TEST(maxPolyfillSize) {
         int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-        t_assert(numHexagons == 7057, "got expected max polyfill size");
+        t_assert(numHexagons == 3457, "got expected max polyfill size");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-        t_assert(numHexagons == 7057, "got expected max polyfill size (hole)");
+        t_assert(numHexagons == 3457, "got expected max polyfill size (hole)");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
-        t_assert(numHexagons == 1, "got expected max polyfill size (empty)");
+        t_assert(numHexagons == 3, "got expected max polyfill size (empty)");
     }
 
     TEST(polyfill) {

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -121,13 +121,13 @@ SUITE(polyfill) {
 
     TEST(maxPolyfillSize) {
         int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-        t_assert(numHexagons == 3457, "got expected max polyfill size");
+        t_assert(numHexagons == 3559, "got expected max polyfill size");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-        t_assert(numHexagons == 3457, "got expected max polyfill size (hole)");
+        t_assert(numHexagons == 3559, "got expected max polyfill size (hole)");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
-        t_assert(numHexagons == 3, "got expected max polyfill size (empty)");
+        t_assert(numHexagons == 15, "got expected max polyfill size (empty)");
     }
 
     TEST(polyfill) {

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -121,10 +121,10 @@ SUITE(polyfill) {
 
     TEST(maxPolyfillSize) {
         int numHexagons = H3_EXPORT(maxPolyfillSize)(&sfGeoPolygon, 9);
-        t_assert(numHexagons == 3559, "got expected max polyfill size");
+        t_assert(numHexagons == 5613, "got expected max polyfill size");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&holeGeoPolygon, 9);
-        t_assert(numHexagons == 3559, "got expected max polyfill size (hole)");
+        t_assert(numHexagons == 5613, "got expected max polyfill size (hole)");
 
         numHexagons = H3_EXPORT(maxPolyfillSize)(&emptyGeoPolygon, 9);
         t_assert(numHexagons == 15, "got expected max polyfill size (empty)");

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -40,4 +40,12 @@ void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
 // Create a LinkedGeoPolygon from a vertex graph
 void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
 
+// Internal function for polyfill that traces a geofence with hexagons of a
+// specific size
+int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
+                     int* numSearchHexes, H3Index* search, H3Index* found);
+
+// The new polyfill algorithm. Separated out because it can theoretically fail
+int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out);
+
 #endif

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -45,7 +45,7 @@ void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
 int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
                      int* numSearchHexes, H3Index* search, H3Index* found);
 
-// The new polyfill algorithm. Separated out because it can theoretically fail
+// The polyfill algorithm. Separated out because it can theoretically fail
 int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out);
 
 #endif

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -38,6 +38,8 @@ bool bboxIsTransmeridian(const BBox* bbox);
 void bboxCenter(const BBox* bbox, GeoCoord* center);
 bool bboxContains(const BBox* bbox, const GeoCoord* point);
 bool bboxEquals(const BBox* b1, const BBox* b2);
-int bboxHexRadius(const BBox* bbox, int res);
+int bboxHexEstimate(const BBox* bbox, int res);
+int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
+                    int res);
 
 #endif

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -46,6 +46,7 @@
 #define HEX_RANGE_K_SUBSEQUENCE 2
 #define MAX_ONE_RING_SIZE 7
 #define HEX_HASH_OVERFLOW -1
+#define POLYFILL_BUFFER 12
 
 /**
  * Directions used for traversing a hexagonal ring counterclockwise around
@@ -661,8 +662,13 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
         totalVerts += geoPolygon->holes[i].numVerts;
     }
     if (numHexagons < totalVerts) numHexagons = totalVerts;
-    numHexagons += 12;  // TODO: Get a better constant here, but this seems
-                        // related to the rotation issue for odd hexes
+    numHexagons += POLYFILL_BUFFER;  // When the polygon is very small, near an
+                                     // icosahedron edge and is an odd
+                                     // resolution, the line tracing needs an
+                                     // extra buffer than the estimator function
+                                     // provides (but beefing that up to cover
+                                     // causes most situations to overallocate
+                                     // memory)
     return numHexagons;
 }
 

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -660,6 +660,8 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
         totalVerts += geoPolygon->holes[i].numVerts;
     }
     if (numHexagons < totalVerts) numHexagons = totalVerts;
+    numHexagons += 12;  // TODO: Get a better constant here, but this seems
+                        // related to the rotation issue for odd hexes
     return numHexagons;
 }
 

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -44,6 +44,7 @@
 #define HEX_RANGE_SUCCESS 0
 #define HEX_RANGE_PENTAGON 1
 #define HEX_RANGE_K_SUBSEQUENCE 2
+#define MAX_ONE_RING_SIZE 7
 
 /**
  * Directions used for traversing a hexagonal ring counterclockwise around
@@ -638,9 +639,8 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index* out) {
  * maxPolyfillSize returns the number of hexagons to allocate space for when
  * performing a polyfill on the given GeoJSON-like data structure.
  *
- * Currently a laughably padded response, being a k-ring that wholly contains
- * a bounding box of the GeoJSON, but still less wasted memory than initializing
- * a Python application? ;)
+ * The size is the maximum of either the number of points in the geofence or the
+ * number of hexagons in the bounding box of the geofence.
  *
  * @param geoPolygon A GeoJSON-like data structure indicating the poly to fill
  * @param res Hexagon resolution (0-15)
@@ -649,12 +649,18 @@ int H3_EXPORT(hexRing)(H3Index origin, int k, H3Index* out) {
 int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
     // Get the bounding box for the GeoJSON-like struct
     BBox bbox;
-    bboxFromGeofence(&geoPolygon->geofence, &bbox);
-    int minK = bboxHexRadius(&bbox, res);
-
-    // The total number of hexagons to allocate can now be determined by
-    // the k-ring hex allocation helper function.
-    return H3_EXPORT(maxKringSize)(minK);
+    const Geofence geofence = geoPolygon->geofence;
+    bboxFromGeofence(&geofence, &bbox);
+    int numHexagons = bboxHexEstimate(&bbox, res);
+    // This algorithm assumes that the number of vertices is usually less than
+    // the number of hexagons, but when it's wrong, this will keep it from
+    // failing
+    int totalVerts = geofence.numVerts;
+    for (int i = 0; i < geoPolygon->numHoles; i++) {
+        totalVerts += geoPolygon->holes[i].numVerts;
+    }
+    if (numHexagons < totalVerts) numHexagons = totalVerts;
+    return numHexagons;
 }
 
 /**
@@ -662,15 +668,108 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
  * zeroed memory, and fills it with the hexagons that are contained by
  * the GeoJSON-like data structure.
  *
- * The current implementation is very primitive and slow, but correct,
- * performing a point-in-poly operation on every hexagon in a k-ring defined
- * around the given geofence.
+ * This implementation traces the GeoJSON geofence(s) in cartesian space with
+ * hexagons, tests them and their neighbors to be contained by the geofence(s),
+ * and then any newly found hexagons are used to test again until no new
+ * hexagons are found.
  *
  * @param geoPolygon The geofence and holes defining the relevant area
  * @param res The Hexagon resolution (0-15)
  * @param out The slab of zeroed memory to write to. Assumed to be big enough.
  */
 void H3_EXPORT(polyfill)(const GeoPolygon* geoPolygon, int res, H3Index* out) {
+    // TODO: Eliminate this wrapper with the H3 4.0.0 release
+    int failure = _polyfillInternal(geoPolygon, res, out);
+    // The polyfill algorithm can theoretically fail if the allocated memory is
+    // not large enough for the polygon, but this should be impossible given the
+    // conservative overestimation of the number of hexagons possible.
+    // LCOV_EXCL_START
+    if (failure) {
+        int numHexagons = H3_EXPORT(maxPolyfillSize)(geoPolygon, res);
+        for (int i = 0; i < numHexagons; i++) out[i] = H3_INVALID_INDEX;
+    }
+    // LCOV_EXCL_STOP
+}
+
+/**
+ * _getEdgeHexagons takes a given geofence ring (either the main geofence or
+ * one of the holes) and traces it with hexagons and updates the search and
+ * found memory blocks. This is used for determining the initial hexagon set
+ * for the polyfill algorithm to execute on.
+ *
+ * @param geofence The geofence (or hole) to be traced
+ * @param numHexagons The maximum number of hexagons possible for the geofence
+ *                    (also the bounds of the search and found arrays)
+ * @param res The hexagon resolution (0-15)
+ * @param numSearchHexes The number of hexagons found so far to be searched
+ * @param search The block of memory containing the hexagons to search from
+ * @param found The block of memory containing the hexagons found from the
+ * search
+ *
+ * @return An error code if the hash function cannot insert a found hexagon
+ *         into the found array.
+ */
+int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
+                     int* numSearchHexes, H3Index* search, H3Index* found) {
+    for (int i = 0; i < geofence->numVerts; i++) {
+        GeoCoord origin = geofence->verts[i];
+        GeoCoord destination = i == geofence->numVerts - 1
+                                   ? geofence->verts[0]
+                                   : geofence->verts[i + 1];
+        const int numHexesEstimate =
+            lineHexEstimate(&origin, &destination, res);
+        for (int j = 0; j < numHexesEstimate; j++) {
+            GeoCoord interpolate;
+            interpolate.lat =
+                (origin.lat * (numHexesEstimate - j) / numHexesEstimate) +
+                (destination.lat * j / numHexesEstimate);
+            interpolate.lon =
+                (origin.lon * (numHexesEstimate - j) / numHexesEstimate) +
+                (destination.lon * j / numHexesEstimate);
+            H3Index pointHex = H3_EXPORT(geoToH3)(&interpolate, res);
+            // A simple hash to store the hexagon, or move to another place if
+            // needed
+            int loc = (int)(pointHex % numHexagons);
+            int loopCount = 0;
+            while (found[loc] != 0) {
+                // If this conditional is reached, the `found` memory block is
+                // too small for the given polygon. This should not happen.
+                if (loopCount > numHexagons) return -1;  // LCOV_EXCL_LINE
+                if (found[loc] == pointHex)
+                    break;  // At least two points of the geofence index to the
+                            // same cell
+                loc = (loc + 1) % numHexagons;
+                loopCount++;
+            }
+            if (found[loc] == pointHex)
+                continue;  // Skip this hex, already exists in the found hash
+            // Otherwise, set it in the found hash for now
+            found[loc] = pointHex;
+
+            search[*numSearchHexes] = pointHex;
+            (*numSearchHexes)++;
+        }
+    }
+    return 0;
+}
+
+/**
+ * _polyfillInternal traces the provided geoPolygon data structure with hexagons
+ * and then iteratively searches through these hexagons and their immediate
+ * neighbors to see if they are contained within the polygon or not. Those that
+ * are found are added to the out array as well as the found array. Once all
+ * hexagons to search are checked, the found hexagons become the new search
+ * array and the found array is wiped and the process repeats until no new
+ * hexagons can be found.
+ *
+ * @param geoPolygon The geofence and holes defining the relevant area
+ * @param res The Hexagon resolution (0-15)
+ * @param out The slab of zeroed memory to write to. Assumed to be big enough.
+ *
+ * @return An error code if any of the hash operations fails to insert a hexagon
+ *         into an array of memory.
+ */
+int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
     // One of the goals of the polyfill algorithm is that two adjacent polygons
     // with zero overlap have zero overlapping hexagons. That the hexagons are
     // uniquely assigned. There are a few approaches to take here, such as
@@ -692,36 +791,139 @@ void H3_EXPORT(polyfill)(const GeoPolygon* geoPolygon, int res, H3Index* out) {
     BBox* bboxes = H3_MEMORY(malloc)((geoPolygon->numHoles + 1) * sizeof(BBox));
     assert(bboxes != NULL);
     bboxesFromGeoPolygon(geoPolygon, bboxes);
-    int minK = bboxHexRadius(&bboxes[0], res);
-    int numHexagons = H3_EXPORT(maxKringSize)(minK);
 
-    // Get the center hex
-    GeoCoord center;
-    bboxCenter(&bboxes[0], &center);
-    H3Index centerH3 = H3_EXPORT(geoToH3)(&center, res);
+    // Get the estimated number of hexagons and allocate some temporary memory
+    // for the hexagons
+    int numHexagons = H3_EXPORT(maxPolyfillSize)(geoPolygon, res);
+    H3Index* search = calloc(numHexagons, sizeof(H3Index));
+    H3Index* found = calloc(numHexagons, sizeof(H3Index));
 
-    // From here on it works differently, first we get all potential
-    // hexagons inserted into the available memory
-    H3_EXPORT(kRing)(centerH3, minK, out);
+    // Some metadata for tracking the state of the search and found memory
+    // blocks
+    int numSearchHexes = 0;
+    int numFoundHexes = 0;
 
-    // Next we iterate through each hexagon, and test its center point to see if
-    // it's contained in the GeoJSON-like struct
-    for (int i = 0; i < numHexagons; i++) {
-        // Skip records that are already zeroed
-        if (out[i] == 0) {
-            continue;
-        }
-        // Check if hexagon is inside of polygon
-        GeoCoord hexCenter;
-        H3_EXPORT(h3ToGeo)(out[i], &hexCenter);
-        hexCenter.lat = constrainLat(hexCenter.lat);
-        hexCenter.lon = constrainLng(hexCenter.lon);
-        // And remove from list if not
-        if (!pointInsidePolygon(geoPolygon, bboxes, &hexCenter)) {
-            out[i] = H3_INVALID_INDEX;
-        }
+    // 1. Trace the hexagons along the polygon defining the outer geofence and
+    // add them to the search hash. The hexagon containing the geofence point
+    // may or may not be contained by the geofence (as the hexagon's center
+    // point may be outside of the boundary.)
+    const Geofence geofence = geoPolygon->geofence;
+    int failure = _getEdgeHexagons(&geofence, numHexagons, res, &numSearchHexes,
+                                   search, found);
+    // If this branch is reached, we have exceeded the maximum number of
+    // hexagons possible and need to clean up the allocated memory.
+    // LCOV_EXCL_START
+    if (failure) {
+        H3_MEMORY(free)(search);
+        H3_MEMORY(free)(found);
+        H3_MEMORY(free)(bboxes);
+        return failure;
     }
+    // LCOV_EXCL_STOP
+
+    // 2. Iterate over all holes, trace the polygons defining the holes with
+    // hexagons and add to only the search hash. We're going to temporarily use
+    // the `found` hash to use for dedupe purposes and then re-zero it once
+    // we're done here, otherwise we'd have to scan the whole set on each insert
+    // to make sure there's no duplicates, which is very inefficient.
+    for (int i = 0; i < geoPolygon->numHoles; i++) {
+        Geofence* hole = &(geoPolygon->holes[i]);
+        failure = _getEdgeHexagons(hole, numHexagons, res, &numSearchHexes,
+                                   search, found);
+        // If this branch is reached, we have exceeded the maximum number of
+        // hexagons possible and need to clean up the allocated memory.
+        // LCOV_EXCL_START
+        if (failure) {
+            H3_MEMORY(free)(search);
+            H3_MEMORY(free)(found);
+            H3_MEMORY(free)(bboxes);
+            return failure;
+        }
+        // LCOV_EXCL_STOP
+    }
+
+    // 3. Re-zero the found hash so it can be used in the main loop below
+    for (int i = 0; i < numHexagons; i++) found[i] = 0;
+
+    // 4. Begin main loop. While the search hash is not empty do the following
+    while (numSearchHexes > 0) {
+        // Iterate through all hexagons in the current search hash, then loop
+        // through all neighbors and test Point-in-Poly, if point-in-poly
+        // succeeds, add to out and found hashes if not already there.
+        int currentSearchNum = 0;
+        int i = 0;
+        while (currentSearchNum < numSearchHexes) {
+            H3Index ring[MAX_ONE_RING_SIZE] = {0};
+            H3Index searchHex = search[i];
+            H3_EXPORT(kRing)(searchHex, 1, ring);
+            for (int j = 0; j < MAX_ONE_RING_SIZE; j++) {
+                if (ring[j] == H3_INVALID_INDEX) {
+                    continue;  // Skip if this was a pentagon and only had 5
+                               // neighbors
+                }
+
+                H3Index hex = ring[j];
+
+                // A simple hash to store the hexagon, or move to another place
+                // if needed. This MUST be done before the point-in-poly check
+                // since that's far more expensive
+                int loc = (int)(hex % numHexagons);
+                int loopCount = 0;
+                while (out[loc] != 0) {
+                    // If this branch is reached, we have exceeded the maximum
+                    // number of hexagons possible and need to clean up the
+                    // allocated memory.
+                    // LCOV_EXCL_START
+                    if (loopCount > numHexagons) {
+                        H3_MEMORY(free)(search);
+                        H3_MEMORY(free)(found);
+                        H3_MEMORY(free)(bboxes);
+                        return -1;
+                    }
+                    // LCOV_EXCL_STOP
+                    if (out[loc] == hex) break;  // Skip duplicates found
+                    loc = (loc + 1) % numHexagons;
+                    loopCount++;
+                }
+                if (out[loc] == hex) {
+                    continue;  // Skip this hex, already exists in the out hash
+                }
+
+                // Check if the hexagon is in the polygon or not
+                GeoCoord hexCenter;
+                H3_EXPORT(h3ToGeo)(hex, &hexCenter);
+
+                // If not, skip
+                if (!pointInsidePolygon(geoPolygon, bboxes, &hexCenter)) {
+                    continue;
+                }
+
+                // Otherwise set it in the output array
+                out[loc] = hex;
+
+                // Set the hexagon in the found hash
+                found[numFoundHexes] = hex;
+                numFoundHexes++;
+            }
+            currentSearchNum++;
+            i++;
+        }
+
+        // Swap the search and found pointers, copy the found hex count to the
+        // search hex count, and zero everything related to the found memory.
+        H3Index* temp = search;
+        search = found;
+        found = temp;
+        for (int j = 0; j < numSearchHexes; j++) found[j] = 0;
+        numSearchHexes = numFoundHexes;
+        numFoundHexes = 0;
+        // Repeat until no new hexagons are found
+    }
+    // The out memory structure should be complete, end it here
     H3_MEMORY(free)(bboxes);
+    H3_MEMORY(free)(search);
+    H3_MEMORY(free)(found);
+    return 0;
 }
 
 /**

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -662,13 +662,11 @@ int H3_EXPORT(maxPolyfillSize)(const GeoPolygon* geoPolygon, int res) {
         totalVerts += geoPolygon->holes[i].numVerts;
     }
     if (numHexagons < totalVerts) numHexagons = totalVerts;
-    numHexagons += POLYFILL_BUFFER;  // When the polygon is very small, near an
-                                     // icosahedron edge and is an odd
-                                     // resolution, the line tracing needs an
-                                     // extra buffer than the estimator function
-                                     // provides (but beefing that up to cover
-                                     // causes most situations to overallocate
-                                     // memory)
+    // When the polygon is very small, near an icosahedron edge and is an odd
+    // resolution, the line tracing needs an extra buffer than the estimator
+    // function provides (but beefing that up to cover causes most situations to
+    // overallocate memory)
+    numHexagons += POLYFILL_BUFFER;
     return numHexagons;
 }
 

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -45,6 +45,7 @@
 #define HEX_RANGE_PENTAGON 1
 #define HEX_RANGE_K_SUBSEQUENCE 2
 #define MAX_ONE_RING_SIZE 7
+#define HEX_HASH_OVERFLOW -1
 
 /**
  * Directions used for traversing a hexagonal ring counterclockwise around
@@ -736,7 +737,8 @@ int _getEdgeHexagons(const Geofence* geofence, int numHexagons, int res,
             while (found[loc] != 0) {
                 // If this conditional is reached, the `found` memory block is
                 // too small for the given polygon. This should not happen.
-                if (loopCount > numHexagons) return -1;  // LCOV_EXCL_LINE
+                if (loopCount > numHexagons)
+                    return HEX_HASH_OVERFLOW;  // LCOV_EXCL_LINE
                 if (found[loc] == pointHex)
                     break;  // At least two points of the geofence index to the
                             // same cell

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -805,8 +805,8 @@ int _polyfillInternal(const GeoPolygon* geoPolygon, int res, H3Index* out) {
     // Get the estimated number of hexagons and allocate some temporary memory
     // for the hexagons
     int numHexagons = H3_EXPORT(maxPolyfillSize)(geoPolygon, res);
-    H3Index* search = calloc(numHexagons, sizeof(H3Index));
-    H3Index* found = calloc(numHexagons, sizeof(H3Index));
+    H3Index* search = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
+    H3Index* found = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
 
     // Some metadata for tracking the state of the search and found memory
     // blocks

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -106,21 +106,20 @@ int bboxHexEstimate(const BBox* bbox, int res) {
     // The pentagon has the most distortion (smallest edges) and shares its
     // edges with hexagons, so the most-distorted hexagons have this area
     double pentagonAreaKm2 =
-        2.59807621135 * pentagonRadiusKm * pentagonRadiusKm;
+        0.8 * (2.59807621135 * pentagonRadiusKm * pentagonRadiusKm);
 
     // Then get the area of the bounding box of the geofence in question
     GeoCoord p1, p2;
     p1.lat = bbox->north;
     p1.lon = bbox->east;
     p2.lat = bbox->south;
-    p2.lon = bbox->east;
-    double h = _geoDistKm(&p1, &p2);
-    p2.lat = bbox->north;
     p2.lon = bbox->west;
-    double w = _geoDistKm(&p1, &p2);
+    double d = _geoDistKm(&p1, &p2);
+    double a = d * d / 2.5;  // Derived constant based on:
+                             // https://math.stackexchange.com/a/1921940
 
     // Divide the two to get an estimate of the number of hexagons needed
-    int estimate = (int)ceil(w * h / pentagonAreaKm2);
+    int estimate = (int)ceil(a / pentagonAreaKm2);
     if (estimate == 0) estimate = 1;
     return estimate;
 }

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -90,38 +90,59 @@ double _hexRadiusKm(H3Index h3Index) {
 }
 
 /**
- * Get the radius of the bbox in hexagons - i.e. the radius of a k-ring centered
- * on the bbox center and covering the entire bbox.
- * @param  bbox Bounding box to measure
- * @param  res  Resolution of hexagons to use in measurement
- * @return      Radius in hexagons
+ * bboxHexEstimate returns an estimated number of hexagons that fit
+ *                 within the cartesian-projected bounding box
+ *
+ * @param bbox the bounding box to estimate the hexagon fill level
+ * @param res the resolution of the H3 hexagons to fill the bounding box
+ * @return the estimated number of hexagons to fill the bounding box
  */
-int bboxHexRadius(const BBox* bbox, int res) {
-    // Determine the center of the bounding box
-    GeoCoord center;
-    bboxCenter(bbox, &center);
+int bboxHexEstimate(const BBox* bbox, int res) {
+    // Get the area of the pentagon as the maximally-distorted area possible
+    H3Index pentagons[12] = {0};
+    H3_EXPORT(getPentagonIndexes)(res, pentagons);
+    double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
+    // Area of a regular hexagon is 3/2*sqrt(3) * r * r
+    // The pentagon has the most distortion (smallest edges) and shares its
+    // edges with hexagons, so the most-distorted hexagons have this area
+    double pentagonAreaKm2 =
+        2.59807621135 * pentagonRadiusKm * pentagonRadiusKm;
 
-    // Use a vertex on the side closest to the equator, to ensure the longest
-    // radius in cases with significant distortion. East/west is arbitrary.
-    double lat =
-        fabs(bbox->north) > fabs(bbox->south) ? bbox->south : bbox->north;
-    GeoCoord vertex = {lat, bbox->east};
+    // Then get the area of the bounding box of the geofence in question
+    GeoCoord p1, p2;
+    p1.lat = bbox->north;
+    p1.lon = bbox->east;
+    p2.lat = bbox->south;
+    p2.lon = bbox->east;
+    double h = _geoDistKm(&p1, &p2);
+    p2.lat = bbox->north;
+    p2.lon = bbox->west;
+    double w = _geoDistKm(&p1, &p2);
 
-    // Determine the length of the bounding box "radius" to then use
-    // as a circle on the earth that the k-rings must be greater than
-    double bboxRadiusKm = _geoDistKm(&center, &vertex);
+    // Divide the two to get an estimate of the number of hexagons needed
+    int estimate = (int)ceil(w * h / pentagonAreaKm2);
+    if (estimate == 0) estimate = 1;
+    return estimate;
+}
 
-    // Determine the radius of the center hexagon
-    double centerHexRadiusKm = _hexRadiusKm(H3_EXPORT(geoToH3)(&center, res));
+/**
+ * lineHexEstimate returns an estimated number of hexagons that trace
+ *                 the cartesian-projected line
+ *
+ *  @param origin the origin coordinates
+ *  @param destination the destination coordinates
+ *  @param res the resolution of the H3 hexagons to trace the line
+ *  @return the estimated number of hexagons required to trace the line
+ */
+int lineHexEstimate(const GeoCoord* origin, const GeoCoord* destination,
+                    int res) {
+    // Get the area of the pentagon as the maximally-distorted area possible
+    H3Index pentagons[12] = {0};
+    H3_EXPORT(getPentagonIndexes)(res, pentagons);
+    double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
 
-    // We use centerHexRadiusKm un-scaled and rounded *up* to guarantee
-    // containment ot the bbox.  Ideal, undistorted hexagons could scale
-    // centerHexRadiusKm by a factor of up to 1.5, reducing bboxHexRadius.
-    // This is because the closest point along an undistorted hexagon drawn
-    // through the center points of a k-ring aggregation is exactly 1.5 radii
-    // of the hexagon.  But there is distortion near pentagons, and for those
-    // cases, the scaling needs to be less than 1.5.  Using the un-scaled value
-    // conservatively guarantees containment for all cases, at the expense of a
-    // larger bboxHexRadius.
-    return (int)ceil(bboxRadiusKm / centerHexRadiusKm);
+    double dist = _geoDistKm(origin, destination);
+    int estimate = (int)ceil(dist / (2 * pentagonRadiusKm));
+    if (estimate == 0) estimate = 1;
+    return estimate;
 }


### PR DESCRIPTION
The tests all pass!

There is one fudge factor in the polyfill hexagon estimation function that I can mostly explain:

1. It's not used for the actual output set but for the polygon line tracing.
2. Sometimes the line tracing cuts through more hexagons than you expect because of the strange edge cases around odd-numbered hexagons crossing the icosahedron boundary.
3. I went with `12` to be safe (maximum number of points around an odd-numbered hexagon), but I think I could get away with just adding `5` as I think this issue only arises on polygons directly tracing odd-numbered pentagons, but I'm not sure how to prove that.

Finally, I fixed the issue with the "polyfill the world" test case by using a wild derivation of area based on a diagonal: https://math.stackexchange.com/questions/1921929/find-an-area-of-a-rectangle-by-its-diagonal-and-quotient-of-its-sides and knowing that the opposite corners of the bounding box *have* to be very far away unlike the side overlapping the transmeridian.

Also, the formatter inserted a *ton* of whitespace, and I'm not sure why.