### PR TITLE
Remove extra `malloc` from `kRing`

### DIFF
--- a/src/apps/benchmarks/benchmarkKRing.c
+++ b/src/apps/benchmarks/benchmarkKRing.c
@@ -23,14 +23,12 @@ H3Index pentagon = 0x89080000003ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index* out = malloc(H3_EXPORT(maxKringSize)(400) * sizeof(H3Index));
+H3Index* out = malloc(H3_EXPORT(maxKringSize)(40) * sizeof(H3Index));
 
 BENCHMARK(kRing10, 10000, { H3_EXPORT(kRing)(hex, 10, out); });
 BENCHMARK(kRing20, 10000, { H3_EXPORT(kRing)(hex, 20, out); });
 BENCHMARK(kRing30, 10000, { H3_EXPORT(kRing)(hex, 30, out); });
 BENCHMARK(kRing40, 10000, { H3_EXPORT(kRing)(hex, 40, out); });
-BENCHMARK(kRing100, 1000, { H3_EXPORT(kRing)(hex, 100, out); });
-BENCHMARK(kRing400, 1000, { H3_EXPORT(kRing)(hex, 400, out); });
 
 BENCHMARK(kRingPentagon10, 500, { H3_EXPORT(kRing)(pentagon, 10, out); });
 BENCHMARK(kRingPentagon20, 500, { H3_EXPORT(kRing)(pentagon, 20, out); });

--- a/src/apps/benchmarks/benchmarkKRing.c
+++ b/src/apps/benchmarks/benchmarkKRing.c
@@ -23,12 +23,14 @@ H3Index pentagon = 0x89080000003ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index* out = malloc(H3_EXPORT(maxKringSize)(40) * sizeof(H3Index));
+H3Index* out = malloc(H3_EXPORT(maxKringSize)(400) * sizeof(H3Index));
 
 BENCHMARK(kRing10, 10000, { H3_EXPORT(kRing)(hex, 10, out); });
 BENCHMARK(kRing20, 10000, { H3_EXPORT(kRing)(hex, 20, out); });
 BENCHMARK(kRing30, 10000, { H3_EXPORT(kRing)(hex, 30, out); });
 BENCHMARK(kRing40, 10000, { H3_EXPORT(kRing)(hex, 40, out); });
+BENCHMARK(kRing100, 1000, { H3_EXPORT(kRing)(hex, 100, out); });
+BENCHMARK(kRing400, 1000, { H3_EXPORT(kRing)(hex, 400, out); });
 
 BENCHMARK(kRingPentagon10, 500, { H3_EXPORT(kRing)(pentagon, 10, out); });
 BENCHMARK(kRingPentagon20, 500, { H3_EXPORT(kRing)(pentagon, 20, out); });

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -158,7 +158,7 @@ static const Direction NEW_ADJUSTMENT_III[7][7] = {
 int H3_EXPORT(maxKringSize)(int k) { return 3 * k * (k + 1) + 1; }
 
 /**
- * Produce cells within grid distance k the origin cell.
+ * Produce cells within grid distance k of the origin cell.
  *
  * k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
  * all neighboring cells, and so on.

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -172,14 +172,14 @@ int H3_EXPORT(maxKringSize)(int k) { return 3 * k * (k + 1) + 1; }
  */
 void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
     // Optimistically try the faster k-ring algorithm first
-    const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, 0);
+    const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, NULL);
     if (failed) {
         // Fast algo failed, fall back to slower, correct algo
         // and also wipe out array because contents untrustworthy
         int maxIdx = H3_EXPORT(maxKringSize)(k);
         memset(out, 0, maxIdx * sizeof(H3Index));
-        int* distances = malloc(maxIdx * sizeof(int));
-        _kRingInternal(origin, k, out, distances, maxIdx, 0);
+        int* distances = calloc(maxIdx, sizeof(int));
+        _kRingInternal(origin, k, out, distances, maxIdx, NULL);
         free(distances);
     }
 }
@@ -213,7 +213,7 @@ void H3_EXPORT(kRingDistances)(
         // and also wipe out array because contents untrustworthy
         memset(out, 0, maxIdx * sizeof(H3Index));
         memset(distances, 0, maxIdx * sizeof(int));
-        _kRingInternal(origin, k, out, distances, maxIdx, 0);
+        _kRingInternal(origin, k, out, distances, maxIdx, NULL);
     }
 }
 
@@ -430,7 +430,7 @@ H3Index h3NeighborRotations(H3Index origin, Direction dir, int* rotations) {
  * @return 0 if no pentagon or pentagonal distortion area was encountered.
  */
 int H3_EXPORT(hexRange)(H3Index origin, int k, H3Index* out) {
-    return H3_EXPORT(hexRangeDistances)(origin, k, out, 0);
+    return H3_EXPORT(hexRangeDistances)(origin, k, out, NULL);
 }
 
 /**

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -179,10 +179,16 @@ void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
         int maxIdx = H3_EXPORT(maxKringSize)(k);
         memset(out, 0, maxIdx * sizeof(H3Index));
         int* distances = calloc(maxIdx, sizeof(int));
-        _kRingInternal(origin, k, out, distances, maxIdx, NULL);
+        _kRingInternal(origin, k, out, distances, maxIdx, 0);
         free(distances);
     }
 }
+// void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
+//     int maxIdx = H3_EXPORT(maxKringSize)(k);
+//     int* distances = malloc(maxIdx * sizeof(int));
+//     H3_EXPORT(kRingDistances)(origin, k, out, distances);
+//     free(distances);
+// }
 
 /**
  * Produce cells and their distances from the given origin cell, up to
@@ -199,12 +205,8 @@ void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
  * @param  out         zero-filled array which must be of size maxKringSize(k)
  * @param  distances   zero-filled array which must be of size maxKringSize(k)
  */
-void H3_EXPORT(kRingDistances)(
-    H3Index origin,
-    int k,
-    H3Index* out,
-    int* distances
-) {
+void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
+                               int* distances) {
     // Optimistically try the faster hexRange algorithm first
     const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, distances);
     if (failed) {
@@ -213,7 +215,7 @@ void H3_EXPORT(kRingDistances)(
         // and also wipe out array because contents untrustworthy
         memset(out, 0, maxIdx * sizeof(H3Index));
         memset(distances, 0, maxIdx * sizeof(int));
-        _kRingInternal(origin, k, out, distances, maxIdx, NULL);
+        _kRingInternal(origin, k, out, distances, maxIdx, 0);
     }
 }
 
@@ -233,14 +235,8 @@ void H3_EXPORT(kRingDistances)(
  * @param  maxIdx      Size of out and scratch arrays (must be maxKringSize(k))
  * @param  curK        Current distance from the origin
  */
-void _kRingInternal(
-    H3Index origin,
-    int k,
-    H3Index* out,
-    int* distances,
-    int maxIdx,
-    int curK
-) {
+void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,
+                    int maxIdx, int curK) {
     if (origin == 0) return;
 
     // Put origin in the output array. out is used as a hash set.

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -150,57 +150,64 @@ static const Direction NEW_ADJUSTMENT_III[7][7] = {
      CENTER_DIGIT, IJ_AXES_DIGIT}};
 
 /**
- * Maximum number of indices that result from the kRing algorithm with the given
+ * Maximum number of cells that result from the kRing algorithm with the given
  * k. Formula source and proof: https://oeis.org/A003215
  *
- * @param k k value, k >= 0.
+ * @param  k   k value, k >= 0.
  */
 int H3_EXPORT(maxKringSize)(int k) { return 3 * k * (k + 1) + 1; }
 
 /**
- * k-rings produces indices within k distance of the origin index.
+ * Produce cells within grid distance k the origin cell.
  *
- * k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
- * all neighboring indices, and so on.
+ * k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+ * all neighboring cells, and so on.
  *
  * Output is placed in the provided array in no particular order. Elements of
  * the output array may be left zero, as can happen when crossing a pentagon.
  *
- * @param origin Origin location.
- * @param k k >= 0
- * @param out Zero-filled array which must be of size maxKringSize(k).
+ * @param  origin  origin cell
+ * @param  k       k >= 0
+ * @param  out     zero-filled array which must be of size maxKringSize(k)
  */
 void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
-    int maxIdx = H3_EXPORT(maxKringSize)(k);
-    int* distances = malloc(maxIdx * sizeof(int));
-    H3_EXPORT(kRingDistances)(origin, k, out, distances);
-    free(distances);
-}
-
-/**
- * k-rings produces indices within k distance of the origin index.
- *
- * k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
- * all neighboring indices, and so on.
- *
- * Output is placed in the provided array in no particular order. Elements of
- * the output array may be left zero, as can happen when crossing a pentagon.
- *
- * @param origin Origin location.
- * @param k k >= 0
- * @param out Zero-filled array which must be of size maxKringSize(k).
- * @param distances Zero-filled array which must be of size maxKringSize(k).
- */
-void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
-                               int* distances) {
-    const int maxIdx = H3_EXPORT(maxKringSize)(k);
-    // Optimistically try the faster hexRange algorithm first
-    const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, distances);
+    const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, 0);
     if (failed) {
         // Fast algo failed, fall back to slower, correct algo
         // and also wipe out array because contents untrustworthy
-        memset(out, 0, maxIdx * sizeof(out[0]));
-        memset(distances, 0, maxIdx * sizeof(distances[0]));
+        int maxIdx = H3_EXPORT(maxKringSize)(k);
+        memset(out, 0, maxIdx * sizeof(H3Index));
+        int* distances = malloc(maxIdx * sizeof(int));
+        _kRingInternal(origin, k, out, distances, maxIdx, 0);
+        free(distances);
+    }
+}
+
+/**
+ * Produce cells and their distances from the given origin cell, up to
+ * distance k.
+ *
+ * k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
+ * all neighboring cells, and so on.
+ *
+ * Output is placed in the provided array in no particular order. Elements of
+ * the output array may be left zero, as can happen when crossing a pentagon.
+ *
+ * @param  origin     origin cell
+ * @param  k          k >= 0
+ * @param  out        zero-filled array which must be of size maxKringSize(k)
+ * @param  distances  zero-filled array which must be of size maxKringSize(k)
+ */
+void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
+                               int* distances) {
+    // Optimistically try the faster hexRange algorithm first
+    const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, distances);
+    if (failed) {
+        const int maxIdx = H3_EXPORT(maxKringSize)(k);
+        // Fast algo failed, fall back to slower, correct algo
+        // and also wipe out array because contents untrustworthy
+        memset(out, 0, maxIdx * sizeof(H3Index));
+        memset(distances, 0, maxIdx * sizeof(int));
         _kRingInternal(origin, k, out, distances, maxIdx, 0);
     }
 }
@@ -208,16 +215,18 @@ void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
 /**
  * Internal helper function called recursively for kRingDistances.
  *
- * Adds the origin index to the output set (treating it as a hash set)
+ * Adds the origin cell to the output set (treating it as a hash set)
  * and recurses to its neighbors, if needed.
  *
- * @param origin
- * @param k Maximum distance to move from the origin.
- * @param out Array treated as a hash set, elements being either H3Index or 0.
- * @param distances Scratch area, with elements paralleling the out array.
- * Elements indicate ijk distance from the origin index to the output index.
- * @param maxIdx Size of out and scratch arrays (must be maxKringSize(k))
- * @param curK Current distance from the origin.
+ * @param  origin      Origin cell
+ * @param  k           Maximum distance to move from the origin
+ * @param  out         Array treated as a hash set, elements being either
+ *                     H3Index or 0.
+ * @param  distances   Scratch area, with elements paralleling the out array.
+ *                     Elements indicate ijk distance from the origin cell to
+ *                     the output cell
+ * @param  maxIdx      Size of out and scratch arrays (must be maxKringSize(k))
+ * @param  curK        Current distance from the origin
  */
 void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,
                     int maxIdx, int curK) {

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -171,6 +171,7 @@ int H3_EXPORT(maxKringSize)(int k) { return 3 * k * (k + 1) + 1; }
  * @param  out      zero-filled array which must be of size maxKringSize(k)
  */
 void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
+    // Optimistically try the faster k-ring algorithm first
     const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, 0);
     if (failed) {
         // Fast algo failed, fall back to slower, correct algo

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -183,12 +183,6 @@ void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
         free(distances);
     }
 }
-// void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
-//     int maxIdx = H3_EXPORT(maxKringSize)(k);
-//     int* distances = malloc(maxIdx * sizeof(int));
-//     H3_EXPORT(kRingDistances)(origin, k, out, distances);
-//     free(distances);
-// }
 
 /**
  * Produce cells and their distances from the given origin cell, up to

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -166,9 +166,9 @@ int H3_EXPORT(maxKringSize)(int k) { return 3 * k * (k + 1) + 1; }
  * Output is placed in the provided array in no particular order. Elements of
  * the output array may be left zero, as can happen when crossing a pentagon.
  *
- * @param  origin  origin cell
- * @param  k       k >= 0
- * @param  out     zero-filled array which must be of size maxKringSize(k)
+ * @param  origin   origin cell
+ * @param  k        k >= 0
+ * @param  out      zero-filled array which must be of size maxKringSize(k)
  */
 void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
     const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, 0);
@@ -193,13 +193,17 @@ void H3_EXPORT(kRing)(H3Index origin, int k, H3Index* out) {
  * Output is placed in the provided array in no particular order. Elements of
  * the output array may be left zero, as can happen when crossing a pentagon.
  *
- * @param  origin     origin cell
- * @param  k          k >= 0
- * @param  out        zero-filled array which must be of size maxKringSize(k)
- * @param  distances  zero-filled array which must be of size maxKringSize(k)
+ * @param  origin      origin cell
+ * @param  k           k >= 0
+ * @param  out         zero-filled array which must be of size maxKringSize(k)
+ * @param  distances   zero-filled array which must be of size maxKringSize(k)
  */
-void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
-                               int* distances) {
+void H3_EXPORT(kRingDistances)(
+    H3Index origin,
+    int k,
+    H3Index* out,
+    int* distances
+) {
     // Optimistically try the faster hexRange algorithm first
     const bool failed = H3_EXPORT(hexRangeDistances)(origin, k, out, distances);
     if (failed) {
@@ -228,8 +232,14 @@ void H3_EXPORT(kRingDistances)(H3Index origin, int k, H3Index* out,
  * @param  maxIdx      Size of out and scratch arrays (must be maxKringSize(k))
  * @param  curK        Current distance from the origin
  */
-void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,
-                    int maxIdx, int curK) {
+void _kRingInternal(
+    H3Index origin,
+    int k,
+    H3Index* out,
+    int* distances,
+    int maxIdx,
+    int curK
+) {
     if (origin == 0) return;
 
     // Put origin in the output array. out is used as a hash set.


### PR DESCRIPTION
The fast path of `kRing`, doesn't need a `malloc`, and these changes remove it.

See #319.