### PR TITLE
Add H3 React Native binding

### DIFF
--- a/docs/community/bindings.md
+++ b/docs/community/bindings.md
@@ -34,6 +34,7 @@ As a C library, bindings can be made to call H3 functions from different program
 
 - [uber/h3-js](https://github.com/uber/h3-js)
 - [dfellis/h3-node](https://github.com/dfellis/h3-node)
+- [realPrimoh/h3-reactnative](https://github.com/realPrimoh/h3-reactnative)
 
 ## Julia
 


### PR DESCRIPTION
Made H3-js compatible with React Native. This removes browser components as React Native does not use native browser variables like 'document.'