### PR TITLE
Enable interprocedural optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,19 @@ if(ENABLE_WARNINGS)
     endif()
 endif()
 
+option(ENABLE_LTO "Enable interprocedural optimization for Release builds." ON)
+if(ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT H3_IPO_SUPPORTED
+                        OUTPUT H3_IPO_CHECK_OUTPUT
+                        LANGUAGES C)
+    if(H3_IPO_SUPPORTED)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+    else()
+        message(STATUS "IPO/LTO is not supported: ${H3_IPO_CHECK_OUTPUT}")
+    endif()
+endif()
+
 if(NOT MSVC)
     # Compiler options are set only on non-Windows, since these options are not
     # correct for MSVC.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,19 @@ function(add_h3_library name h3_alloc_prefix_override)
     target_compile_options(${name} PRIVATE ${H3_COMPILE_FLAGS})
     target_link_libraries(${name} PRIVATE ${H3_LINK_FLAGS})
     target_compile_features(${name} PUBLIC c_std_99)
+    if(ENABLE_LTO AND H3_IPO_SUPPORTED AND NOT BUILD_SHARED_LIBS)
+        if(MSVC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+            set_target_properties(
+                ${name} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
+        endif()
+    endif()
+    if(ENABLE_LTO AND H3_IPO_SUPPORTED AND NOT BUILD_SHARED_LIBS AND NOT MSVC)
+        target_compile_options(
+            ${name}
+            PRIVATE
+                $<$<AND:$<CONFIG:Release>,$<COMPILE_LANG_AND_ID:C,GNU>>:-ffat-lto-objects>
+        )
+    endif()
 
     find_library(M_LIB m)
     if(NOT(M_LIB))


### PR DESCRIPTION
without inlining:
```
kom@nucat:~/proj/h3/build$ bin/benchmarkH3Api 
        -- geoToH3: 1.187343 microseconds per iteration (10000 iterations)
        -- h3ToGeo: 0.796665 microseconds per iteration (10000 iterations)
        -- h3ToGeoBoundary: 2.219408 microseconds per iteration (10000 iterations)
```
with inlining:
```
kom@nucat:~/proj/h3/build$ bin/benchmarkH3Api
        -- geoToH3: 0.447104 microseconds per iteration (10000 iterations)
        -- h3ToGeo: 0.265080 microseconds per iteration (10000 iterations)
        -- h3ToGeoBoundary: 1.341663 microseconds per iteration (10000 iterations)
```

Addresses #325.