### PR TITLE
Fix H3_DIGIT_MASK_NEGATIVE

### DIFF
--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -80,7 +80,7 @@
 #define H3_DIGIT_MASK ((uint64_t)(7))
 
 /** 0's in the 7 base cell bits, 1's everywhere else. */
-#define H3_DIGIT_MASK_NEGATIVE (~H3_DIGIT_MASK_NEGATIVE)
+#define H3_DIGIT_MASK_NEGATIVE (~H3_DIGIT_MASK)
 
 /** H3 index with mode 0, res 0, base cell 0, and 7 for all index digits. */
 #define H3_INIT (UINT64_C(35184372088831))


### PR DESCRIPTION
Fixes #328 (thanks @lovettchris!) We don't use this specific macro which is why this wasn't found before. We could add tests for some of these macros to ensure they remain working.