### PR TITLE
removed duplicate include

### DIFF
--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -18,7 +18,6 @@
  *          (see h3api.h for the main library entry functions)
  */
 #include "h3Index.h"
-#include <faceijk.h>
 #include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -20,7 +20,6 @@
  * an origin index.
  */
 #include <assert.h>
-#include <faceijk.h>
 #include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>


### PR DESCRIPTION
As part of this issue https://github.com/uber/h3-go/issues/30 in h3's go binding, we saw that there are duplicated include statements for local header files, this breaks some automatic renaming we're doing to header files which at the moment requires us to manually remove these include statements.