### PR TITLE
Use clang-format-9 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,13 @@ matrix:
       # Check that clang-format doesn't detect some files are not formatted.
     - name: "Formatting check"
       compiler: clang
-      apt:
-        sources:
-          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
-            key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-        packages:
-          - clang-format-9
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - clang-format-9
       script:
         - clang-format-9 --version
         - make format

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
         packages:
           - clang-format-9
       script:
-        - clang-format --version
+        - clang-format-9 --version
         - make format
         - git diff --exit-code
       # Submit coverage report to Coveralls.io, also test that prefixing works.
@@ -90,6 +90,8 @@ matrix:
         - make binding-functions
         # Check that the file exists and has contents
         - test -s binding-functions
+    - name: "ARM64"
+      arch: arm64
 
 # Configure the build script, out of source.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@
 language: c
 
 os: linux
-dist: xenial
+dist: bionic
 
 compiler:
   - gcc
@@ -33,13 +33,16 @@ matrix:
       # Check that clang-format doesn't detect some files are not formatted.
     - name: "Formatting check"
       compiler: clang
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-format-5.0
-      script: make format && git diff --exit-code
+      apt:
+        sources:
+          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+            key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+        packages:
+          - clang-format-9
+      script:
+        - clang-format --version
+        - make format
+        - git diff --exit-code
       # Submit coverage report to Coveralls.io, also test that prefixing works.
     - name: "Coverage report"
       compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,8 @@ endfunction()
 add_h3_library(h3 "")
 
 # Automatic code formatting
-find_program(CLANG_FORMAT_PATH clang-format)
+# Give preference to clang-format-9
+find_program(CLANG_FORMAT_PATH NAMES clang-format-9 clang-format)
 cmake_dependent_option(
     ENABLE_FORMAT "Enable running clang-format before compiling" ON
     "CLANG_FORMAT_PATH" OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Planned improvements and changes are listed on the [H3 Roadmap](https://github.c
 * Please include tests that show the bug is fixed or feature works as intended.
 * Please add a description of your change to the Unreleased section of the [changelog](./CHANGELOG.md).
 * Please open issues to discuss large features or changes which would break compatibility, before submitting pull requests.
-* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC.
+* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC. We use clang-format-9 for source code formatting, if you have another version the CI job may error on formatting differences.
 * Please keep code coverage of the core H3 library at 100%.
 
 Before we can merge your changes, you must agree to the [Uber Contributor License Agreement](https://cla-assistant.io/uber/h3).

--- a/src/apps/applib/include/args.h
+++ b/src/apps/applib/include/args.h
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
+
 #include "utility.h"
 
 /** Maximum number of names an argument may have. */

--- a/src/apps/applib/include/test.h
+++ b/src/apps/applib/include/test.h
@@ -21,6 +21,7 @@
 #define TEST_H
 
 #include <stdio.h>
+
 #include "geoCoord.h"
 #include "h3api.h"
 

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -21,6 +21,7 @@
 #define UTILITY_H
 
 #include <stdio.h>
+
 #include "coordijk.h"
 #include "h3api.h"
 

--- a/src/apps/applib/lib/args.c
+++ b/src/apps/applib/lib/args.c
@@ -18,10 +18,12 @@
  */
 
 #include "args.h"
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "h3api.h"
 
 /*

--- a/src/apps/applib/lib/kml.c
+++ b/src/apps/applib/lib/kml.c
@@ -18,7 +18,9 @@
  */
 
 #include "kml.h"
+
 #include <stdio.h>
+
 #include "h3api.h"
 
 void kmlPtsHeader(const char* name, const char* desc) {

--- a/src/apps/applib/lib/test.c
+++ b/src/apps/applib/lib/test.c
@@ -18,6 +18,7 @@
  */
 
 #include "test.h"
+
 #include <assert.h>
 #include <stdio.h>
 

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -18,12 +18,14 @@
  */
 
 #include "utility.h"
+
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
 #include "coordijk.h"
 #include "h3Index.h"
 #include "h3api.h"

--- a/src/apps/filters/h3ToComponents.c
+++ b/src/apps/filters/h3ToComponents.c
@@ -24,6 +24,7 @@
  */
 
 #include <inttypes.h>
+
 #include "args.h"
 #include "h3Index.h"
 #include "utility.h"

--- a/src/apps/filters/h3ToGeo.c
+++ b/src/apps/filters/h3ToGeo.c
@@ -41,6 +41,7 @@
  */
 
 #include <inttypes.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "kml.h"

--- a/src/apps/filters/h3ToGeoBoundary.c
+++ b/src/apps/filters/h3ToGeoBoundary.c
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "kml.h"

--- a/src/apps/filters/h3ToLocalIj.c
+++ b/src/apps/filters/h3ToLocalIj.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "utility.h"

--- a/src/apps/filters/hexRange.c
+++ b/src/apps/filters/hexRange.c
@@ -31,6 +31,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "utility.h"

--- a/src/apps/filters/kRing.c
+++ b/src/apps/filters/kRing.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "utility.h"

--- a/src/apps/filters/localIjToH3.c
+++ b/src/apps/filters/localIjToH3.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "h3api.h"
 #include "utility.h"

--- a/src/apps/miscapps/generateFaceCenterPoint.c
+++ b/src/apps/miscapps/generateFaceCenterPoint.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdlib.h>
+
 #include "faceijk.h"
 #include "vec3d.h"
 

--- a/src/apps/miscapps/generateNumHexagons.c
+++ b/src/apps/miscapps/generateNumHexagons.c
@@ -26,6 +26,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "constants.h"
 
 /**

--- a/src/apps/miscapps/h3ToGeoBoundaryHier.c
+++ b/src/apps/miscapps/h3ToGeoBoundaryHier.c
@@ -53,6 +53,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "args.h"
 #include "baseCells.h"
 #include "h3Index.h"

--- a/src/apps/miscapps/h3ToGeoHier.c
+++ b/src/apps/miscapps/h3ToGeoHier.c
@@ -53,6 +53,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "args.h"
 #include "baseCells.h"
 #include "h3Index.h"

--- a/src/apps/miscapps/h3ToHier.c
+++ b/src/apps/miscapps/h3ToHier.c
@@ -32,6 +32,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "baseCells.h"
 #include "h3Index.h"

--- a/src/apps/testapps/mkRandGeo.c
+++ b/src/apps/testapps/mkRandGeo.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "utility.h"
 

--- a/src/apps/testapps/mkRandGeoBoundary.c
+++ b/src/apps/testapps/mkRandGeoBoundary.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "args.h"
 #include "utility.h"
 

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -16,6 +16,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+
 #include "bbox.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/apps/testapps/testCompact.c
+++ b/src/apps/testapps/testCompact.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "constants.h"
 #include "h3Index.h"
 #include "test.h"

--- a/src/apps/testapps/testCoordIj.c
+++ b/src/apps/testapps/testCoordIj.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "constants.h"

--- a/src/apps/testapps/testGeoCoord.c
+++ b/src/apps/testapps/testGeoCoord.c
@@ -20,6 +20,7 @@
  */
 
 #include <math.h>
+
 #include "constants.h"
 #include "geoCoord.h"
 #include "h3api.h"

--- a/src/apps/testapps/testGeoToH3.c
+++ b/src/apps/testapps/testGeoToH3.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "geoCoord.h"
 #include "h3Index.h"
 #include "test.h"

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -20,6 +20,7 @@
  */
 
 #include <math.h>
+
 #include "geoCoord.h"
 #include "h3api.h"
 #include "test.h"

--- a/src/apps/testapps/testH3Distance.c
+++ b/src/apps/testapps/testH3Distance.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "constants.h"

--- a/src/apps/testapps/testH3DistanceExhaustive.c
+++ b/src/apps/testapps/testH3DistanceExhaustive.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "constants.h"

--- a/src/apps/testapps/testH3GetFaces.c
+++ b/src/apps/testapps/testH3GetFaces.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "baseCells.h"
 #include "h3Index.h"
 #include "h3api.h"

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "constants.h"
 #include "h3Index.h"
 #include "test.h"

--- a/src/apps/testapps/testH3Line.c
+++ b/src/apps/testapps/testH3Line.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "h3Index.h"
 #include "h3api.h"
 #include "localij.h"

--- a/src/apps/testapps/testH3LineExhaustive.c
+++ b/src/apps/testapps/testH3LineExhaustive.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "h3Index.h"
 #include "h3api.h"
 #include "localij.h"

--- a/src/apps/testapps/testH3Memory.c
+++ b/src/apps/testapps/testH3Memory.c
@@ -21,6 +21,7 @@
 
 #include <math.h>
 #include <string.h>
+
 #include "geoCoord.h"
 #include "h3Index.h"
 #include "h3api.h"

--- a/src/apps/testapps/testH3NeighborRotations.c
+++ b/src/apps/testapps/testH3NeighborRotations.c
@@ -29,6 +29,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testH3SetToLinkedGeo.c
+++ b/src/apps/testapps/testH3SetToLinkedGeo.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+
 #include "algos.h"
 #include "test.h"
 #include "utility.h"

--- a/src/apps/testapps/testH3SetToVertexGraph.c
+++ b/src/apps/testapps/testH3SetToVertexGraph.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+
 #include "algos.h"
 #include "test.h"
 #include "utility.h"

--- a/src/apps/testapps/testH3ToCenterChild.c
+++ b/src/apps/testapps/testH3ToCenterChild.c
@@ -16,6 +16,7 @@
 
 #include <inttypes.h>
 #include <stdlib.h>
+
 #include "h3Index.h"
 #include "test.h"
 

--- a/src/apps/testapps/testH3ToChildren.c
+++ b/src/apps/testapps/testH3ToChildren.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "h3Index.h"
 #include "test.h"
 

--- a/src/apps/testapps/testH3ToGeo.c
+++ b/src/apps/testapps/testH3ToGeo.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "constants.h"
 #include "geoCoord.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testH3ToGeoBoundary.c
+++ b/src/apps/testapps/testH3ToGeoBoundary.c
@@ -27,6 +27,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "baseCells.h"
 #include "geoCoord.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "constants.h"

--- a/src/apps/testapps/testH3ToLocalIjExhaustive.c
+++ b/src/apps/testapps/testH3ToLocalIjExhaustive.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "constants.h"

--- a/src/apps/testapps/testH3ToParent.c
+++ b/src/apps/testapps/testH3ToParent.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "h3Index.h"
 #include "test.h"
 

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdlib.h>
+
 #include "constants.h"
 #include "geoCoord.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testHexRanges.c
+++ b/src/apps/testapps/testHexRanges.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "algos.h"
 #include "test.h"
 

--- a/src/apps/testapps/testHexRing.c
+++ b/src/apps/testapps/testHexRing.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "algos.h"
 #include "constants.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdlib.h>
+
 #include "algos.h"
 #include "baseCells.h"
 #include "h3Index.h"

--- a/src/apps/testapps/testLinkedGeo.c
+++ b/src/apps/testapps/testLinkedGeo.c
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "geoCoord.h"
 #include "h3api.h"
 #include "linkedGeo.h"

--- a/src/apps/testapps/testMaxH3ToChildrenSize.c
+++ b/src/apps/testapps/testMaxH3ToChildrenSize.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "h3Index.h"
 #include "test.h"
 

--- a/src/apps/testapps/testPentagonIndexes.c
+++ b/src/apps/testapps/testPentagonIndexes.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "h3api.h"
 #include "test.h"
 

--- a/src/apps/testapps/testPolyfill.c
+++ b/src/apps/testapps/testPolyfill.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "algos.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/apps/testapps/testPolyfillReported.c
+++ b/src/apps/testapps/testPolyfillReported.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdlib.h>
+
 #include "algos.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+
 #include "bbox.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/apps/testapps/testVec2d.c
+++ b/src/apps/testapps/testVec2d.c
@@ -17,6 +17,7 @@
 #include <float.h>
 #include <math.h>
 #include <stdlib.h>
+
 #include "test.h"
 #include "vec2d.h"
 

--- a/src/apps/testapps/testVec3d.c
+++ b/src/apps/testapps/testVec3d.c
@@ -17,6 +17,7 @@
 #include <float.h>
 #include <math.h>
 #include <stdlib.h>
+
 #include "test.h"
 #include "vec3d.h"
 

--- a/src/apps/testapps/testVertexGraph.c
+++ b/src/apps/testapps/testVertexGraph.c
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+
 #include "geoCoord.h"
 #include "h3api.h"
 #include "test.h"

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -21,6 +21,7 @@
 #define BBOX_H
 
 #include <stdbool.h>
+
 #include "geoCoord.h"
 
 /** @struct BBox

--- a/src/h3lib/include/geoCoord.h
+++ b/src/h3lib/include/geoCoord.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+
 #include "constants.h"
 #include "h3api.h"
 

--- a/src/h3lib/include/linkedGeo.h
+++ b/src/h3lib/include/linkedGeo.h
@@ -21,6 +21,7 @@
 #define LINKED_GEO_H
 
 #include <stdlib.h>
+
 #include "bbox.h"
 #include "geoCoord.h"
 #include "h3api.h"

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -21,6 +21,7 @@
 #define POLYGON_H
 
 #include <stdbool.h>
+
 #include "bbox.h"
 #include "geoCoord.h"
 #include "h3api.h"

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -25,6 +25,7 @@
 #include <float.h>
 #include <math.h>
 #include <stdbool.h>
+
 #include "bbox.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/h3lib/include/vertexGraph.h
+++ b/src/h3lib/include/vertexGraph.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+
 #include "geoCoord.h"
 
 /** @struct VertexNode

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -18,12 +18,14 @@
  */
 
 #include "algos.h"
+
 #include <assert.h>
 #include <float.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "alloc.h"
 #include "baseCells.h"
 #include "bbox.h"

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -18,6 +18,7 @@
  */
 
 #include "baseCells.h"
+
 #include "h3Index.h"
 
 /** @struct BaseCellOrient

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -18,9 +18,11 @@
  */
 
 #include "bbox.h"
+
 #include <float.h>
 #include <math.h>
 #include <stdbool.h>
+
 #include "constants.h"
 #include "geoCoord.h"
 #include "h3Index.h"

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -19,10 +19,12 @@
  */
 
 #include "coordijk.h"
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "constants.h"
 #include "geoCoord.h"
 #include "mathExtensions.h"

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -19,11 +19,13 @@
  */
 
 #include "faceijk.h"
+
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "constants.h"
 #include "coordijk.h"
 #include "geoCoord.h"

--- a/src/h3lib/lib/geoCoord.c
+++ b/src/h3lib/lib/geoCoord.c
@@ -18,8 +18,10 @@
  */
 
 #include "geoCoord.h"
+
 #include <math.h>
 #include <stdbool.h>
+
 #include "constants.h"
 #include "h3api.h"
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -18,10 +18,13 @@
  *          (see h3api.h for the main library entry functions)
  */
 #include "h3Index.h"
+
+#include <faceijk.h>
 #include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "alloc.h"
 #include "baseCells.h"
 #include "faceijk.h"

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -19,6 +19,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+
 #include "algos.h"
 #include "constants.h"
 #include "coordijk.h"

--- a/src/h3lib/lib/linkedGeo.c
+++ b/src/h3lib/lib/linkedGeo.c
@@ -18,8 +18,10 @@
  */
 
 #include "linkedGeo.h"
+
 #include <assert.h>
 #include <stdlib.h>
+
 #include "alloc.h"
 #include "geoCoord.h"
 #include "h3api.h"

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "baseCells.h"
 #include "faceijk.h"
 #include "h3Index.h"

--- a/src/h3lib/lib/polygon.c
+++ b/src/h3lib/lib/polygon.c
@@ -18,9 +18,11 @@
  */
 
 #include "polygon.h"
+
 #include <float.h>
 #include <math.h>
 #include <stdbool.h>
+
 #include "bbox.h"
 #include "constants.h"
 #include "geoCoord.h"

--- a/src/h3lib/lib/vec2d.c
+++ b/src/h3lib/lib/vec2d.c
@@ -18,6 +18,7 @@
  */
 
 #include "vec2d.h"
+
 #include <math.h>
 #include <stdio.h>
 

--- a/src/h3lib/lib/vec3d.c
+++ b/src/h3lib/lib/vec3d.c
@@ -18,6 +18,7 @@
  */
 
 #include "vec3d.h"
+
 #include <math.h>
 
 /**

--- a/src/h3lib/lib/vertexGraph.c
+++ b/src/h3lib/lib/vertexGraph.c
@@ -18,11 +18,13 @@
  */
 
 #include "vertexGraph.h"
+
 #include <assert.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "alloc.h"
 #include "geoCoord.h"
 


### PR DESCRIPTION
Upgrade CI to Ubuntu Bionic and to use clang-format-9 as our standard code formatter. Not using clang-format-9 should still be OK by contributors since other clang-format versions will probably be close, or manual adjustments can be made.

Ubuntu Bionic upgrades GCC from `5.4.0-6ubuntu1~16.04.12` to `7.4.0-1ubuntu1~18.04.1`. Default Clang version doesn't seem to be changed.

I saw Travis CI has an alpha feature of testing on other architectures now (https://docs.travis-ci.com/user/multi-cpu-architectures/) so I'm trying to enable a single arm64 test. They also support ppc64le and s390x in the same way.

edit: looks like it can take much more than 10 mins for Travis CI to start an arm64 build, so we may want to wait on trying to enable other CPU architectures until they have lifted some of the concurrency limits.