### PR TITLE
Correct the links in docs referring to python tutorials

### DIFF
--- a/docs/community/tutorials.md
+++ b/docs/community/tutorials.md
@@ -24,5 +24,6 @@ This page lists further learning materials and code walkthroughs for the H3 libr
 
 ## Python
 
-- [Usage (IPython Notebook)](https://github.com/uber/h3-py/blob/master/docs/Usage.ipynb)
-- [Unified Data Layers (IPython Notebook)](https://github.com/uber/h3-py/blob/master/docs/UnifiedDataLayers.ipynb)
+- [Usage (IPython Notebook)](https://github.com/uber/h3-py-notebooks/blob/master/Usage.ipynb)
+- [Unified Data Layers (IPython Notebook)](https://github.com/uber/h3-py-notebooks/blob/master/UnifiedDataLayers.ipynb)
+- [H3 API examples on Urban Analytics(IPython Notebook)](https://github.com/uber/h3-py-notebooks/blob/master/H3%20API%20examples%20on%20Urban%20Analytics.ipynb)


### PR DESCRIPTION
Jupyter notebooks were moved to [h3-py-notebooks repository.](https://github.com/uber/h3-py-notebooks)