### PR TITLE
Fix undefined memory allocation functions on Mac OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- Fixed building the library with custom memory allocation functions on Mac OSX. (#356)
 
 ## [3.6.4] - 2020-06-19
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,11 +218,20 @@ function(add_h3_library name h3_alloc_prefix_override)
     endif()
 
     target_compile_definitions(${name} PUBLIC H3_PREFIX=${H3_PREFIX})
+    set(has_alloc_prefix NO)
     if(h3_alloc_prefix_override)
+        set(has_alloc_prefix YES)
         target_compile_definitions(${name} PUBLIC H3_ALLOC_PREFIX=${h3_alloc_prefix_override})
     elseif(H3_ALLOC_PREFIX)
+        set(has_alloc_prefix YES)
         target_compile_definitions(${name} PUBLIC H3_ALLOC_PREFIX=${H3_ALLOC_PREFIX})
     endif()
+    # Mac OSX defaults to not looking up undefined symbols dynamically,
+    # so enable that explicitly.
+    if(has_alloc_prefix AND APPLE)
+        target_link_libraries(${name} PRIVATE "-undefined dynamic_lookup")
+    endif()
+
     if(have_alloca)
         target_compile_definitions(${name} PUBLIC H3_HAVE_ALLOCA)
     endif()


### PR DESCRIPTION
Fixes #361, thanks @chenrui333 for reporting.

Edit: In addition to my comment on that issue, I should add that this should have been caught in Travis CI's OSX build - we should probably see if we can get this reproduced in CI to prevent regression.