### PR TITLE
Add Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Documentation is available at [https://uber.github.io/h3/](https://uber.github.i
 
  * Post **bug reports or feature requests** to the [GitHub Issues page](https://github.com/uber/h3/issues)
  * Ask **questions** by posting to the [H3 tag on StackOverflow](https://stackoverflow.com/questions/tagged/h3)
+ * There is also an [H3 Slack workspace](https://join.slack.com/t/h3-core/shared_invite/zt-g6u5r1hf-W_~uVJmfeiWtMQuBGc1NNg)
 
 ## Installing
 

--- a/docs/community/tutorials.md
+++ b/docs/community/tutorials.md
@@ -1,6 +1,10 @@
-# Tutorials
+# Learning Resources
 
 This page lists further learning materials and code walkthroughs for the H3 library and bindings. Contributions to this list are welcome, please feel free to open a [pull request](https://github.com/uber/h3/tree/master/docs/community/tutorials.md).
+
+## Community
+
+- [H3 Slack workspace](https://join.slack.com/t/h3-core/shared_invite/zt-g6u5r1hf-W_~uVJmfeiWtMQuBGc1NNg)
 
 ## Videos
 


### PR DESCRIPTION
Adds a Slack link for the H3 workspace. This link is set to never expire.

I also renamed the "Tutorials" page on the website but left the URL the same. "Learning Resources" seemed to reflect the content a little more.