### PR TITLE
Add exhaustive tests and benchmark for getH3UnidirectionalEdgeBoundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ dev-docs/Doxyfile
 # CMake generated
 CMakeFiles
 CMakeCache.txt
+CPackConfig.cmake
+CPackSourceConfig.cmake
 Makefile
 cmake_install.cmake
 install_manifest.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/testVec2d.c
     src/apps/testapps/testVec3d.c
     src/apps/testapps/testH3UniEdge.c
-    src/apps/testapps/testH3uniEdgeExhaustive.c
+    src/apps/testapps/testH3UniEdgeExhaustive.c
     src/apps/testapps/testLinkedGeo.c
     src/apps/testapps/mkRandGeo.c
     src/apps/testapps/testH3Api.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ set(OTHER_SOURCE_FILES
     src/apps/benchmarks/benchmarkH3SetToLinkedGeo.c
     src/apps/benchmarks/benchmarkKRing.c
     src/apps/benchmarks/benchmarkH3Line.c
+    src/apps/benchmarks/benchmarkH3UniEdge.c
     src/apps/benchmarks/benchmarkH3Api.c)
 
 set(ALL_SOURCE_FILES
@@ -604,6 +605,7 @@ if(BUILD_BENCHMARKS)
     add_h3_benchmark(benchmarkH3Api src/apps/benchmarks/benchmarkH3Api.c)
     add_h3_benchmark(benchmarkKRing src/apps/benchmarks/benchmarkKRing.c)
     add_h3_benchmark(benchmarkH3Line src/apps/benchmarks/benchmarkH3Line.c)
+    add_h3_benchmark(benchmarkH3UniEdge src/apps/benchmarks/benchmarkH3UniEdge.c)
     add_h3_benchmark(benchmarkH3SetToLinkedGeo src/apps/benchmarks/benchmarkH3SetToLinkedGeo.c)
     add_h3_benchmark(benchmarkPolyfill src/apps/benchmarks/benchmarkPolyfill.c)
     add_h3_benchmark(benchmarkPolygon src/apps/benchmarks/benchmarkPolygon.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ set(OTHER_SOURCE_FILES
     src/apps/testapps/testVec2d.c
     src/apps/testapps/testVec3d.c
     src/apps/testapps/testH3UniEdge.c
+    src/apps/testapps/testH3uniEdgeExhaustive.c
     src/apps/testapps/testLinkedGeo.c
     src/apps/testapps/mkRandGeo.c
     src/apps/testapps/testH3Api.c
@@ -580,6 +581,7 @@ if(BUILD_TESTING)
 
     # The "Exhaustive" part of the test name is used by the test-fast to exclude these files.
     # test-fast exists so that Travis CI can run Valgrind on tests without taking a very long time.
+    add_h3_test(testH3UniEdgeExhaustive src/apps/testapps/testH3UniEdgeExhaustive.c)
     add_h3_test(testH3ToLocalIjExhaustive src/apps/testapps/testH3ToLocalIjExhaustive.c)
     add_h3_test(testH3LineExhaustive src/apps/testapps/testH3LineExhaustive.c)
     add_h3_test(testH3DistanceExhaustive src/apps/testapps/testH3DistanceExhaustive.c)

--- a/src/apps/benchmarks/benchmarkH3Api.c
+++ b/src/apps/benchmarks/benchmarkH3Api.c
@@ -17,7 +17,7 @@
 #include "geoCoord.h"
 #include "h3api.h"
 
-// Fixtures
+// Fixtures (arbitrary res 9 hexagon)
 GeoCoord coord = {0.659966917655, -2.1364398519396};
 H3Index hex = 0x89283080ddbffff;
 

--- a/src/apps/benchmarks/benchmarkH3UniEdge.c
+++ b/src/apps/benchmarks/benchmarkH3UniEdge.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "benchmark.h"
+#include "geoCoord.h"
+#include "h3api.h"
+
+// Fixtures
+H3Index edges[6] = {0};
+H3Index hex = 0x89283080ddbffff;
+
+BEGIN_BENCHMARKS();
+
+GeoBoundary outBoundary;
+H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(hex, edges);
+
+BENCHMARK(getH3UnidirectionalEdgeBoundary, 10000, {
+    for (int i = 0; i < 6; i++)
+        H3_EXPORT(getH3UnidirectionalEdgeBoundary)(edges[i], &outBoundary);
+});
+
+END_BENCHMARKS();

--- a/src/apps/benchmarks/benchmarkH3UniEdge.c
+++ b/src/apps/benchmarks/benchmarkH3UniEdge.c
@@ -17,7 +17,7 @@
 #include "geoCoord.h"
 #include "h3api.h"
 
-// Fixtures
+// Fixtures (arbitrary res 9 hexagon)
 H3Index edges[6] = {0};
 H3Index hex = 0x89283080ddbffff;
 

--- a/src/apps/testapps/testH3UniEdgeExhaustive.c
+++ b/src/apps/testapps/testH3UniEdgeExhaustive.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Uber Technologies, Inc.
+ * Copyright 2020 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/apps/testapps/testH3UniEdgeExhaustive.c
+++ b/src/apps/testapps/testH3UniEdgeExhaustive.c
@@ -44,6 +44,10 @@ static void h3UniEdge_correctness_assertions(H3Index h3) {
         }
         t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
                  "edge is an edge");
+        t_assert(
+            H3_EXPORT(getOriginH3IndexFromUnidirectionalEdge)(edges[i]) == h3,
+            "origin matches input origin");
+
         destination =
             H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(edges[i]);
         t_assert(H3_EXPORT(h3IndexesAreNeighbors)(h3, destination),

--- a/src/apps/testapps/testH3UniEdgeExhaustive.c
+++ b/src/apps/testapps/testH3UniEdgeExhaustive.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief tests H3 unidirectional edge functions using tests over a large number
+ *        of indexes.
+ *
+ *  usage: `testH3UniEdgeExhaustive`
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "constants.h"
+#include "geoCoord.h"
+#include "h3Index.h"
+#include "test.h"
+#include "utility.h"
+
+static void h3UniEdge_correctness_assertions(H3Index h3) {
+    H3Index edges[6] = {0};
+    int isPentagon = H3_EXPORT(h3IsPentagon)(h3);
+    H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(h3, edges);
+    H3Index destination;
+
+    for (int i = 0; i < 6; i++) {
+        if (isPentagon && i == 0) {
+            t_assert(edges[i] == H3_INVALID_INDEX,
+                     "last pentagon edge is empty");
+            continue;
+        }
+        t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edges[i]) == 1,
+                 "edge is an edge");
+        destination =
+            H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(edges[i]);
+        t_assert(H3_EXPORT(h3IndexesAreNeighbors)(h3, destination),
+                 "destination is a neighbor");
+    }
+}
+
+static void h3UniEdge_boundary_assertions(H3Index h3) {
+    H3Index edges[6] = {0};
+    H3_EXPORT(getH3UnidirectionalEdgesFromHexagon)(h3, edges);
+    H3Index destination;
+    H3Index revEdge;
+    GeoBoundary edgeBoundary;
+    GeoBoundary revEdgeBoundary;
+
+    for (int i = 0; i < 6; i++) {
+        if (edges[i] == H3_INVALID_INDEX) continue;
+        H3_EXPORT(getH3UnidirectionalEdgeBoundary)(edges[i], &edgeBoundary);
+        destination =
+            H3_EXPORT(getDestinationH3IndexFromUnidirectionalEdge)(edges[i]);
+        revEdge = H3_EXPORT(getH3UnidirectionalEdge)(destination, h3);
+        H3_EXPORT(getH3UnidirectionalEdgeBoundary)(revEdge, &revEdgeBoundary);
+
+        t_assert(edgeBoundary.numVerts == revEdgeBoundary.numVerts,
+                 "numVerts is equal for edge and reverse");
+
+        for (int j = 0; j < edgeBoundary.numVerts; j++) {
+            t_assert(
+                geoAlmostEqualThreshold(
+                    &edgeBoundary.verts[j],
+                    &revEdgeBoundary.verts[revEdgeBoundary.numVerts - 1 - j],
+                    0.000001),
+                "Got expected vertex");
+        }
+    }
+}
+
+SUITE(h3UniEdge) {
+    TEST(h3UniEdge_correctness) {
+        iterateAllIndexesAtRes(0, h3UniEdge_correctness_assertions);
+        iterateAllIndexesAtRes(1, h3UniEdge_correctness_assertions);
+        iterateAllIndexesAtRes(2, h3UniEdge_correctness_assertions);
+        iterateAllIndexesAtRes(3, h3UniEdge_correctness_assertions);
+    }
+
+    TEST(h3UniEdge_boundary) {
+        iterateAllIndexesAtRes(0, h3UniEdge_boundary_assertions);
+        iterateAllIndexesAtRes(1, h3UniEdge_boundary_assertions);
+        iterateAllIndexesAtRes(2, h3UniEdge_boundary_assertions);
+        iterateAllIndexesAtRes(3, h3UniEdge_boundary_assertions);
+    }
+}


### PR DESCRIPTION
This is a precursor to refactoring `getH3UnidirectionalEdgeBoundary` to an approach not based on comparing geo coordinates, which should be faster and will fix correctness at fine resolutions. But first, tests!

- Adds exhaustive tests for `getH3UnidirectionalEdgeBoundary` at res 0, 1, 2, and 3.
  - For every cell, get all edges
  - For every edge, assert that the boundary equals the reversed boundary of the same edge in the other direction

- Adds a benchmark for `getH3UnidirectionalEdgeBoundary`, current output on my machine:
```
-- getH3UnidirectionalEdgeBoundary: 53.851000 microseconds per iteration (10000 iterations)
```
