### PR TITLE
Fix bug in pentagon-to-neighbor getH3UnidirectionalEdge

### DIFF
--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -124,13 +124,22 @@ SUITE(h3UniEdge) {
     }
 
     TEST(getH3UnidirectionalEdgeFromPentagon) {
-        H3Index pentagon;
-        setH3Index(&pentagon, 0, 4, 0);
-        H3Index adjacent;
-        setH3Index(&adjacent, 0, 8, 0);
+        H3Index pentagon = 0x801dfffffffffff;
+        H3Index ring[7] = {0};
+        H3Index edge;
 
-        H3Index edge = H3_EXPORT(getH3UnidirectionalEdge)(pentagon, adjacent);
-        t_assert(edge != 0, "Produces a valid edge");
+        H3_EXPORT(kRing)(pentagon, 1, ring);
+
+        for (int i = 0; i < 7; i++) {
+            H3Index neighbor = ring[i];
+            if (neighbor == pentagon || neighbor == 0) continue;
+            edge = H3_EXPORT(getH3UnidirectionalEdge)(pentagon, neighbor);
+            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
+                     "pentagon-to-neighbor is a valid edge");
+            edge = H3_EXPORT(getH3UnidirectionalEdge)(neighbor, pentagon);
+            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
+                     "neighbor-to-pentagon is a valid edge");
+        }
     }
 
     TEST(h3UnidirectionalEdgeIsValid) {

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -137,7 +137,7 @@ SUITE(h3UniEdge) {
 
                 for (int i = 0; i < 7; i++) {
                     H3Index neighbor = ring[i];
-                    if (neighbor == pentagon || neighbor == 0) continue;
+                    if (neighbor == pentagon || neighbor == H3_NULL) continue;
                     edge =
                         H3_EXPORT(getH3UnidirectionalEdge)(pentagon, neighbor);
                     t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),

--- a/src/apps/testapps/testH3UniEdge.c
+++ b/src/apps/testapps/testH3UniEdge.c
@@ -124,21 +124,30 @@ SUITE(h3UniEdge) {
     }
 
     TEST(getH3UnidirectionalEdgeFromPentagon) {
-        H3Index pentagon = 0x801dfffffffffff;
+        H3Index pentagons[NUM_PENTAGONS] = {0};
         H3Index ring[7] = {0};
+        H3Index pentagon;
         H3Index edge;
 
-        H3_EXPORT(kRing)(pentagon, 1, ring);
+        for (int res = 0; res < 16; res++) {
+            H3_EXPORT(getPentagonIndexes)(res, pentagons);
+            for (int p = 0; p < NUM_PENTAGONS; p++) {
+                pentagon = pentagons[p];
+                H3_EXPORT(kRing)(pentagon, 1, ring);
 
-        for (int i = 0; i < 7; i++) {
-            H3Index neighbor = ring[i];
-            if (neighbor == pentagon || neighbor == 0) continue;
-            edge = H3_EXPORT(getH3UnidirectionalEdge)(pentagon, neighbor);
-            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
-                     "pentagon-to-neighbor is a valid edge");
-            edge = H3_EXPORT(getH3UnidirectionalEdge)(neighbor, pentagon);
-            t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
-                     "neighbor-to-pentagon is a valid edge");
+                for (int i = 0; i < 7; i++) {
+                    H3Index neighbor = ring[i];
+                    if (neighbor == pentagon || neighbor == 0) continue;
+                    edge =
+                        H3_EXPORT(getH3UnidirectionalEdge)(pentagon, neighbor);
+                    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
+                             "pentagon-to-neighbor is a valid edge");
+                    edge =
+                        H3_EXPORT(getH3UnidirectionalEdge)(neighbor, pentagon);
+                    t_assert(H3_EXPORT(h3UnidirectionalEdgeIsValid)(edge),
+                             "neighbor-to-pentagon is a valid edge");
+                }
+            }
         }
     }
 

--- a/src/h3lib/lib/h3UniEdge.c
+++ b/src/h3lib/lib/h3UniEdge.c
@@ -110,12 +110,14 @@ H3Index H3_EXPORT(getH3UnidirectionalEdge)(H3Index origin,
     H3Index output = origin;
     H3_SET_MODE(output, H3_UNIEDGE_MODE);
 
+    bool isPentagon = H3_EXPORT(h3IsPentagon)(origin);
+
     // Checks each neighbor, in order, to determine which direction the
     // destination neighbor is located. Skips CENTER_DIGIT since that
     // would be this index.
     H3Index neighbor;
-    for (Direction direction = K_AXES_DIGIT; direction < NUM_DIGITS;
-         direction++) {
+    for (Direction direction = isPentagon ? J_AXES_DIGIT : K_AXES_DIGIT;
+         direction < NUM_DIGITS; direction++) {
         int rotations = 0;
         neighbor = h3NeighborRotations(origin, direction, &rotations);
         if (neighbor == destination) {


### PR DESCRIPTION
We had a bug in `getH3UnidirectionalEdge` where certain pentagons would produce invalid or incorrect edges for some neighbors. This is because we were testing all directions, including `K_AXES_DIGIT`, to see if they matched the destination using `h3NeighborRotations` - but apparently `h3NeighborRotations` will wrap around to other valid neighbors in the K direction for some pentagons.

The fix here is one line, but I also added a more exhaustive test for all pentagons at all resolutions.