### PR TITLE
Remove coverage from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ compiler:
   - gcc
   - clang
 
+arch:
+  - arm64
+  - ppc64le
+  - s390x
+
 # Docs are built during the normal compile/test check.
 addons:
   apt:
@@ -30,24 +35,11 @@ addons:
 
 matrix:
   include:
-      # Submit coverage report to Coveralls.io, also test that prefixing works.
-    - name: "Coverage report"
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - lcov
-      install:
-        - gem install coveralls-lcov
-      before_script:
-        - cmake -DCMAKE_BUILD_TYPE=Debug -DWARNINGS_AS_ERRORS=ON -DH3_PREFIX=testprefix_ .
-      script:
-        - make
-        - make coverage
-      after_success:
-        - coveralls-lcov coverage.cleaned.info
       # Test building the website also - needed for FOSSA to pick up dependencies
+      # FOSSA is run here because the API key will not be present in Github Actions.
+      # Blocked on https://github.com/fossas/fossa-cli/issues/617
     - name: "Website and FOSSA report"
+      arch: amd64
       language: node_js
       node_js: 10
       install: []
@@ -59,8 +51,6 @@ matrix:
         - yarn build
         - cd ..
         - 'if [ -n "$FOSSA_API_KEY" ]; then fossa; fi'
-    - name: "ARM64"
-      arch: arm64
 
 # Configure the build script, out of source.
 before_script:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![test-linux](https://github.com/uber/h3/workflows/test-linux/badge.svg)](https://github.com/uber/h3/actions)
 [![test-macos](https://github.com/uber/h3/workflows/test-macos/badge.svg)](https://github.com/uber/h3/actions)
 [![test-windows](https://github.com/uber/h3/workflows/test-windows/badge.svg)](https://github.com/uber/h3/actions)
+[![test-website](https://github.com/uber/h3/workflows/test-website/badge.svg)](https://github.com/uber/h3/actions)
 [![Coverage Status](https://coveralls.io/repos/github/uber/h3/badge.svg?branch=master)](https://coveralls.io/github/uber/h3?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
* Remove coverage, should already be switched over to Github Actions.
* FOSSA is still being run in both since Github Actions will not have the secret needed.
* Potentially add some additional architectures in Travis CI