### PR TITLE
Don't build tests if someone else includes package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ set(H3_SOVERSION 1)
 
 project(h3 LANGUAGES C VERSION ${H3_VERSION})
 
+# Detect if someone else is including the package
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(H3_IS_ROOT_PROJECT ON)
+endif()
+
 set(H3_COMPILE_FLAGS "")
 set(H3_LINK_FLAGS "")
 if(NOT WIN32)
@@ -82,7 +87,9 @@ endif()
 
 include(CMakeDependentOption)
 include(CheckIncludeFile)
-include(CTest)
+if(H3_IS_ROOT_PROJECT)
+    include(CTest)
+endif()
 
 set(LIB_SOURCE_FILES
     src/h3lib/include/bbox.h
@@ -404,7 +411,7 @@ if(BUILD_GENERATORS)
     add_h3_executable(mkRandGeoBoundary src/apps/testapps/mkRandGeoBoundary.c ${APP_SOURCE_FILES})
 endif()
 
-if(BUILD_TESTING)
+if(H3_IS_ROOT_PROJECT AND BUILD_TESTING)
     option(PRINT_TEST_FILES "Print which test files correspond to which tests" OFF)
 
     include(TestWrapValgrind)


### PR DESCRIPTION
This PR doesn't `include(CTest)` when package is not top-level, as suggested in [Modern CMake / General Testing Information](https://cliutils.gitlab.io/modern-cmake/chapters/testing.html).

> The reason for this is that if someone else includes your package, and they use BUILD_TESTING, they probably do not want your tests to build.

This will allow me to enable BUILD_TESTING for my own project, and use

```cmake
FetchContent_Declare(h3
  GIT_REPOSITORY https://github.com/uber/h3.git
  GIT_TAG v3.7.0
)
FetchContent_MakeAvailable(h3)
```

without building the h3 core tests.