### PR TITLE
Vertex optimizations, first pass

### DIFF
--- a/src/apps/benchmarks/benchmarkVertex.c
+++ b/src/apps/benchmarks/benchmarkVertex.c
@@ -19,6 +19,10 @@
 
 // Fixtures. Cells are arbitrary, except that ring2 is all hexagons and
 // ring2Pent is centered on a pentagon.
+
+H3Index hex = 0x89283080ddbffff;
+H3Index pentagon = 0x89080000003ffff;
+
 H3Index ring2[] = {
     0x89283081083ffff, 0x8928308109bffff, 0x8928308108bffff, 0x8928308108fffff,
     0x89283081087ffff, 0x89283081097ffff, 0x89283081093ffff, 0x89283081467ffff,
@@ -38,13 +42,19 @@ BEGIN_BENCHMARKS();
 
 H3Index* vertexes = calloc(6, sizeof(H3Index));
 
-BENCHMARK(cellToVertexes, 10000, {
+BENCHMARK(cellToVertexes, 10000, { H3_EXPORT(cellToVertexes)(hex, vertexes); });
+
+BENCHMARK(cellToVertexesPent, 10000, {
+    H3_EXPORT(cellToVertexes)(pentagon, vertexes);
+});
+
+BENCHMARK(cellToVertexesRing, 10000, {
     for (int i = 0; i < ring2Count; i++) {
         H3_EXPORT(cellToVertexes)(ring2[i], vertexes);
     }
 });
 
-BENCHMARK(cellToVertexesPent, 10000, {
+BENCHMARK(cellToVertexesRingPent, 10000, {
     for (int i = 0; i < ring2PentCount; i++) {
         H3_EXPORT(cellToVertexes)(ring2Pent[i], vertexes);
     }

--- a/src/apps/testapps/testVertex.c
+++ b/src/apps/testapps/testVertex.c
@@ -86,6 +86,19 @@ SUITE(Vertex) {
                  "invalid pent vertex should return invalid direction");
     }
 
+    TEST(cellToVertex_badVerts) {
+        H3Index origin = 0x823d6ffffffffff;
+
+        t_assert(cellToVertex(origin, -1) == H3_NULL,
+                 "negative vertex should return null index");
+        t_assert(cellToVertex(origin, 6) == H3_NULL,
+                 "invalid vertex should return null index");
+
+        H3Index pentagon = 0x823007fffffffff;
+        t_assert(cellToVertex(pentagon, 5) == H3_NULL,
+                 "invalid pent vertex should return null index");
+    }
+
     TEST(isValidVertex_hex) {
         H3Index origin = 0x823d6ffffffffff;
         H3Index vert = 0x2222597fffffffff;
@@ -98,7 +111,19 @@ SUITE(Vertex) {
         }
     }
 
-    TEST(isValidVertex_badOwner) {
+    TEST(isValidVertex_invalidOwner) {
+        H3Index origin = 0x823d6ffffffffff;
+        int vertexNum = 0;
+        H3Index vert = H3_EXPORT(cellToVertex)(origin, vertexNum);
+
+        // Set a bit for an unused digit to something else.
+        vert ^= 1;
+
+        t_assert(H3_EXPORT(isValidVertex)(vert) == 0,
+                 "vertex with invalid owner is not valid");
+    }
+
+    TEST(isValidVertex_wrongOwner) {
         H3Index origin = 0x823d6ffffffffff;
         int vertexNum = 0;
         H3Index vert = H3_EXPORT(cellToVertex)(origin, vertexNum);

--- a/src/apps/testapps/testVertex.c
+++ b/src/apps/testapps/testVertex.c
@@ -89,13 +89,13 @@ SUITE(Vertex) {
     TEST(cellToVertex_badVerts) {
         H3Index origin = 0x823d6ffffffffff;
 
-        t_assert(cellToVertex(origin, -1) == H3_NULL,
+        t_assert(H3_EXPORT(cellToVertex)(origin, -1) == H3_NULL,
                  "negative vertex should return null index");
-        t_assert(cellToVertex(origin, 6) == H3_NULL,
+        t_assert(H3_EXPORT(cellToVertex)(origin, 6) == H3_NULL,
                  "invalid vertex should return null index");
 
         H3Index pentagon = 0x823007fffffffff;
-        t_assert(cellToVertex(pentagon, 5) == H3_NULL,
+        t_assert(H3_EXPORT(cellToVertex)(pentagon, 5) == H3_NULL,
                  "invalid pent vertex should return null index");
     }
 

--- a/src/h3lib/lib/vertex.c
+++ b/src/h3lib/lib/vertex.c
@@ -172,6 +172,17 @@ Direction directionForVertexNum(const H3Index origin, const int vertexNum) {
                                                 NUM_HEX_VERTS];
 }
 
+/** @brief Directions in CCW order */
+static const Direction DIRECTIONS[NUM_HEX_VERTS] = {
+    J_AXES_DIGIT,  JK_AXES_DIGIT, K_AXES_DIGIT,
+    IK_AXES_DIGIT, I_AXES_DIGIT,  IJ_AXES_DIGIT};
+
+/** @brief Reverse direction from neighbor in each direction,
+ *         given as an index into DIRECTIONS to facilitate rotation
+ */
+static const int revNeighborDirectionsHex[NUM_DIGITS] = {
+    INVALID_DIGIT, 5, 3, 4, 1, 0, 2};
+
 /**
  * Get a single vertex for a given cell, as an H3 index, or
  * H3_NULL if the vertex is invalid
@@ -181,44 +192,74 @@ Direction directionForVertexNum(const H3Index origin, const int vertexNum) {
 H3Index H3_EXPORT(cellToVertex)(H3Index cell, int vertexNum) {
     int cellIsPentagon = H3_EXPORT(h3IsPentagon)(cell);
     int cellNumVerts = cellIsPentagon ? NUM_PENT_VERTS : NUM_HEX_VERTS;
+    int res = H3_GET_RESOLUTION(cell);
 
-    // Get the left neighbor of the vertex, with its rotations
-    Direction left = directionForVertexNum(cell, vertexNum);
-    if (left == INVALID_DIGIT) return H3_NULL;
-    int rRotations = 0;
-    H3Index leftNeighbor = h3NeighborRotations(cell, left, &rRotations);
-
-    // Get the right neighbor of the vertex, with its rotations
-    // Note that vertex - 1 is the right side, as vertex numbers are CCW
-    Direction right = directionForVertexNum(
-        cell, (vertexNum - 1 + cellNumVerts) % cellNumVerts);
-    // This case should be unreachable; invalid verts fail the left side first
-    if (right == INVALID_DIGIT) return H3_NULL;  // LCOV_EXCL_LINE
-    int lRotations = 0;
-    H3Index rightNeighbor = h3NeighborRotations(cell, right, &lRotations);
-
-    // Determine the owner. By convention, this is the cell with the
-    // lowest numerical index.
+    // Default the owner and vertex number to the input cell
     H3Index owner = cell;
-    if (leftNeighbor < owner) owner = leftNeighbor;
-    if (rightNeighbor < owner) owner = rightNeighbor;
-
-    // Determine the vertex number for the owner cell
     int ownerVertexNum = vertexNum;
 
-    if (owner == leftNeighbor) {
-        Direction dir = directionForNeighbor(owner, cell);
-        // For the left neighbor, we need the second vertex of the
-        // edge, which may involve looping around the vertex nums
-        ownerVertexNum = vertexNumForDirection(owner, dir) + 1;
-        if (ownerVertexNum == NUM_HEX_VERTS ||
-            (H3_EXPORT(h3IsPentagon)(owner) &&
-             ownerVertexNum == NUM_PENT_VERTS)) {
-            ownerVertexNum = 0;
+    // Get the left direction. This also checks whether the vertexNum is valid.
+    Direction left = directionForVertexNum(cell, vertexNum);
+    if (left == INVALID_DIGIT) return H3_NULL;
+
+    // Determine the owner, looking at the three cells that share the vertex.
+    // By convention, the owner is the cell with the lowest numerical index.
+
+    // If the cell is the center child of its parent, it will always have
+    // the lowest index of any neighbor, so we can skip determining the owner
+    if (res == 0 || H3_GET_INDEX_DIGIT(cell, res) != CENTER_DIGIT) {
+        H3Index leftNeighbor = H3_NULL;
+        H3Index rightNeighbor = H3_NULL;
+        Direction neighborDir = CENTER_DIGIT;
+        int neighborRotations = 0;
+
+        // Get the left neighbor of the vertex, with its rotations
+        int lRotations = 0;
+        leftNeighbor = h3NeighborRotations(cell, left, &lRotations);
+        // Set to owner if lowest index
+        if (leftNeighbor < owner) {
+            owner = leftNeighbor;
+            neighborDir = left;
+            neighborRotations = lRotations;
         }
-    } else if (owner == rightNeighbor) {
-        Direction dir = directionForNeighbor(owner, cell);
-        ownerVertexNum = vertexNumForDirection(owner, dir);
+
+        // As above, skip the right neighbor if the left is known lowest
+        if (res == 0 || H3_GET_INDEX_DIGIT(leftNeighbor, res) != CENTER_DIGIT) {
+            // Get the right neighbor of the vertex, with its rotations
+            // Note that vertex - 1 is the right side, as vertex numbers are CCW
+            Direction right = directionForVertexNum(
+                cell, (vertexNum - 1 + cellNumVerts) % cellNumVerts);
+            int rRotations = 0;
+            rightNeighbor = h3NeighborRotations(cell, right, &rRotations);
+            // Set to owner if lowest index
+            if (rightNeighbor < owner) {
+                owner = rightNeighbor;
+                neighborDir = right;
+                neighborRotations = rRotations;
+            }
+        }
+
+        // Determine the vertex number for the approppriate neighbor
+        if (owner != cell) {
+            int ownerIsPentagon = H3_EXPORT(h3IsPentagon)(owner);
+            Direction dir =
+                (cellIsPentagon || ownerIsPentagon)
+                    ? directionForNeighbor(owner, cell)
+                    : DIRECTIONS[(revNeighborDirectionsHex[neighborDir] +
+                                  neighborRotations) %
+                                 NUM_HEX_VERTS];
+            if (owner == rightNeighbor) {
+                ownerVertexNum = vertexNumForDirection(owner, dir);
+            } else {
+                // For the left neighbor, we need the second vertex of the
+                // edge, which may involve looping around the vertex nums
+                ownerVertexNum = vertexNumForDirection(owner, dir) + 1;
+                if (ownerVertexNum == NUM_HEX_VERTS ||
+                    (ownerIsPentagon && ownerVertexNum == NUM_PENT_VERTS)) {
+                    ownerVertexNum = 0;
+                }
+            }
+        }
     }
 
     // Create the vertex index


### PR DESCRIPTION
Small optimizations for `cellToVertex`. The main benefit of this work was to identify the key perf bottleneck, which is the call to `_h3ToFaceIjk` in `vertexRotations`. The optimizations here are mainly to avoid expensive calls:

- Skip calculating left and right neighbors if the origin is a center child (center children will always have the lowest index)
- Skip calculating right neighbor if the left neighbor is a center child
- For hexagon cells, use a simple direction lookup table to determine the reverse direction, instead of using the slightly slower `directionForNeighbor`.

This improves things, but doesn't add up as much as I'd like - approx 20% speedup:

**Before** 
```
	-- cellToVertexes: 257.191600 microseconds per iteration (10000 iterations)
	-- cellToVertexesPent: 267.356200 microseconds per iteration (10000 iterations)
```

**After**
```
	-- cellToVertexes: 13.119300 microseconds per iteration (10000 iterations)
	-- cellToVertexesPent: 0.357300 microseconds per iteration (10000 iterations)
	-- cellToVertexesRing: 215.354700 microseconds per iteration (10000 iterations)
	-- cellToVertexesRingPent: 227.581100 microseconds per iteration (10000 iterations)
```

I think I can improve on this significantly by refactoring `cellToVertexes` to avoid repeated calculations for the origin and neighbors, but that will come in a later PR.