### PR TITLE
Add bounds checks for some base cell accesses

### DIFF
--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -100,6 +100,12 @@ SUITE(h3Api) {
         t_assertBoundary(h3, &boundary);
     }
 
+    TEST(h3ToGeoInvalid) {
+        GeoCoord coord;
+        H3_EXPORT(h3ToGeo)(0x7fffffffffffffff, &coord);
+        // Test is this should not crash (should return an error in the future)
+    }
+
     TEST(version) {
         t_assert(H3_VERSION_MAJOR >= 0, "major version is set");
         t_assert(H3_VERSION_MINOR >= 0, "minor version is set");

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -132,9 +132,11 @@ SUITE(h3ToLocalIj) {
 
     TEST(experimentalH3ToLocalIjInvalid) {
         CoordIJ ij;
-        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(bc1, 0x7fffffffffffffff,
-                                                    &ij) != 0,
-                 "invalid index");
+        H3Index invalidIndex = 0x7fffffffffffffff;
+        H3_SET_RESOLUTION(invalidIndex, H3_GET_RESOLUTION(bc1));
+        t_assert(
+            H3_EXPORT(experimentalH3ToLocalIj)(bc1, invalidIndex, &ij) != 0,
+            "invalid index");
         t_assert(H3_EXPORT(experimentalH3ToLocalIj)(0x7fffffffffffffff, bc1,
                                                     &ij) != 0,
                  "invalid origin");

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -130,6 +130,27 @@ SUITE(h3ToLocalIj) {
                  "found IJ (5)");
     }
 
+    TEST(experimentalH3ToLocalIjInvalid) {
+        CoordIJ ij;
+        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(bc1, 0x7fffffffffffffff,
+                                                    &ij) != 0,
+                 "invalid index");
+        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(0x7fffffffffffffff, bc1,
+                                                    &ij) != 0,
+                 "invalid origin");
+        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(
+                     0x7fffffffffffffff, 0x7fffffffffffffff, &ij) != 0,
+                 "invalid origin and index");
+    }
+
+    TEST(experimentalLocalIjToH3Invalid) {
+        CoordIJ ij = {0, 0};
+        H3Index index;
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(0x7fffffffffffffff, &ij,
+                                                    &index) != 0,
+                 "invalid origin for ijToH3");
+    }
+
     /**
      * Test that coming from the same direction outside the pentagon is handled
      * the same as coming from the same direction inside the pentagon.

--- a/src/apps/testapps/testH3ToParent.c
+++ b/src/apps/testapps/testH3ToParent.c
@@ -47,5 +47,7 @@ SUITE(h3ToParent) {
                  "Invalid resolution fails");
         t_assert(H3_EXPORT(h3ToParent)(child, 15) == 0,
                  "Invalid resolution fails");
+        t_assert(H3_EXPORT(h3ToParent)(child, 16) == 0,
+                 "Invalid resolution fails");
     }
 }

--- a/src/apps/testapps/testKRing.c
+++ b/src/apps/testapps/testKRing.c
@@ -351,4 +351,13 @@ SUITE(kRing) {
             }
         }
     }
+
+    TEST(kRingInvalid) {
+        int k = 1000;
+        int kSz = H3_EXPORT(maxKringSize)(k);
+        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
+        H3_EXPORT(kRing)(0x7fffffffffffffff, 1000, neighbors);
+        // Assertion is should not crash - should return an error in the future
+        free(neighbors);
+    }
 }

--- a/src/apps/testapps/testPentagonIndexes.c
+++ b/src/apps/testapps/testPentagonIndexes.c
@@ -55,4 +55,10 @@ SUITE(getPentagonIndexes) {
                      "there should be exactly 12 pentagons");
         }
     }
+
+    TEST(invalidPentagons) {
+        t_assert(!H3_EXPORT(h3IsPentagon)(0), "0 is not a pentagon");
+        t_assert(!H3_EXPORT(h3IsPentagon)(0x7fffffffffffffff),
+                 "all but high bit is not a pentagon");
+    }
 }

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -290,7 +290,9 @@ H3Index h3NeighborRotations(H3Index origin, Direction dir, int* rotations) {
 
     int newRotations = 0;
     int oldBaseCell = H3_GET_BASE_CELL(out);
-    if (oldBaseCell < 0 || oldBaseCell >= NUM_BASE_CELLS) {
+    if (oldBaseCell < 0 ||
+        oldBaseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
+        // Base cells less than zero can not be represented in an index
         return H3_NULL;
     }
     Direction oldLeadingDigit = _h3LeadingNonZeroDigit(out);

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -290,6 +290,9 @@ H3Index h3NeighborRotations(H3Index origin, Direction dir, int* rotations) {
 
     int newRotations = 0;
     int oldBaseCell = H3_GET_BASE_CELL(out);
+    if (oldBaseCell < 0 || oldBaseCell >= NUM_BASE_CELLS) {
+        return H3_NULL;
+    }
     Direction oldLeadingDigit = _h3LeadingNonZeroDigit(out);
 
     // Adjust the indexing digits and, if needed, the base cell.

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -822,6 +822,9 @@ const BaseCellData baseCellData[NUM_BASE_CELLS] = {
 
 /** @brief Return whether or not the indicated base cell is a pentagon. */
 int _isBaseCellPentagon(int baseCell) {
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
+        return false;
+    }
     return baseCellData[baseCell].isPentagon;
 }
 

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -822,7 +822,8 @@ const BaseCellData baseCellData[NUM_BASE_CELLS] = {
 
 /** @brief Return whether or not the indicated base cell is a pentagon. */
 int _isBaseCellPentagon(int baseCell) {
-    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
+        // Base cells less than zero can not be represented in an index
         return false;
     }
     return baseCellData[baseCell].isPentagon;

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -787,6 +787,10 @@ int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK* fijk) {
  */
 void _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
     int baseCell = H3_GET_BASE_CELL(h);
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
+        // TODO: Indicate an error to the caller
+        return;
+    }
     // adjust for the pentagonal missing sequence; all of sub-sequence 5 needs
     // to be adjusted (and some of sub-sequence 4 below)
     if (_isBaseCellPentagon(baseCell) && _h3LeadingNonZeroDigit(h) == 5)

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -793,7 +793,7 @@ int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK* fijk) {
  */
 void _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
     int baseCell = H3_GET_BASE_CELL(h);
-    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // aaa TODO
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
         // Base cells less than zero can not be represented in an index
         // TODO: Indicate an error to the caller
         // To prevent reading uninitialized memory, we zero the output.

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -138,6 +138,13 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
     int originBaseCell = H3_GET_BASE_CELL(origin);
     int baseCell = H3_GET_BASE_CELL(h3);
 
+    if (originBaseCell < 0 || originBaseCell >= NUM_BASE_CELLS) {
+        return 1;
+    }
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
+        return 1;
+    }
+
     // Direction from origin base cell to index base cell
     Direction dir = CENTER_DIGIT;
     Direction revDir = CENTER_DIGIT;
@@ -280,6 +287,9 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
 int localIjkToH3(H3Index origin, const CoordIJK* ijk, H3Index* out) {
     int res = H3_GET_RESOLUTION(origin);
     int originBaseCell = H3_GET_BASE_CELL(origin);
+    if (originBaseCell < 0 || originBaseCell >= NUM_BASE_CELLS) {
+        return 1;
+    }
     int originOnPent = _isBaseCellPentagon(originBaseCell);
 
     // This logic is very similar to faceIjkToH3

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -138,10 +138,13 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
     int originBaseCell = H3_GET_BASE_CELL(origin);
     int baseCell = H3_GET_BASE_CELL(h3);
 
-    if (originBaseCell < 0 || originBaseCell >= NUM_BASE_CELLS) {
+    if (originBaseCell < 0 ||  // LCOV_EXCL_BR_LINE
+        originBaseCell >= NUM_BASE_CELLS) {
+        // Base cells less than zero can not be represented in an index
         return 1;
     }
-    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
+    if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
+        // Base cells less than zero can not be represented in an index
         return 1;
     }
 
@@ -287,7 +290,9 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
 int localIjkToH3(H3Index origin, const CoordIJK* ijk, H3Index* out) {
     int res = H3_GET_RESOLUTION(origin);
     int originBaseCell = H3_GET_BASE_CELL(origin);
-    if (originBaseCell < 0 || originBaseCell >= NUM_BASE_CELLS) {
+    if (originBaseCell < 0 ||  // LCOV_EXCL_BR_LINE
+        originBaseCell >= NUM_BASE_CELLS) {
+        // Base cells less than zero can not be represented in an index
         return 1;
     }
     int originOnPent = _isBaseCellPentagon(originBaseCell);


### PR DESCRIPTION
Partial update of #423 with tests (thanks @alexey-milovidov). These fix potential crashes (segfault) or otherwise out of bounds reads. I did not port two of the checks in baseCells.c since I could not readily test them. They could be added in a future PR.

Benchmark results (release configuration, recent MacBook Pro)
***Before***
```
% make benchmarks
[  9%] Formatting sources
[  9%] Built target format
[ 36%] Built target h3
[ 45%] Built target benchmarkH3Line
Scanning dependencies of target bench_benchmarkH3Line
	-- h3LineNear: 16.212100 microseconds per iteration (10000 iterations)
	-- h3LineFar: 700.057000 microseconds per iteration (1000 iterations)
[ 45%] Built target bench_benchmarkH3Line
[ 54%] Built target benchmarkPolygon
Scanning dependencies of target bench_benchmarkPolygon
	-- pointInsideGeofenceSmall: 0.034070 microseconds per iteration (100000 iterations)
	-- pointInsideGeofenceLarge: 0.295750 microseconds per iteration (100000 iterations)
	-- bboxFromGeofenceSmall: 0.027170 microseconds per iteration (100000 iterations)
	-- bboxFromGeofenceLarge: 0.322950 microseconds per iteration (100000 iterations)
[ 54%] Built target bench_benchmarkPolygon
[ 63%] Built target benchmarkH3SetToLinkedGeo
Scanning dependencies of target bench_benchmarkH3SetToLinkedGeo
	-- h3SetToLinkedGeoRing2: 59.360300 microseconds per iteration (10000 iterations)
	-- h3SetToLinkedGeoDonut: 22.918100 microseconds per iteration (10000 iterations)
	-- h3SetToLinkedGeoNestedDonuts: 95.143400 microseconds per iteration (10000 iterations)
[ 63%] Built target bench_benchmarkH3SetToLinkedGeo
[ 63%] Built target benchmarkH3Api
Scanning dependencies of target bench_benchmarkH3Api
	-- geoToH3: 0.687900 microseconds per iteration (10000 iterations)
	-- h3ToGeo: 0.422600 microseconds per iteration (10000 iterations)
	-- h3ToGeoBoundary: 2.132000 microseconds per iteration (10000 iterations)
[ 63%] Built target bench_benchmarkH3Api
[ 72%] Built target benchmarkVertex
Scanning dependencies of target bench_benchmarkVertex
	-- cellToVertexes: 2.287000 microseconds per iteration (10000 iterations)
	-- cellToVertexesPent: 0.090400 microseconds per iteration (10000 iterations)
	-- cellToVertexesRing: 31.332400 microseconds per iteration (10000 iterations)
	-- cellToVertexesRingPent: 35.073900 microseconds per iteration (10000 iterations)
[ 72%] Built target bench_benchmarkVertex
[ 81%] Built target benchmarkKRing
Scanning dependencies of target bench_benchmarkKRing
	-- kRing10: 7.425000 microseconds per iteration (10000 iterations)
	-- kRing20: 26.990900 microseconds per iteration (10000 iterations)
	-- kRing30: 58.684600 microseconds per iteration (10000 iterations)
	-- kRing40: 100.795300 microseconds per iteration (10000 iterations)
	-- kRingPentagon10: 213.414000 microseconds per iteration (500 iterations)
	-- kRingPentagon20: 1768.964000 microseconds per iteration (500 iterations)
	-- kRingPentagon30: 5831.160000 microseconds per iteration (50 iterations)
	-- kRingPentagon40: 13730.700000 microseconds per iteration (10 iterations)
[ 81%] Built target bench_benchmarkKRing
[ 90%] Built target benchmarkH3UniEdge
Scanning dependencies of target bench_benchmarkH3UniEdge
	-- getH3UnidirectionalEdgeBoundary: 5.064700 microseconds per iteration (10000 iterations)
[ 90%] Built target bench_benchmarkH3UniEdge
[100%] Built target benchmarkPolyfill
Scanning dependencies of target bench_benchmarkPolyfill
	-- polyfillSF: 1203.760000 microseconds per iteration (500 iterations)
	-- polyfillAlameda: 1664.290000 microseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 54339.300000 microseconds per iteration (10 iterations)
[100%] Built target bench_benchmarkPolyfill
Scanning dependencies of target benchmarks
[100%] Built target benchmarks
```

***After***
```
% make benchmarks
[  9%] Formatting sources
[  9%] Built target format
[ 36%] Built target h3
[ 45%] Built target benchmarkH3UniEdge
	-- getH3UnidirectionalEdgeBoundary: 4.853900 microseconds per iteration (10000 iterations)
[ 45%] Built target bench_benchmarkH3UniEdge
[ 54%] Built target benchmarkH3Line
	-- h3LineNear: 14.541700 microseconds per iteration (10000 iterations)
	-- h3LineFar: 688.441000 microseconds per iteration (1000 iterations)
[ 54%] Built target bench_benchmarkH3Line
[ 63%] Built target benchmarkPolygon
	-- pointInsideGeofenceSmall: 0.035170 microseconds per iteration (100000 iterations)
	-- pointInsideGeofenceLarge: 0.293390 microseconds per iteration (100000 iterations)
	-- bboxFromGeofenceSmall: 0.027260 microseconds per iteration (100000 iterations)
	-- bboxFromGeofenceLarge: 0.308790 microseconds per iteration (100000 iterations)
[ 63%] Built target bench_benchmarkPolygon
[ 72%] Built target benchmarkH3SetToLinkedGeo
	-- h3SetToLinkedGeoRing2: 60.570600 microseconds per iteration (10000 iterations)
	-- h3SetToLinkedGeoDonut: 22.946600 microseconds per iteration (10000 iterations)
	-- h3SetToLinkedGeoNestedDonuts: 95.399400 microseconds per iteration (10000 iterations)
[ 72%] Built target bench_benchmarkH3SetToLinkedGeo
[ 72%] Built target benchmarkH3Api
	-- geoToH3: 0.654900 microseconds per iteration (10000 iterations)
	-- h3ToGeo: 0.412700 microseconds per iteration (10000 iterations)
	-- h3ToGeoBoundary: 2.152000 microseconds per iteration (10000 iterations)
[ 72%] Built target bench_benchmarkH3Api
[ 81%] Built target benchmarkVertex
	-- cellToVertexes: 2.062300 microseconds per iteration (10000 iterations)
	-- cellToVertexesPent: 0.067100 microseconds per iteration (10000 iterations)
	-- cellToVertexesRing: 30.586400 microseconds per iteration (10000 iterations)
	-- cellToVertexesRingPent: 35.477500 microseconds per iteration (10000 iterations)
[ 81%] Built target bench_benchmarkVertex
[ 90%] Built target benchmarkPolyfill
	-- polyfillSF: 1206.176000 microseconds per iteration (500 iterations)
	-- polyfillAlameda: 1686.132000 microseconds per iteration (500 iterations)
	-- polyfillSouthernExpansion: 53059.800000 microseconds per iteration (10 iterations)
[ 90%] Built target bench_benchmarkPolyfill
[100%] Built target benchmarkKRing
	-- kRing10: 8.776000 microseconds per iteration (10000 iterations)
	-- kRing20: 27.379200 microseconds per iteration (10000 iterations)
	-- kRing30: 59.835500 microseconds per iteration (10000 iterations)
	-- kRing40: 102.880500 microseconds per iteration (10000 iterations)
	-- kRingPentagon10: 204.118000 microseconds per iteration (500 iterations)
	-- kRingPentagon20: 1792.512000 microseconds per iteration (500 iterations)
	-- kRingPentagon30: 5691.240000 microseconds per iteration (50 iterations)
	-- kRingPentagon40: 13445.700000 microseconds per iteration (10 iterations)
[100%] Built target bench_benchmarkKRing
[100%] Built target benchmarks
```

From the benchmarks, h3ToGeo, h3ToGeoBoundary, and kRing do not seem to be significantly impacted. I don't think we have a benchmarking setup that is capable of detecting very small changes in performance, but there is no large change.