### PR TITLE
Add fuzzer harnesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 option(ENABLE_COVERAGE "Enable compiling tests with coverage." ON)
 option(BUILD_BENCHMARKS "Build benchmarking applications." ON)
+option(BUILD_FUZZERS "Build fuzzer applications (for use with afl)." ON)
 option(BUILD_FILTERS "Build filter applications." ON)
 option(BUILD_GENERATORS "Build code generation applications." ON)
 
@@ -209,6 +210,9 @@ set(OTHER_SOURCE_FILES
     src/apps/miscapps/generatePentagonDirectionFaces.c
     src/apps/miscapps/generateFaceCenterPoint.c
     src/apps/miscapps/h3ToHier.c
+    src/apps/fuzzers/fuzzerGeoToH3.c
+    src/apps/fuzzers/fuzzerH3ToGeo.c
+    src/apps/fuzzers/fuzzerKRing.c
     src/apps/benchmarks/benchmarkPolyfill.c
     src/apps/benchmarks/benchmarkPolygon.c
     src/apps/benchmarks/benchmarkH3SetToLinkedGeo.c
@@ -620,6 +624,19 @@ if(H3_IS_ROOT_PROJECT AND BUILD_TESTING)
     endif()
 
     add_custom_target(test-fast COMMAND ctest -E Exhaustive)
+endif()
+
+if(BUILD_FUZZERS)
+    add_custom_target(fuzzers)
+
+    macro(add_h3_fuzzer name srcfile)
+        add_h3_executable(${name} ${srcfile} ${APP_SOURCE_FILES})
+        add_dependencies(fuzzers ${name})
+    endmacro()
+
+    add_h3_fuzzer(fuzzerGeoToH3 src/apps/fuzzers/fuzzerGeoToH3.c)
+    add_h3_fuzzer(fuzzerH3ToGeo src/apps/fuzzers/fuzzerH3ToGeo.c)
+    add_h3_fuzzer(fuzzerKRing src/apps/fuzzers/fuzzerKRing.c)
 endif()
 
 if(BUILD_BENCHMARKS)

--- a/src/apps/fuzzers/README.md
+++ b/src/apps/fuzzers/README.md
@@ -1,0 +1,34 @@
+# Fuzzer harnesses for H3
+
+This directory contains helper programs for testing the H3 library using the
+''[American fuzzy lop](https://lcamtuf.coredump.cx/afl/)'' fuzzer.
+
+# Installation
+
+```
+apt install afl-clang
+```
+
+(There is also an afl-cov which looks interesting but isn't necessary.)
+
+# Usage
+
+You must compile with the instrumented compiler:
+
+```
+CXX=afl-clang++ CC=afl-clang cmake .
+make fuzzers
+```
+
+An individual fuzzer run is invoked as follows. The argument is a file containing the number of bytes needed.
+
+```
+fuzzerGeoToH3 bytes24
+```
+
+To begin running the fuzzer, run the following. The testcase directory (`testcase_dir`) should contain a file
+with at least the right number of bytes that the fuzzer will read (such as 16 for fuzzerKRing.)
+
+```
+afl-fuzz -i testcase_dir -o findings_dir -- fuzzerGeoToH3 @@
+```

--- a/src/apps/fuzzers/fuzzerGeoToH3.c
+++ b/src/apps/fuzzers/fuzzerGeoToH3.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief Fuzzer program for geoToH3
+ */
+
+#include "h3api.h"
+#include "utility.h"
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        error("Should have one argument (test case file)\n");
+    }
+    const char* filename = argv[1];
+    FILE* fp = fopen(filename, "rb");
+    struct args {
+        double lat;
+        double lon;
+        int res;
+    } args;
+    if (fread(&args, sizeof(args), 1, fp) != 1) {
+        error("Error reading\n");
+    }
+    fclose(fp);
+
+    GeoCoord g = {.lat = args.lat,
+                  .lon = args.lon};
+    H3Index h = H3_EXPORT(geoToH3)(&g, args.res);
+
+    h3Println(h);
+}

--- a/src/apps/fuzzers/fuzzerGeoToH3.c
+++ b/src/apps/fuzzers/fuzzerGeoToH3.c
@@ -36,8 +36,7 @@ int main(int argc, char* argv[]) {
     }
     fclose(fp);
 
-    GeoCoord g = {.lat = args.lat,
-                  .lon = args.lon};
+    GeoCoord g = {.lat = args.lat, .lon = args.lon};
     H3Index h = H3_EXPORT(geoToH3)(&g, args.res);
 
     h3Println(h);

--- a/src/apps/fuzzers/fuzzerH3ToGeo.c
+++ b/src/apps/fuzzers/fuzzerH3ToGeo.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief Fuzzer program for h3ToGeo and h3ToGeoBoundary
+ */
+
+#include "h3api.h"
+#include "utility.h"
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        error("Should have one argument (test case file)\n");
+    }
+    const char* filename = argv[1];
+    FILE* fp = fopen(filename, "rb");
+    H3Index index;
+    if (fread(&index, sizeof(H3Index), 1, fp) != 1) {
+        error("Error reading\n");
+    }
+    fclose(fp);
+
+    GeoCoord geo;
+    H3_EXPORT(h3ToGeo)(index, &geo);
+    printf("%lf %lf\n", geo.lat, geo.lon);
+    GeoBoundary geoBoundary;
+    H3_EXPORT(h3ToGeoBoundary)(index, &geoBoundary);
+    printf("%d\n", geoBoundary.numVerts);
+}

--- a/src/apps/fuzzers/fuzzerKRing.c
+++ b/src/apps/fuzzers/fuzzerKRing.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief Fuzzer program for kRing
+ */
+
+#include "h3api.h"
+#include "utility.h"
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        error("Should have one argument (test case file)\n");
+    }
+    const char* filename = argv[1];
+    FILE* fp = fopen(filename, "rb");
+    struct {
+        H3Index index;
+        int k;
+    } args;
+    if (fread(&args, sizeof(args), 1, fp) != 1) {
+        error("Error reading\n");
+    }
+    fclose(fp);
+
+    int sz = H3_EXPORT(maxKringSize)(args.k);
+    H3Index* results = calloc(sizeof(H3Index), sz);
+    if (results != NULL) {
+         H3_EXPORT(kRing)(args.index, args.k, results);
+         h3Println(results[0]);
+    }
+    free(results);
+}

--- a/src/apps/fuzzers/fuzzerKRing.c
+++ b/src/apps/fuzzers/fuzzerKRing.c
@@ -38,8 +38,8 @@ int main(int argc, char* argv[]) {
     int sz = H3_EXPORT(maxKringSize)(args.k);
     H3Index* results = calloc(sizeof(H3Index), sz);
     if (results != NULL) {
-         H3_EXPORT(kRing)(args.index, args.k, results);
-         h3Println(results[0]);
+        H3_EXPORT(kRing)(args.index, args.k, results);
+        h3Println(results[0]);
     }
     free(results);
 }


### PR DESCRIPTION
This pull request adds harness programs for use with the AFL fuzzer in order to detect crashes. At first, tests for `geoToH3`, `h3ToGeo`, `h3ToGeoBoundary`, and `kRing` are added.