### PR TITLE
Naming RFC: drop `Cells` from `gridPath`, `compact`, `uncompact`

### DIFF
--- a/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
+++ b/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
@@ -13,6 +13,7 @@
 - **Discussions**:
     - <https://github.com/uber/h3/pull/308>
     - <https://github.com/uber/h3/pull/403>
+    - <https://github.com/uber/h3/pull/441>
 
 ## Motivation
 

--- a/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
+++ b/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
@@ -140,8 +140,8 @@ There is some ambiguity between property, transform, and computation, so use you
 | `h3GetFaces`                  | `getIcosahedronFaces` |
 | `geoToH3`                     | `pointToCell`         |
 | `h3ToGeo`                     | `cellToPoint`         |
-| `compact`                     | `compactCells`        |
-| `uncompact`                   | `uncompactCells`      |
+| `compact`                     | (unchanged)           |
+| `uncompact`                   | (unchanged)           |
 | `polyfill`                    | `polygonToCells`      |
 
 **Note**: `getResolution` and `getBaseCellNumber` should work for both cells and edges.

--- a/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
+++ b/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
@@ -8,9 +8,11 @@
 - **Dates**:
     - Started: 2020-02-02
     - Accepted: 2020-03-26
+    - Updated: 2021-04-03
 - **Status**: Accepted
 - **Discussions**:
     - <https://github.com/uber/h3/pull/308>
+    - <https://github.com/uber/h3/pull/403>
 
 ## Motivation
 
@@ -173,7 +175,7 @@ We may expose them in the future if a need becomes clear.
 | Current name |      Proposed name      |
 |--------------|-------------------------|
 | `h3Distance` | `gridDistance`          |
-| `h3Line`     | `gridPathCells`         |
+| `h3Line`     | `gridPath`              |
 | *DNE*        | `gridPathEdges`         |
 | *DNE*        | `gridPathDirectedEdges` |
 


### PR DESCRIPTION
The name `gridPathCells` was originally intended to distinguish from future possible names like `gridPathEdges` or `gridPathVertexes`. However, `gridPathCells` is a bit of an awkward name, and we may never actually implement the edge and vertex versions.

Instead, we're proposing just `gridPath`. 

This could extend to a general naming rule: **When an H3 mode is not specified (cell, edge, vertex...), the user should assume the function pertains to Cells.**