### PR TITLE
Add CNAME file

### DIFF
--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+h3geo.org


### PR DESCRIPTION
Attempting to deploy without this causes the website to not just break, but become broken in a way that requires Github support to intervene and reconnect the domain.