### PR TITLE
Add libfuzzer fuzzer for continuous fuzzing

### DIFF
--- a/src/apps/fuzzers/libfuzzer.c
+++ b/src/apps/fuzzers/libfuzzer.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "h3api.h"
+#include "utility.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+        return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    
+    H3Index h3;
+    h3 = H3_EXPORT(stringToH3)(new_str);
+    
+    H3Index input[] = {h3, h3};
+    int inputSize = sizeof(input) / sizeof(H3Index);
+
+    // fuzz compactCells
+    H3Index* compacted = calloc(inputSize, sizeof(H3Index));
+    int err = compactCells(input, compacted, inputSize);
+    
+    // fuzz uncompactCells
+    int compactedCount = 0;
+    for (int i = 0; i < inputSize; i++) {
+        if (compacted[i] != 0) {
+            compactedCount++;
+        }
+    }
+    if(uncompactedSize<10) {
+        int uncompactRes = 10;
+        int uncompactedSize =
+            maxUncompactCellsSize(compacted, inputSize, uncompactRes);
+        
+        H3Index* uncompacted = calloc(uncompactedSize, sizeof(H3Index));
+        int err2 = uncompactCells(compacted, compactedCount, uncompacted,
+                              uncompactedSize, uncompactRes);
+        free(uncompacted);
+    }
+    
+    // fuzz h3NeighborRotations 
+    int rotations = 0;
+    h3NeighborRotations(h3, CENTER_DIGIT, &rotations);
+
+    free(compacted);    
+    free(new_str);
+    return 0;
+}


### PR DESCRIPTION
Hi all, this is [Adam](https://twitter.com/AdamKorcz4) of [AdaLogics](https://adalogics.com/). I work on securing open source software and have worked on setting up continuous fuzzing of h3 through OSS-fuzz.

Since we cannot use the existing AFL fuzzers for the OSS-fuzz integration, I have added a libfuzzer fuzzer in this PR. Once this one is merged, the build on the OSS-fuzz side (https://github.com/google/oss-fuzz/pull/5616) will pass. 

Since each target of h3 in general is pretty small I have added them all in a single fuzzer. For now I recommend following this until it becomes stricly necessary to have more fuzzers, since there is little point in having dedicated fuzzers for 100-200 lines of code in terms of maintenance.

I will be happy to add more targets to the fuzzer. This will become easier once h3 is fuzzed by OSS-fuzz, since OSS-fuzz offers some useful diagnostic tools and coverage reports.

On the OSS-fuzz side a maintainers email address is needed for bug reports.