### PR TITLE
Docs: Update for 4.x in progress for hierarchy, indexing

### DIFF
--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -323,7 +323,7 @@ function example() {
 
 Uncompacts the set `compactedSet` of indexes to the resolution `res`. `cellSet` must be at least of size `maxUncompactSize(compactedSet, numCells, res)`.
 
-## maxuncompactCellsSize
+## maxUncompactCellsSize
 
 <Tabs
   groupId="language"
@@ -338,7 +338,7 @@ Uncompacts the set `compactedSet` of indexes to the resolution `res`. `cellSet` 
 <TabItem value="c">
 
 ```c
-int maxuncompactCellsSize(const H3Index *compactedSet, const int numCells, const int res)
+int maxUncompactCellsSize(const H3Index *compactedSet, const int numCells, const int res)
 ```
 
 </TabItem>

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 These functions permit moving between resolutions in the H3 grid system. The functions produce parent (coarser) or children (finer) cells.
 
-## h3ToParent
+## cellToParent
 
 <Tabs
   groupId="language"
@@ -25,44 +25,44 @@ These functions permit moving between resolutions in the H3 grid system. The fun
 <TabItem value="c">
 
 ```c
-H3Index h3ToParent(H3Index h, int parentRes);
+H3Index cellToParent(H3Index cell, int parentRes);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_to_parent(h, parent_res)
+h3.cell_to_parent(cell, parent_res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long h3ToParent(long h3, int parentRes);
-String h3ToParent(String h3Address, int parentRes);
+long cellToParent(long cell, int parentRes);
+String cellToParent(String cellAddress, int parentRes);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3ToParent(h3Index, parentRes)
+h3.cellToParent(cell, parentRes)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  return h3.h3ToParent(h, 4);
+  const cell = '85283473fffffff';
+  return h3.cellToParent(cell, 4);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Returns the parent (coarser) index containing `h`.
+Returns the parent (coarser) index containing `cell`.
 
-## h3ToChildren
+## cellToChildren
 
 <Tabs
   groupId="language"
@@ -77,44 +77,44 @@ Returns the parent (coarser) index containing `h`.
 <TabItem value="c">
 
 ```c
-void h3ToChildren(H3Index h, int childRes, H3Index *children);
+void cellToChildren(H3Index cell, int childRes, H3Index *children);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_to_children(h, child_res)
+h3.cell_to_children(cell, child_res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> h3ToChildren(long h3, int childRes);
-List<String> h3ToChildren(String h3Address, int childRes);
+List<Long> cellToChildren(long cell, int childRes);
+List<String> cellToChildren(String cellAddress, int childRes);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3ToChildren(h3Index, childRes)
+h3.cellToChildren(cell, childRes)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  return h3.h3ToChildren(h, 6);
+  const cell = '85283473fffffff';
+  return h3.cellToChildren(cell, 6);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Populates `children` with the indexes contained by `h` at resolution `childRes`. `children` must be an array of at least size `maxH3ToChildrenSize(h, childRes)`.
+Populates `children` with the indexes contained by `cell` at resolution `childRes`. `children` must be an array of at least size `maxH3ToChildrenSize(cell, childRes)`.
 
-## maxH3ToChildrenSize
+## maxCellToChildrenSize
 
 <Tabs
   groupId="language"
@@ -129,7 +129,7 @@ Populates `children` with the indexes contained by `h` at resolution `childRes`.
 <TabItem value="c">
 
 ```c
-int maxH3ToChildrenSize(H3Index h, int childRes);
+int maxCellToChildrenSize(H3Index cell, int childRes);
 ```
 
 </TabItem>
@@ -162,9 +162,9 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Returns the parent (coarser) index containing `h`.
+Returns the size of the `children` array needed for the given inputs to `cellToChildren`.
 
-## h3ToCenterChild
+## cellToCenterChild
 
 <Tabs
   groupId="language"
@@ -179,44 +179,44 @@ Returns the parent (coarser) index containing `h`.
 <TabItem value="c">
 
 ```c
-H3Index h3ToCenterChild(H3Index h, int childRes);
+H3Index cellToCenterChild(H3Index cell, int childRes);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_to_center_child(h3, child_res)
+h3.cell_to_center_child(cell, child_res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long h3ToCenterChild(long h3, int childRes);
-String h3ToCenterChild(String h3, int childRes);
+long cellToCenterChild(long cell, int childRes);
+String cellToCenterChild(String cellAddress, int childRes);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3ToCenterChild(h, childRes)
+h3.cellToCenterChild(cell, childRes)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  return h3.h3ToCenterChild(h, 7);
+  const cell = '85283473fffffff';
+  return h3.cellToCenterChild(h, 7);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Returns the center child (finer) index contained by `h` at resolution `childRes`.
+Returns the center child (finer) index contained by `cell` at resolution `childRes`.
 
-## compact
+## compactCells
 
 <Tabs
   groupId="language"
@@ -231,47 +231,45 @@ Returns the center child (finer) index contained by `h` at resolution `childRes`
 <TabItem value="c">
 
 ```c
-int compact(const H3Index *h3Set, H3Index *compactedSet, const int numHexes);
+int compactCells(const H3Index *cellSet, H3Index *compactedSet, const int numCells);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.compact(hexes)
+h3.compact_cells(cells)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> compact(Collection<Long> h3);
-List<String> compactAddress(Collection<String> h3);
+List<Long> compactCells(Collection<Long> cells);
+List<String> compactCellsAddress(Collection<String> cells);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.compact(hexes)
+h3.compactCells(cells)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  const nearby = h3.kRing(h, 4);
-  return h3.compact(nearby);
+  const cell = '85283473fffffff';
+  const nearby = h3.kRing(cell, 4);
+  return h3.compactCells(nearby);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Compacts the set `h3Set` of indexes as best as possible, into the array `compactedSet`. `compactedSet` must be at least the size of `h3Set` in case the set cannot be compacted.
+Compacts the set `cellSet` of indexes as best as possible, into the array `compactedSet`. `compactedSet` must be at least the size of `cellSet` in case the set cannot be compacted.
 
-Returns 0 on success.
-
-## uncompact
+## uncompactCells
 
 <Tabs
   groupId="language"
@@ -286,48 +284,46 @@ Returns 0 on success.
 <TabItem value="c">
 
 ```c
-int uncompact(const H3Index *compactedSet, const int numHexes, H3Index *h3Set, const int maxHexes, const int res);
+int uncompactCells(const H3Index *compactedSet, const int numCells, H3Index *cellSet, const int maxCells, const int res);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.uncompact(hexes, res)
+h3.uncompact_cells(cells, res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> uncompact(Collection<Long> h3, int res);
-List<String> uncompactAddress(Collection<String> h3, int res);
+List<Long> uncompactCells(Collection<Long> cells, int res);
+List<String> uncompactCellsAddress(Collection<String> cells, int res);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.uncompact(hexes, res)
+h3.uncompactCells(cells, res)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  const nearby = h3.kRing(h, 4);
+  const cell = '85283473fffffff';
+  const nearby = h3.kRing(cell, 4);
   const compacted = h3.compact(nearby);
-  return h3.uncompact(compacted, 5);
+  return h3.uncompactCells(compacted, 5);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Uncompacts the set `compactedSet` of indexes to the resolution `res`. `h3Set` must be at least of size `maxUncompactSize(compactedSet, numHexes, res)`.
+Uncompacts the set `compactedSet` of indexes to the resolution `res`. `cellSet` must be at least of size `maxUncompactSize(compactedSet, numCells, res)`.
 
-Returns 0 on success.
-
-## maxUncompactSize
+## maxuncompactCellsSize
 
 <Tabs
   groupId="language"
@@ -342,7 +338,7 @@ Returns 0 on success.
 <TabItem value="c">
 
 ```c
-int maxUncompactSize(const H3Index *compactedSet, const int numHexes, const int res)
+int maxuncompactCellsSize(const H3Index *compactedSet, const int numCells, const int res)
 ```
 
 </TabItem>
@@ -375,4 +371,4 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Returns the size of the array needed by `uncompact`.
+Returns the size of the array needed by `uncompactCells`.

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -64,7 +64,7 @@ function example() {
 
 Indexes the location at the specified resolution, returning the index of the cell containing the location.
 
-Returns 0 on error.
+Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToPoint
 
@@ -118,6 +118,8 @@ function example() {
 
 Finds the centroid of the cell.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 ## cellToBoundary
 
 <Tabs
@@ -169,3 +171,5 @@ function example() {
 </Tabs>
 
 Finds the boundary of the cell.
+
+Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -8,9 +8,9 @@ slug: /api/indexing
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-These function are used for finding the H3 index containing coordinates, and for finding the center and boundary of H3 indexes.
+These function are used for finding the H3 cell index containing coordinates, and for finding the center and boundary of H3 indexes.
 
-## geoToH3
+## pointToCell
 
 <Tabs
   groupId="language"
@@ -25,29 +25,29 @@ These function are used for finding the H3 index containing coordinates, and for
 <TabItem value="c">
 
 ```c
-H3Index geoToH3(const GeoCoord *g, int res);
+H3Error pointToCell(const GeoPoint *g, int res, H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.geo_to_h3(lat, lng, resolution)
+h3.point_to_cell(lat, lng, resolution)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long geoToH3(double lat, double lng, int res);
-String geoToH3Address(double lat, double lng, int res);
+long pointToCell(double lat, double lng, int res);
+String pointToCellAddress(double lat, double lng, int res);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.geoToH3(lat, lng, res)
+h3.pointToCell(lat, lng, res)
 ```
 
 ```js live
@@ -55,7 +55,7 @@ function example() {
   const lat = 45;
   const lng = 40;
   const res = 2;
-  return h3.geoToH3(lat, lng, res);
+  return h3.pointToCell(lat, lng, res);
 }
 ```
 
@@ -66,7 +66,7 @@ Indexes the location at the specified resolution, returning the index of the cel
 
 Returns 0 on error.
 
-## h3ToGeo
+## cellToPoint
 
 <Tabs
   groupId="language"
@@ -81,44 +81,44 @@ Returns 0 on error.
 <TabItem value="c">
 
 ```c
-void h3ToGeo(H3Index h3, GeoCoord *g);
+H3Error cellToPoint(H3Index cell, GeoPoint *g);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_to_geo(h)
+h3.cell_to_point(cell)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-GeoCoord h3ToGeo(long h3);
-GeoCoord h3ToGeo(String h3Address);
+GeoPoint cellToPoint(long cell);
+GeoPoint cellToPoint(String cellAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3ToGeo(h3Index)
+h3.cellToPoint(cell)
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  return h3.h3ToGeo(h);
+  const cell = '85283473fffffff';
+  return h3.cellToPoint(cell);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Finds the centroid of the index.
+Finds the centroid of the cell.
 
-## h3ToGeoBoundary
+## cellToBoundary
 
 <Tabs
   groupId="language"
@@ -133,39 +133,39 @@ Finds the centroid of the index.
 <TabItem value="c">
 
 ```c
-void h3ToGeoBoundary(H3Index h3, GeoBoundary *gp);
+H3Error cellToBoundary(H3Index cell, CellBoundary *bndry);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_to_geo_boundary(h, geo_json=False)
+h3.cell_to_boundary(cell, geo_json=False)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<GeoCoord> h3ToGeoBoundary(long h3);
-List<GeoCoord> h3ToGeoBoundary(String h3Address);
+List<GeoPoint> cellToBoundary(long cell);
+List<GeoPoint> cellToBoundary(String cellAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3ToGeoBoundary(h3Index, [formatAsGeoJson])
+h3.cellToBoundary(cell, [formatAsGeoJson])
 ```
 
 ```js live
 function example() {
-  const h = '85283473fffffff';
-  return h3.h3ToGeoBoundary(h);
+  const cell = '85283473fffffff';
+  return h3.cellToBoundary(cell);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Finds the boundary of the index.
+Finds the boundary of the cell.


### PR DESCRIPTION
Begin updating function docs for v4. Starts with hierarchy and indexing. Note that only indexing has the error codes since that is what's in h3api.h right now.

Note that I'm also changing the argument names in the docs to try to make it a little clearer what an `H3Index` represents. We should be able to do this in h3api.h as well if we want - the argument names are not part of the API for versioning purposes.