### PR TITLE
Swallow some errors from the live code editor, format as JSON

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -97,7 +97,7 @@ module.exports = {
           },
           versions: {
             current: {
-              label: '4.x (in development)'
+              label: '4.x (alpha)'
             },
           },
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -97,7 +97,7 @@ module.exports = {
           },
           versions: {
             current: {
-              label: '4.x'
+              label: '4.x (in development)'
             },
           },
         },

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from "react";
+import { LiveProvider, LiveEditor, LiveError, LiveContext } from "react-live";
+import clsx from "clsx";
+import Translate from "@docusaurus/Translate";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import usePrismTheme from "@theme/hooks/usePrismTheme";
+import styles from "./styles.module.css";
+
+function Header({ children }) {
+  return <div className={clsx(styles.playgroundHeader)}>{children}</div>;
+}
+
+// Modified version to wrap:
+// https://github.com/FormidableLabs/react-live/blob/4ef370647d4e52f8f87148b70c6429237de508cb/src/utils/transpile/errorBoundary.js
+// In order to fix issues with null rendering. Note that this just swallows errors
+// that would have crashed the above.
+class ErrorBoundary2 extends React.Component {
+  componentDidCatch() {
+    // Don't do anything
+  }
+
+  render() {
+    return this.props.children;
+  }
+};
+
+function ResultWithHeader() {
+  return (
+    <>
+      <Header>
+        <Translate
+          id="theme.Playground.result"
+          description="The result label of the live codeblocks"
+        >
+          Result
+        </Translate>
+      </Header>
+      <div className={styles.playgroundPreview}>
+        {/* This div replaces LivePreview */}
+        <LiveContext.Consumer>
+          {({ element: Element }) =>
+            Element ? (
+              <pre>
+                <ErrorBoundary2>
+                  <Element />
+                </ErrorBoundary2>
+              </pre>
+            ) : null
+          }
+        </LiveContext.Consumer>
+        <LiveError />
+      </div>
+    </>
+  );
+}
+
+function EditorWithHeader() {
+  return (
+    <>
+      <Header>
+        <Translate
+          id="theme.Playground.liveEditor"
+          description="The live editor label of the live codeblocks"
+        >
+          Live Editor
+        </Translate>
+      </Header>
+      <LiveEditor className={styles.playgroundEditor} />
+    </>
+  );
+}
+
+export default function Playground({ children, transformCode, ...props }) {
+  const {
+    isClient,
+    siteConfig: {
+      themeConfig: {
+        liveCodeBlock: { playgroundPosition },
+      },
+    },
+  } = useDocusaurusContext();
+  const prismTheme = usePrismTheme();
+
+  return (
+    <div className={styles.playgroundContainer}>
+      <LiveProvider
+        key={isClient}
+        code={isClient ? children.replace(/\n$/, "") : ""}
+        transformCode={
+          transformCode || ((code) => `JSON.stringify(${code}());`)
+        }
+        theme={prismTheme}
+        {...props}
+      >
+        {playgroundPosition === "top" ? (
+          <>
+            <ResultWithHeader />
+            <EditorWithHeader />
+          </>
+        ) : (
+          <>
+            <EditorWithHeader />
+            <ResultWithHeader />
+          </>
+        )}
+      </LiveProvider>
+    </div>
+  );
+}

--- a/website/src/theme/Playground/styles.module.css
+++ b/website/src/theme/Playground/styles.module.css
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.playgroundContainer {
+  margin-bottom: var(--ifm-leading);
+}
+
+.playgroundHeader {
+  letter-spacing: 0.08rem;
+  padding: 0.75rem;
+  text-transform: uppercase;
+  font-weight: bold;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-content);
+  font-size: var(--ifm-code-font-size);
+}
+
+.playgroundHeader:first-of-type {
+  background: var(--ifm-color-emphasis-600);
+  color: var(--ifm-color-content-inverse);
+  border-top-left-radius: var(--ifm-global-radius);
+  border-top-right-radius: var(--ifm-global-radius);
+}
+
+.playgroundEditor {
+  font: var(--ifm-code-font-size) / var(--ifm-pre-line-height)
+    var(--ifm-font-family-monospace) !important;
+  /*rtl:ignore*/
+  direction: ltr;
+}
+
+.playgroundPreview {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  padding: 1rem;
+}
+
+.playgroundPreview:last-of-type, .playgroundEditor:last-of-type {
+  border-bottom-left-radius: var(--ifm-global-radius);
+  border-bottom-right-radius: var(--ifm-global-radius);
+}


### PR DESCRIPTION
Workaround certain crashes in react-live that happen if bad code blocks are passed in.

I did notice that we may have issues supporting live code editor for both 3.x and 4.x on the website at once - perhaps once we switch to 4.x as "live" we will need to disable live code on the old site. I think that would be a fair workaround.