### PR TITLE
Use consistent pointer style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,5 @@
 BasedOnStyle: Google
 IndentWidth: 4
+
+DerivePointerAlignment: false
+PointerAlignment: Right

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ cmake_minimum_required(VERSION 3.1)
 set(H3_PREFIX "" CACHE STRING "Prefix for exported symbols")
 set(H3_ALLOC_PREFIX "" CACHE STRING "Prefix for allocation functions")
 
+# Do not try to append extensions to source files
+cmake_policy(SET CMP0115 NEW)
 # Needed due to CMP0042
 set(CMAKE_MACOSX_RPATH 1)
 # YCM needs compilation database

--- a/examples/compactCells.c
+++ b/examples/compactCells.c
@@ -23,7 +23,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     H3Index input[] = {
         // All with the same parent index
         0x8a2a1072b587fffL, 0x8a2a1072b5b7fffL, 0x8a2a1072b597fffL,
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
     int inputSize = sizeof(input) / sizeof(H3Index);
     printf("Starting with %d indexes.\n", inputSize);
 
-    H3Index* compacted = calloc(inputSize, sizeof(H3Index));
+    H3Index *compacted = calloc(inputSize, sizeof(H3Index));
     H3Error err = compactCells(input, compacted, inputSize);
     // An error case can occur on e.g. duplicate input.
     assert(err == E_SUCCESS);
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
     H3Error err2 = uncompactCellsSize(compacted, inputSize, uncompactRes,
                                       &uncompactedSize);
     assert(err2 == E_SUCCESS);
-    H3Index* uncompacted = calloc(uncompactedSize, sizeof(H3Index));
+    H3Index *uncompacted = calloc(uncompactedSize, sizeof(H3Index));
     int err3 = uncompactCells(compacted, compactedCount, uncompacted,
                               uncompactedSize, uncompactRes);
     // An error case could happen if the output array is too small, or indexes

--- a/examples/neighbors.c
+++ b/examples/neighbors.c
@@ -22,13 +22,13 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     H3Index indexed = 0x8a2a1072b59ffffL;
     // Distance away from the origin to find:
     int k = 2;
 
     int maxNeighboring = maxGridDiskSize(k);
-    H3Index* neighboring = calloc(maxNeighboring, sizeof(H3Index));
+    H3Index *neighboring = calloc(maxNeighboring, sizeof(H3Index));
     gridDisk(indexed, k, neighboring);
 
     printf("Neighbors:\n");

--- a/src/apps/applib/include/args.h
+++ b/src/apps/applib/include/args.h
@@ -38,7 +38,7 @@ typedef struct {
      * Both short and long names of the argument. A name may be null, but the
      * first name must be non-null.
      */
-    const char* const names[NUM_ARG_NAMES];
+    const char *const names[NUM_ARG_NAMES];
 
     /**
      * If true, this argument must be specified. If the argument is not
@@ -50,18 +50,18 @@ typedef struct {
      * Scan format for the argument, which will be passed to sscanf. May be null
      * to indicate the argument does not take a value.
      */
-    const char* const scanFormat;
+    const char *const scanFormat;
 
     /**
      * Name to present the value as when printing help.
      */
-    const char* const valueName;
+    const char *const valueName;
 
     /**
      * Value will be placed here if the argument is present and scanFormat is
      * not null.
      */
-    void* const value;
+    void *const value;
 
     /**
      * Will be set to true if the argument is present. Should be false when
@@ -72,20 +72,20 @@ typedef struct {
     /**
      * Help text for this argument.
      */
-    const char* const helpText;
+    const char *const helpText;
 } Arg;
 
 // prototypes
 
-int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
-              const Arg* helpArg, const char* helpText);
-void printHelp(FILE* out, const char* programName, const char* helpText,
-               int numArgs, Arg* args[], const char* errorMessage,
-               const char* errorDetails);
+int parseArgs(int argc, char *argv[], int numArgs, Arg *args[],
+              const Arg *helpArg, const char *helpText);
+void printHelp(FILE *out, const char *programName, const char *helpText,
+               int numArgs, Arg *args[], const char *errorMessage,
+               const char *errorDetails);
 
-int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
-                   const Arg* helpArg, const char** errorMessage,
-                   const char** errorDetail);
+int _parseArgsList(int argc, char *argv[], int numArgs, Arg *args[],
+                   const Arg *helpArg, const char **errorMessage,
+                   const char **errorDetail);
 
 // common arguments
 

--- a/src/apps/applib/include/benchmark.h
+++ b/src/apps/applib/include/benchmark.h
@@ -67,11 +67,11 @@
 
 #endif
 
-#define BEGIN_BENCHMARKS() int main(int argc, char* argv[]) {
+#define BEGIN_BENCHMARKS() int main(int argc, char *argv[]) {
 #define BENCHMARK(NAME, ITERATIONS, BODY)                                   \
     do {                                                                    \
         const int iterations = ITERATIONS;                                  \
-        const char* name = #NAME;                                           \
+        const char *name = #NAME;                                           \
         START_TIMER;                                                        \
         for (int i = 0; i < iterations; i++) {                              \
             BODY;                                                           \

--- a/src/apps/applib/include/kml.h
+++ b/src/apps/applib/include/kml.h
@@ -23,19 +23,19 @@
 #include "latLng.h"
 
 // output the KML header file for points
-void kmlPtsHeader(const char* name, const char* desc);
-void kmlBoundaryHeader(const char* name, const char* desc);
+void kmlPtsHeader(const char *name, const char *desc);
+void kmlBoundaryHeader(const char *name, const char *desc);
 
 // output the KML footer file
 void kmlPtsFooter(void);
 void kmlBoundaryFooter(void);
 
 // output KML individual points or polygons
-void outputLngLatKML(const LatLng* g);
-void outputPointKML(const LatLng* g, const char* name);
-void outputTriKML(const LatLng* v1, const LatLng* v2, const LatLng* v3,
-                  const char* name);
-void outputPolyKML(const LatLng geoVerts[], int numVerts, const char* name);
-void outputBoundaryKML(const CellBoundary* b, const char* name);
+void outputLngLatKML(const LatLng *g);
+void outputPointKML(const LatLng *g, const char *name);
+void outputTriKML(const LatLng *v1, const LatLng *v2, const LatLng *v3,
+                  const char *name);
+void outputPolyKML(const LatLng geoVerts[], int numVerts, const char *name);
+void outputBoundaryKML(const CellBoundary *b, const char *name);
 
 #endif

--- a/src/apps/applib/include/test.h
+++ b/src/apps/applib/include/test.h
@@ -26,8 +26,8 @@
 #include "latLng.h"
 
 extern int globalTestCount;
-extern const char* currentSuiteName;
-extern const char* currentTestName;
+extern const char *currentSuiteName;
+extern const char *currentTestName;
 
 #define t_assert(condition, msg)                                           \
     do {                                                                   \
@@ -43,7 +43,7 @@ extern const char* currentTestName;
 
 #define t_assertSuccess(condition) t_assert(!(condition), "expected E_SUCCESS")
 
-void t_assertBoundary(H3Index h3, const CellBoundary* b1);
+void t_assertBoundary(H3Index h3, const CellBoundary *b1);
 
 #define SUITE(NAME)                                         \
     static void runTests(void);                             \

--- a/src/apps/applib/include/utility.h
+++ b/src/apps/applib/include/utility.h
@@ -30,24 +30,24 @@
 /** Macro: Get the size of a fixed-size array */
 #define ARRAY_SIZE(x) sizeof(x) / sizeof(x[0])
 
-void error(const char* msg);
+void error(const char *msg);
 void h3Print(H3Index h);    // prints as integer
 void h3Println(H3Index h);  // prints as integer
 
-void coordIjkPrint(const CoordIJK* c);
+void coordIjkPrint(const CoordIJK *c);
 
-void geoToStringRads(const LatLng* p, char* str);
-void geoToStringDegs(const LatLng* p, char* str);
-void geoToStringDegsNoFmt(const LatLng* p, char* str);
+void geoToStringRads(const LatLng *p, char *str);
+void geoToStringDegs(const LatLng *p, char *str);
+void geoToStringDegsNoFmt(const LatLng *p, char *str);
 
-void geoPrint(const LatLng* p);
-void geoPrintln(const LatLng* p);
-void geoPrintNoFmt(const LatLng* p);
-void geoPrintlnNoFmt(const LatLng* p);
-void cellBoundaryPrint(const CellBoundary* b);
-void cellBoundaryPrintln(const CellBoundary* b);
+void geoPrint(const LatLng *p);
+void geoPrintln(const LatLng *p);
+void geoPrintNoFmt(const LatLng *p);
+void geoPrintlnNoFmt(const LatLng *p);
+void cellBoundaryPrint(const CellBoundary *b);
+void cellBoundaryPrintln(const CellBoundary *b);
 
-void randomGeo(LatLng* p);
+void randomGeo(LatLng *p);
 
 void iterateAllIndexesAtRes(int res, void (*callback)(H3Index));
 void iterateAllIndexesAtResPartial(int res, void (*callback)(H3Index),
@@ -56,6 +56,6 @@ void iterateBaseCellIndexesAtRes(int res, void (*callback)(H3Index),
                                  int baseCell);
 void iterateAllDirectedEdgesAtRes(int res, void (*callback)(H3Index));
 
-int countNonNullIndexes(H3Index* indexes, int numCells);
+int countNonNullIndexes(H3Index *indexes, int numCells);
 
 #endif

--- a/src/apps/applib/lib/args.c
+++ b/src/apps/applib/lib/args.c
@@ -60,10 +60,10 @@
  * @return 0 if argument parsing succeeded, otherwise non-0. If help is printed,
  * return value is non-0.
  */
-int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
-              const Arg* helpArg, const char* helpText) {
-    const char* errorMessage = NULL;
-    const char* errorDetails = NULL;
+int parseArgs(int argc, char *argv[], int numArgs, Arg *args[],
+              const Arg *helpArg, const char *helpText) {
+    const char *errorMessage = NULL;
+    const char *errorDetails = NULL;
 
     int failed = _parseArgsList(argc, argv, numArgs, args, helpArg,
                                 &errorMessage, &errorDetails);
@@ -96,9 +96,9 @@ int parseArgs(int argc, char* argv[], int numArgs, Arg* args[],
  * null, and may be a pointer from `argv` or `args`.
  * @return 0 if argument parsing succeeded, otherwise non-0.
  */
-int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
-                   const Arg* helpArg, const char** errorMessage,
-                   const char** errorDetail) {
+int _parseArgsList(int argc, char *argv[], int numArgs, Arg *args[],
+                   const Arg *helpArg, const char **errorMessage,
+                   const char **errorDetail) {
     // Whether help was found and required arguments do not need to be checked
     bool foundHelp = false;
 
@@ -109,7 +109,7 @@ int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
             // Test this argument, which may have multiple names, for whether it
             // matches. argName will be set to the name used for this argument
             // if it matches.
-            const char* argName = NULL;
+            const char *argName = NULL;
             for (int k = 0; k < NUM_ARG_NAMES; k++) {
                 if (args[j]->names[k] == NULL) continue;
 
@@ -185,9 +185,9 @@ int _parseArgsList(int argc, char* argv[], int numArgs, Arg* args[],
  * @param errorMessage Error message, or null
  * @param errorDetails Additional error detail message, or null
  */
-void printHelp(FILE* out, const char* programName, const char* helpText,
-               int numArgs, Arg* args[], const char* errorMessage,
-               const char* errorDetails) {
+void printHelp(FILE *out, const char *programName, const char *helpText,
+               int numArgs, Arg *args[], const char *errorMessage,
+               const char *errorDetails) {
     if (errorMessage != NULL) {
         fprintf(out, "%s: %s", programName, errorMessage);
         if (errorDetails != NULL) {

--- a/src/apps/applib/lib/kml.c
+++ b/src/apps/applib/lib/kml.c
@@ -23,7 +23,7 @@
 
 #include "h3api.h"
 
-void kmlPtsHeader(const char* name, const char* desc) {
+void kmlPtsHeader(const char *name, const char *desc) {
     printf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     printf(
         "<kml xmlns=\"http://www.opengis.net/kml/2.2\" "
@@ -83,7 +83,7 @@ void kmlPtsHeader(const char* name, const char* desc) {
     printf("        </Style>\n");
 }
 
-void kmlBoundaryHeader(const char* name, const char* desc) {
+void kmlBoundaryHeader(const char *name, const char *desc) {
     printf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     printf("<kml xmlns=\"http://earth.google.com/kml/2.1\">\n");
     printf("<Folder>\n");
@@ -107,12 +107,12 @@ void kmlBoundaryFooter(void) {
     printf("</kml>\n");
 }
 
-void outputLngLatKML(const LatLng* g) {
+void outputLngLatKML(const LatLng *g) {
     printf("            %8lf,%8lf,5.0\n", H3_EXPORT(radsToDegs)(g->lng),
            H3_EXPORT(radsToDegs)(g->lat));
 }
 
-void outputPointKML(const LatLng* g, const char* name) {
+void outputPointKML(const LatLng *g, const char *name) {
     printf("<Placemark>\n");
     printf("   <name>%s</name>\n", name);
     printf("   <styleUrl>#m_ylw-pushpin</styleUrl>\n");
@@ -125,8 +125,8 @@ void outputPointKML(const LatLng* g, const char* name) {
     printf("</Placemark>\n");
 }
 
-void outputTriKML(const LatLng* v1, const LatLng* v2, const LatLng* v3,
-                  const char* name) {
+void outputTriKML(const LatLng *v1, const LatLng *v2, const LatLng *v3,
+                  const char *name) {
     printf("<Placemark>\n");
     printf("<name>%s</name>\n", name);
     printf("      <styleUrl>#lineStyle1</styleUrl>\n");
@@ -142,12 +142,12 @@ void outputTriKML(const LatLng* v1, const LatLng* v2, const LatLng* v3,
     printf("</Placemark>\n");
 }
 
-void outputBoundaryKML(const CellBoundary* b, const char* name) {
-    const LatLng* v = (const LatLng*)&(b->verts);
+void outputBoundaryKML(const CellBoundary *b, const char *name) {
+    const LatLng *v = (const LatLng *)&(b->verts);
     outputPolyKML(v, b->numVerts, name);
 }
 
-void outputPolyKML(const LatLng geoVerts[], int numVerts, const char* name) {
+void outputPolyKML(const LatLng geoVerts[], int numVerts, const char *name) {
     printf("<Placemark>\n");
     printf("<name>%s</name>\n", name);
     printf("      <styleUrl>#lineStyle1</styleUrl>\n");

--- a/src/apps/applib/lib/test.c
+++ b/src/apps/applib/lib/test.c
@@ -25,10 +25,10 @@
 // Assert
 
 int globalTestCount = 0;
-const char* currentSuiteName = "";
-const char* currentTestName = "";
+const char *currentSuiteName = "";
+const char *currentTestName = "";
 
-void t_assertBoundary(H3Index h3, const CellBoundary* b1) {
+void t_assertBoundary(H3Index h3, const CellBoundary *b1) {
     // Generate cell boundary for the h3 index
     CellBoundary b2;
     H3_EXPORT(cellToBoundary)(h3, &b2);

--- a/src/apps/applib/lib/utility.c
+++ b/src/apps/applib/lib/utility.c
@@ -29,7 +29,7 @@
 #include "h3Index.h"
 #include "iterators.h"
 
-void error(const char* msg) {
+void error(const char *msg) {
     fflush(stdout);
     fflush(stderr);
     fprintf(stderr, "ERROR: %s.\n", msg);
@@ -49,21 +49,21 @@ void h3Println(H3Index h) { printf("%" PRIx64 "\n", h); }
 /**
  * Prints the CoordIJK
  */
-void coordIjkPrint(const CoordIJK* c) {
+void coordIjkPrint(const CoordIJK *c) {
     printf("[%d, %d, %d]", c->i, c->j, c->k);
 }
 
 /**
  * Assumes `str` is big enough to hold the result.
  */
-void geoToStringRads(const LatLng* p, char* str) {
+void geoToStringRads(const LatLng *p, char *str) {
     sprintf(str, "(%.4lf, %.4lf)", p->lat, p->lng);
 }
 
 /**
  * Assumes `str` is big enough to hold the result.
  */
-void geoToStringDegs(const LatLng* p, char* str) {
+void geoToStringDegs(const LatLng *p, char *str) {
     sprintf(str, "(%.9lf, %.9lf)", H3_EXPORT(radsToDegs)(p->lat),
             H3_EXPORT(radsToDegs)(p->lng));
 }
@@ -71,34 +71,34 @@ void geoToStringDegs(const LatLng* p, char* str) {
 /**
  * Assumes `str` is big enough to hold the result.
  */
-void geoToStringDegsNoFmt(const LatLng* p, char* str) {
+void geoToStringDegsNoFmt(const LatLng *p, char *str) {
     sprintf(str, "%.9lf %.9lf", H3_EXPORT(radsToDegs)(p->lat),
             H3_EXPORT(radsToDegs)(p->lng));
 }
 
-void geoPrint(const LatLng* p) {
+void geoPrint(const LatLng *p) {
     char buff[BUFF_SIZE];
     geoToStringDegs(p, buff);
     printf("%s", buff);
 }
 
-void geoPrintln(const LatLng* p) {
+void geoPrintln(const LatLng *p) {
     geoPrint(p);
     printf("\n");
 }
 
-void geoPrintNoFmt(const LatLng* p) {
+void geoPrintNoFmt(const LatLng *p) {
     char buff[BUFF_SIZE];
     geoToStringDegsNoFmt(p, buff);
     printf("%s", buff);
 }
 
-void geoPrintlnNoFmt(const LatLng* p) {
+void geoPrintlnNoFmt(const LatLng *p) {
     geoPrintNoFmt(p);
     printf("\n");
 }
 
-void cellBoundaryPrint(const CellBoundary* b) {
+void cellBoundaryPrint(const CellBoundary *b) {
     char buff[BUFF_SIZE];
     printf("{");
     for (int v = 0; v < b->numVerts; v++) {
@@ -108,7 +108,7 @@ void cellBoundaryPrint(const CellBoundary* b) {
     printf("}");
 }
 
-void cellBoundaryPrintln(const CellBoundary* b) {
+void cellBoundaryPrintln(const CellBoundary *b) {
     char buff[BUFF_SIZE];
     printf("{\n");
     for (int v = 0; v < b->numVerts; v++) {
@@ -171,7 +171,7 @@ void iterateBaseCellIndexesAtRes(int res, void (*callback)(H3Index),
  *
  * @param g Lat/lng will be placed here.
  */
-void randomGeo(LatLng* g) {
+void randomGeo(LatLng *g) {
     static int init = 0;
     if (!init) {
         srand((unsigned int)time(0));
@@ -186,7 +186,7 @@ void randomGeo(LatLng* g) {
 /**
  * Returns the number of non-invalid indexes in the array.
  */
-int countNonNullIndexes(H3Index* indexes, int numCells) {
+int countNonNullIndexes(H3Index *indexes, int numCells) {
     int nonNullIndexes = 0;
     for (int i = 0; i < numCells; i++) {
         if (indexes[i] != H3_NULL) {

--- a/src/apps/benchmarks/benchmarkGridDiskCells.c
+++ b/src/apps/benchmarks/benchmarkGridDiskCells.c
@@ -23,7 +23,7 @@ H3Index pentagon = 0x89080000003ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index* out = malloc(H3_EXPORT(maxGridDiskSize)(40) * sizeof(H3Index));
+H3Index *out = malloc(H3_EXPORT(maxGridDiskSize)(40) * sizeof(H3Index));
 
 BENCHMARK(gridDisk10, 10000, { H3_EXPORT(gridDisk)(hex, 10, out); });
 BENCHMARK(gridDisk20, 10000, { H3_EXPORT(gridDisk)(hex, 20, out); });

--- a/src/apps/benchmarks/benchmarkGridPathCells.c
+++ b/src/apps/benchmarks/benchmarkGridPathCells.c
@@ -23,7 +23,7 @@ H3Index endFar = 0x8929a5653c3ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index* out =
+H3Index *out =
     calloc(H3_EXPORT(gridPathCellsSize)(startIndex, endFar), sizeof(H3Index));
 
 BENCHMARK(gridPathCellsNear, 10000, {

--- a/src/apps/benchmarks/benchmarkPolygonToCells.c
+++ b/src/apps/benchmarks/benchmarkPolygonToCells.c
@@ -119,7 +119,7 @@ southernGeoLoop.verts = southernVerts;
 southernGeoPolygon.geoloop = southernGeoLoop;
 
 int numHexagons;
-H3Index* hexagons;
+H3Index *hexagons;
 
 BENCHMARK(polygonToCellsSF, 500, {
     numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&sfGeoPolygon, 9);

--- a/src/apps/benchmarks/benchmarkVertex.c
+++ b/src/apps/benchmarks/benchmarkVertex.c
@@ -40,7 +40,7 @@ int ring2PentCount = 16;
 
 BEGIN_BENCHMARKS();
 
-H3Index* vertexes = calloc(6, sizeof(H3Index));
+H3Index *vertexes = calloc(6, sizeof(H3Index));
 
 BENCHMARK(cellToVertexes, 10000, { H3_EXPORT(cellToVertexes)(hex, vertexes); });
 

--- a/src/apps/filters/gridDisk.c
+++ b/src/apps/filters/gridDisk.c
@@ -37,8 +37,8 @@
 
 void doCell(H3Index h, int k, int printDistances) {
     int maxSize = H3_EXPORT(maxGridDiskSize)(k);
-    H3Index* rings = calloc(maxSize, sizeof(H3Index));
-    int* distances = calloc(maxSize, sizeof(int));
+    H3Index *rings = calloc(maxSize, sizeof(H3Index));
+    int *distances = calloc(maxSize, sizeof(int));
     H3_EXPORT(gridDiskDistances)(h, k, rings, distances);
 
     for (int i = 0; i < maxSize; i++) {
@@ -56,7 +56,7 @@ void doCell(H3Index h, int k, int printDistances) {
     free(rings);
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int k = 0;
     H3Index origin = 0;
 
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
         .helpText =
             "Origin, or not specified to read origins from standard input."};
 
-    Arg* args[] = {&helpArg, &kArg, &printDistancesArg, &originArg};
+    Arg *args[] = {&helpArg, &kArg, &printDistancesArg, &originArg};
 
     if (parseArgs(argc, argv, 4, args, &helpArg,
                   "Print indexes k distance away from the origin")) {

--- a/src/apps/filters/gridDiskUnsafe.c
+++ b/src/apps/filters/gridDiskUnsafe.c
@@ -38,7 +38,7 @@
 
 void doCell(H3Index h, int k) {
     int maxSize = H3_EXPORT(maxGridDiskSize)(k);
-    H3Index* rings = calloc(maxSize, sizeof(H3Index));
+    H3Index *rings = calloc(maxSize, sizeof(H3Index));
 
     if (!H3_EXPORT(gridDiskUnsafe)(h, k, rings)) {
         for (int i = 0; i < maxSize; i++) {
@@ -51,7 +51,7 @@ void doCell(H3Index h, int k) {
     free(rings);
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int k = 0;
     H3Index origin = 0;
 
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
         .helpText =
             "Origin, or not specified to read origins from standard input."};
     const int numArgs = 3;
-    Arg* args[] = {&helpArg, &kArg, &originArg};
+    Arg *args[] = {&helpArg, &kArg, &originArg};
 
     if (parseArgs(argc, argv, numArgs, args, &helpArg,
                   "Print indexes k distance away from the origin")) {

--- a/src/apps/filters/h3ToComponents.c
+++ b/src/apps/filters/h3ToComponents.c
@@ -48,7 +48,7 @@ void doCell(H3Index h, bool verboseMode) {
     int h3Res = H3_GET_RESOLUTION(h);
     int h3BaseCell = H3_GET_BASE_CELL(h);
     if (verboseMode) {
-        const char* modes[] = {
+        const char *modes[] = {
             "RESERVED",       // 0
             "Cell",           // 1
             "Directed Edge",  // 2
@@ -102,13 +102,13 @@ void doCell(H3Index h, bool verboseMode) {
     }
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     Arg helpArg = ARG_HELP;
     Arg verboseArg = {.names = {"-v", "--verbose"},
                       .helpText = "Verbose output mode."};
     DEFINE_INDEX_ARG(index, indexArg);
     const int numArgs = 3;
-    Arg* args[] = {&helpArg, &verboseArg, &indexArg};
+    Arg *args[] = {&helpArg, &verboseArg, &indexArg};
 
     if (parseArgs(argc, argv, numArgs, args, &helpArg,
                   "Converts H3 indexes to component parts")) {

--- a/src/apps/filters/h3ToLocalIj.c
+++ b/src/apps/filters/h3ToLocalIj.c
@@ -47,7 +47,7 @@ void doCell(H3Index h, H3Index origin) {
     }
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     H3Index origin = 0;
 
     Arg helpArg = ARG_HELP;
@@ -61,9 +61,9 @@ int main(int argc, char* argv[]) {
             "Origin (anchoring index) for the local coordinate system."};
     DEFINE_INDEX_ARG(index, indexArg);
 
-    Arg* args[] = {&helpArg, &originArg, &indexArg};
+    Arg *args[] = {&helpArg, &originArg, &indexArg};
     const int numArgs = 3;
-    const char* helpText = "Converts H3 indexes to local IJ coordinates";
+    const char *helpText = "Converts H3 indexes to local IJ coordinates";
 
     if (parseArgs(argc, argv, numArgs, args, &helpArg, helpText)) {
         return helpArg.found ? 0 : 1;

--- a/src/apps/filters/latLngToCell.c
+++ b/src/apps/filters/latLngToCell.c
@@ -57,7 +57,7 @@ void doCoords(double lat, double lng, int res) {
     }
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int res = 0;
     double lat = 0;
     double lng = 0;
@@ -82,9 +82,9 @@ int main(int argc, char* argv[]) {
                   .value = &lng,
                   .helpText = "Longitude in degrees."};
 
-    Arg* args[] = {&helpArg, &resArg, &latArg, &lngArg};
+    Arg *args[] = {&helpArg, &resArg, &latArg, &lngArg};
     const int numArgs = 4;
-    const char* helpText =
+    const char *helpText =
         "Convert degrees latitude/longitude coordinates to H3 indexes.";
 
     if (parseArgs(argc, argv, numArgs, args, &helpArg, helpText)) {

--- a/src/apps/fuzzers/fuzzerCellToLatLng.c
+++ b/src/apps/fuzzers/fuzzerCellToLatLng.c
@@ -20,12 +20,12 @@
 #include "h3api.h"
 #include "utility.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     if (argc != 2) {
         error("Should have one argument (test case file)\n");
     }
-    const char* filename = argv[1];
-    FILE* fp = fopen(filename, "rb");
+    const char *filename = argv[1];
+    FILE *fp = fopen(filename, "rb");
     H3Index index;
     if (fread(&index, sizeof(H3Index), 1, fp) != 1) {
         error("Error reading\n");

--- a/src/apps/fuzzers/fuzzerGridDisk.c
+++ b/src/apps/fuzzers/fuzzerGridDisk.c
@@ -20,12 +20,12 @@
 #include "h3api.h"
 #include "utility.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     if (argc != 2) {
         error("Should have one argument (test case file)\n");
     }
-    const char* filename = argv[1];
-    FILE* fp = fopen(filename, "rb");
+    const char *filename = argv[1];
+    FILE *fp = fopen(filename, "rb");
     struct {
         H3Index index;
         int k;
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
     fclose(fp);
 
     int sz = H3_EXPORT(maxGridDiskSize)(args.k);
-    H3Index* results = calloc(sizeof(H3Index), sz);
+    H3Index *results = calloc(sizeof(H3Index), sz);
     if (results != NULL) {
         H3_EXPORT(gridDisk)(args.index, args.k, results);
         h3Println(results[0]);

--- a/src/apps/fuzzers/fuzzerLatLngToCell.c
+++ b/src/apps/fuzzers/fuzzerLatLngToCell.c
@@ -20,12 +20,12 @@
 #include "h3api.h"
 #include "utility.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     if (argc != 2) {
         error("Should have one argument (test case file)\n");
     }
-    const char* filename = argv[1];
-    FILE* fp = fopen(filename, "rb");
+    const char *filename = argv[1];
+    FILE *fp = fopen(filename, "rb");
     struct args {
         double lat;
         double lng;

--- a/src/apps/miscapps/generateBaseCellNeighbors.c
+++ b/src/apps/miscapps/generateBaseCellNeighbors.c
@@ -250,7 +250,7 @@ static void generate() {
     printf("};\n");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/miscapps/generateFaceCenterPoint.c
+++ b/src/apps/miscapps/generateFaceCenterPoint.c
@@ -64,7 +64,7 @@ static void generate() {
     printf("};\n");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/miscapps/generatePentagonDirectionFaces.c
+++ b/src/apps/miscapps/generatePentagonDirectionFaces.c
@@ -56,7 +56,7 @@ static void generate() {
     printf("};\n");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/testapps/mkRandGeo.c
+++ b/src/apps/testapps/mkRandGeo.c
@@ -29,7 +29,7 @@
 #include "args.h"
 #include "utility.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int res = 0;
     int numPoints = 0;
 
@@ -48,9 +48,9 @@ int main(int argc, char* argv[]) {
                   .value = &res,
                   .helpText = "Resolution, 0-15 inclusive."};
 
-    Arg* args[] = {&helpArg, &numPointsArg, &resArg};
+    Arg *args[] = {&helpArg, &numPointsArg, &resArg};
     const int numArgs = 3;
-    const char* helpText =
+    const char *helpText =
         "Generates random lat/lng pairs and indexes them at the specified "
         "resolution.";
 

--- a/src/apps/testapps/mkRandGeoBoundary.c
+++ b/src/apps/testapps/mkRandGeoBoundary.c
@@ -28,7 +28,7 @@
 #include "args.h"
 #include "utility.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int res = 0;
     int numPoints = 0;
 
@@ -47,9 +47,9 @@ int main(int argc, char* argv[]) {
                   .value = &res,
                   .helpText = "Resolution, 0-15 inclusive."};
 
-    Arg* args[] = {&helpArg, &numPointsArg, &resArg};
+    Arg *args[] = {&helpArg, &numPointsArg, &resArg};
     const int numArgs = 3;
-    const char* helpText =
+    const char *helpText =
         "Generates random cell indexes and cell boundaries at the specified "
         "resolution.";
 

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -23,8 +23,8 @@
 #include "polygon.h"
 #include "test.h"
 
-void assertBBox(const GeoLoop* geoloop, const BBox* expected,
-                const LatLng* inside, const LatLng* outside) {
+void assertBBox(const GeoLoop *geoloop, const BBox *expected,
+                const LatLng *inside, const LatLng *outside) {
     BBox result;
 
     bboxFromGeoLoop(geoloop, &result);

--- a/src/apps/testapps/testCellToBoundary.c
+++ b/src/apps/testapps/testCellToBoundary.c
@@ -38,7 +38,7 @@
  * Assumes `f` is open and ready for reading.
  * @return 0 on success, EOF on EOF
  */
-int readBoundary(FILE* f, CellBoundary* b) {
+int readBoundary(FILE *f, CellBoundary *b) {
     char buff[BUFF_SIZE];
 
     // get the first line, which should be a "{"
@@ -92,7 +92,7 @@ int readBoundary(FILE* f, CellBoundary* b) {
     return 0;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/testapps/testCellToLatLng.c
+++ b/src/apps/testapps/testCellToLatLng.c
@@ -33,7 +33,7 @@
 #include "test.h"
 #include "utility.h"
 
-void assertExpected(H3Index h1, const LatLng* g1) {
+void assertExpected(H3Index h1, const LatLng *g1) {
     const double epsilon = 0.000001 * M_PI_180;
     // convert H3 to lat/lng and verify
     LatLng g2;
@@ -49,7 +49,7 @@ void assertExpected(H3Index h1, const LatLng* g1) {
     t_assert(h1 == h2, "got expected latLngToCell output");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -34,10 +34,10 @@ SUITE(compactCells) {
         int expectedCompactCount = 73;
 
         // Generate a set of hexagons to compact
-        H3Index* sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
+        H3Index *sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
         H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded);
 
-        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        H3Index *compressed = calloc(hexCount, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount));
 
@@ -52,7 +52,7 @@ SUITE(compactCells) {
         int64_t countUncompact;
         t_assertSuccess(H3_EXPORT(uncompactCellsSize)(compressed, count, 9,
                                                       &countUncompact));
-        H3Index* decompressed = calloc(countUncompact, sizeof(H3Index));
+        H3Index *decompressed = calloc(countUncompact, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(uncompactCells)(compressed, count,
                                                   decompressed, hexCount, 9));
 
@@ -72,11 +72,11 @@ SUITE(compactCells) {
     TEST(res0) {
         int hexCount = NUM_BASE_CELLS;
 
-        H3Index* res0Hexes = calloc(hexCount, sizeof(H3Index));
+        H3Index *res0Hexes = calloc(hexCount, sizeof(H3Index));
         for (int i = 0; i < hexCount; i++) {
             setH3Index(&res0Hexes[i], 0, i, 0);
         }
-        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        H3Index *compressed = calloc(hexCount, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(compactCells)(res0Hexes, compressed, hexCount));
 
@@ -91,7 +91,7 @@ SUITE(compactCells) {
         int64_t countUncompact;
         t_assertSuccess(H3_EXPORT(uncompactCellsSize)(compressed, hexCount, 0,
                                                       &countUncompact));
-        H3Index* decompressed = calloc(countUncompact, sizeof(H3Index));
+        H3Index *decompressed = calloc(countUncompact, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(uncompactCells)(compressed, hexCount,
                                                   decompressed, hexCount, 0));
 
@@ -112,7 +112,7 @@ SUITE(compactCells) {
         int hexCount = 3;
         int expectedCompactCount = 3;
 
-        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        H3Index *compressed = calloc(hexCount, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(compactCells)(uncompactable, compressed, hexCount));
 
@@ -127,7 +127,7 @@ SUITE(compactCells) {
         int64_t countUncompact;
         t_assertSuccess(H3_EXPORT(uncompactCellsSize)(compressed, count, 9,
                                                       &countUncompact));
-        H3Index* decompressed = calloc(countUncompact, sizeof(H3Index));
+        H3Index *decompressed = calloc(countUncompact, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(uncompactCells)(compressed, count,
                                                   decompressed, hexCount, 9));
 
@@ -164,13 +164,13 @@ SUITE(compactCells) {
         setH3Index(&h3, res, 0, 2);
 
         int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1) + 1;
-        H3Index* children = calloc(arrSize, sizeof(H3Index));
+        H3Index *children = calloc(arrSize, sizeof(H3Index));
 
         H3_EXPORT(cellToChildren)(h3, res + 1, children);
         // duplicate one index
         children[arrSize - 1] = children[0];
 
-        H3Index* output = calloc(arrSize, sizeof(H3Index));
+        H3Index *output = calloc(arrSize, sizeof(H3Index));
 
         H3Error compactCellsResult =
             H3_EXPORT(compactCells)(children, output, arrSize);
@@ -189,13 +189,13 @@ SUITE(compactCells) {
         setH3Index(&h3, res, 4, 0);
 
         int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1) + 1;
-        H3Index* children = calloc(arrSize, sizeof(H3Index));
+        H3Index *children = calloc(arrSize, sizeof(H3Index));
 
         H3_EXPORT(cellToChildren)(h3, res + 1, children);
         // duplicate one index
         children[arrSize - 1] = H3_EXPORT(cellToCenterChild)(h3, res + 1);
 
-        H3Index* output = calloc(arrSize, sizeof(H3Index));
+        H3Index *output = calloc(arrSize, sizeof(H3Index));
 
         H3Error compactCellsResult =
             H3_EXPORT(compactCells)(children, output, arrSize);
@@ -216,13 +216,13 @@ SUITE(compactCells) {
         setH3Index(&h3, res, 0, 2);
 
         int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1);
-        H3Index* children = calloc(arrSize, sizeof(H3Index));
+        H3Index *children = calloc(arrSize, sizeof(H3Index));
 
         H3_EXPORT(cellToChildren)(h3, res + 1, children);
         // duplicate one index
         children[arrSize - 1] = children[0];
 
-        H3Index* output = calloc(arrSize, sizeof(H3Index));
+        H3Index *output = calloc(arrSize, sizeof(H3Index));
 
         t_assertSuccess(H3_EXPORT(compactCells)(children, output, arrSize));
 
@@ -306,11 +306,11 @@ SUITE(compactCells) {
         int64_t childrenSz;
         t_assertSuccess(
             H3_EXPORT(uncompactCellsSize)(&origin, 1, 2, &childrenSz));
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        H3Index *children = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(uncompactCells)(&origin, 1, children, childrenSz, 2));
 
-        H3Index* result = calloc(childrenSz, sizeof(H3Index));
+        H3Index *result = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(compactCells)(children, result, childrenSz));
 
         int found = 0;
@@ -345,7 +345,7 @@ SUITE(compactCells) {
         int64_t childrenSz;
         t_assertSuccess(
             H3_EXPORT(uncompactCellsSize)(&origin, 1, 2, &childrenSz));
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        H3Index *children = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(uncompactCells)(&origin, 1, children, childrenSz, 2));
 
@@ -359,7 +359,7 @@ SUITE(compactCells) {
         int64_t childrenSz;
         t_assertSuccess(H3_EXPORT(uncompactCellsSize)(uncompactableWithZero, 4,
                                                       10, &childrenSz));
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        H3Index *children = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(uncompactCells)(uncompactableWithZero, 4,
                                                   children, childrenSz, 10));
 
@@ -382,11 +382,11 @@ SUITE(compactCells) {
         int64_t childrenSz;
         t_assertSuccess(
             H3_EXPORT(uncompactCellsSize)(&pentagon, 1, 2, &childrenSz));
-        H3Index* children = calloc(childrenSz, sizeof(H3Index));
+        H3Index *children = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(uncompactCells)(&pentagon, 1, children, childrenSz, 2));
 
-        H3Index* result = calloc(childrenSz, sizeof(H3Index));
+        H3Index *result = calloc(childrenSz, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(compactCells)(children, result, childrenSz));
 
         int found = 0;

--- a/src/apps/testapps/testGridDisksUnsafe.c
+++ b/src/apps/testapps/testGridDisksUnsafe.c
@@ -23,7 +23,7 @@ SUITE(gridDisksUnsafe) {
     LatLng sf = {0.659966917655, 2 * 3.14159 - 2.1364398519396};
     H3Index sfHex;
     t_assertSuccess(H3_EXPORT(latLngToCell)(&sf, 9, &sfHex));
-    H3Index* sfHexPtr = &sfHex;
+    H3Index *sfHexPtr = &sfHex;
 
     H3Index k1[] = {0x89283080ddbffff, 0x89283080c37ffff, 0x89283080c27ffff,
                     0x89283080d53ffff, 0x89283080dcfffff, 0x89283080dc3ffff};
@@ -61,7 +61,7 @@ SUITE(gridDisksUnsafe) {
 
     TEST(ring2of1) {
         int err;
-        H3Index* allKrings2 = calloc(6 * (1 + 6 + 12), sizeof(H3Index));
+        H3Index *allKrings2 = calloc(6 * (1 + 6 + 12), sizeof(H3Index));
         err = H3_EXPORT(gridDisksUnsafe)(k1, 6, 2, allKrings2);
 
         t_assert(err == 0, "No error on gridDisksUnsafe");
@@ -80,7 +80,7 @@ SUITE(gridDisksUnsafe) {
 
     TEST(failed) {
         int err;
-        H3Index* allKrings = calloc(2 * (1 + 6), sizeof(H3Index));
+        H3Index *allKrings = calloc(2 * (1 + 6), sizeof(H3Index));
         err = H3_EXPORT(gridDisksUnsafe)(withPentagon, 2, 1, allKrings);
 
         t_assert(err != 0, "Expected error on gridDisksUnsafe");

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -55,7 +55,7 @@ SUITE(h3Api) {
 
     TEST(cellToBoundary_classIIIEdgeVertex) {
         // Bug test for https://github.com/uber/h3/issues/45
-        char* hexes[] = {
+        char *hexes[] = {
             "894cc5349b7ffff", "894cc534d97ffff", "894cc53682bffff",
             "894cc536b17ffff", "894cc53688bffff", "894cead92cbffff",
             "894cc536537ffff", "894cc5acbabffff", "894cc536597ffff"};

--- a/src/apps/testapps/testH3Memory.c
+++ b/src/apps/testapps/testH3Memory.c
@@ -44,7 +44,7 @@ void resetMemoryCounters(int permitted) {
     permittedAllocCalls = permitted;
 }
 
-void* test_prefix_malloc(size_t size) {
+void *test_prefix_malloc(size_t size) {
     actualAllocCalls++;
     if (permittedAllocCalls && actualAllocCalls > permittedAllocCalls) {
         failAlloc = true;
@@ -55,7 +55,7 @@ void* test_prefix_malloc(size_t size) {
     return malloc(size);
 }
 
-void* test_prefix_calloc(size_t num, size_t size) {
+void *test_prefix_calloc(size_t num, size_t size) {
     actualAllocCalls++;
     if (permittedAllocCalls && actualAllocCalls > permittedAllocCalls) {
         failAlloc = true;
@@ -66,7 +66,7 @@ void* test_prefix_calloc(size_t num, size_t size) {
     return calloc(num, size);
 }
 
-void* test_prefix_realloc(void* ptr, size_t size) {
+void *test_prefix_realloc(void *ptr, size_t size) {
     actualAllocCalls++;
     if (permittedAllocCalls && actualAllocCalls > permittedAllocCalls) {
         failAlloc = true;
@@ -77,7 +77,7 @@ void* test_prefix_realloc(void* ptr, size_t size) {
     return realloc(ptr, size);
 }
 
-void test_prefix_free(void* ptr) {
+void test_prefix_free(void *ptr) {
     actualFreeCalls++;
     return free(ptr);
 }
@@ -89,7 +89,7 @@ SUITE(h3Memory) {
     TEST(gridDisk) {
         int k = 2;
         int hexCount = H3_EXPORT(maxGridDiskSize)(k);
-        H3Index* gridDiskOutput = calloc(hexCount, sizeof(H3Index));
+        H3Index *gridDiskOutput = calloc(hexCount, sizeof(H3Index));
 
         resetMemoryCounters(0);
         H3_EXPORT(gridDisk)(sunnyvale, k, gridDiskOutput);
@@ -122,13 +122,13 @@ SUITE(h3Memory) {
         int expectedCompactCount = 73;
 
         // Generate a set of hexagons to compact
-        H3Index* sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
+        H3Index *sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
         resetMemoryCounters(0);
         H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded);
         t_assert(actualAllocCalls == 0, "gridDisk did not call alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 
-        H3Index* compressed = calloc(hexCount, sizeof(H3Index));
+        H3Index *compressed = calloc(hexCount, sizeof(H3Index));
 
         resetMemoryCounters(0);
         failAlloc = true;

--- a/src/apps/testapps/testH3NeighborRotations.c
+++ b/src/apps/testapps/testH3NeighborRotations.c
@@ -48,12 +48,12 @@ typedef struct {
     int ret2;
 } TestOutput;
 
-void doCell(H3Index h, int maxK, TestOutput* testOutput) {
+void doCell(H3Index h, int maxK, TestOutput *testOutput) {
     for (int k = 0; k < maxK; k++) {
         int maxSz = H3_EXPORT(maxGridDiskSize)(k);
-        H3Index* gridDiskInternalOutput = calloc(sizeof(H3Index), maxSz);
-        H3Index* gridDiskUnsafeOutput = calloc(sizeof(H3Index), maxSz);
-        int* gridDiskInternalDistances = calloc(sizeof(int), maxSz);
+        H3Index *gridDiskInternalOutput = calloc(sizeof(H3Index), maxSz);
+        H3Index *gridDiskUnsafeOutput = calloc(sizeof(H3Index), maxSz);
+        int *gridDiskInternalDistances = calloc(sizeof(int), maxSz);
 
         H3_EXPORT(gridDiskDistancesSafe)
         (h, k, gridDiskInternalOutput, gridDiskInternalDistances);
@@ -121,7 +121,7 @@ void doCell(H3Index h, int maxK, TestOutput* testOutput) {
 }
 
 void recursiveH3IndexToGeo(H3Index h, int res, int maxK,
-                           TestOutput* testOutput) {
+                           TestOutput *testOutput) {
     for (int d = 0; d < 7; d++) {
         H3_SET_INDEX_DIGIT(h, res, d);
 
@@ -140,7 +140,7 @@ void recursiveH3IndexToGeo(H3Index h, int res, int maxK,
     }
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc != 2 && argc != 3) {
         fprintf(stderr, "usage: %s resolution [maxK]\n", argv[0]);

--- a/src/apps/testapps/testLatLng.c
+++ b/src/apps/testapps/testLatLng.c
@@ -36,7 +36,7 @@
  * @param message
  */
 static void testDecreasingFunction(double (*function)(int),
-                                   const char* message) {
+                                   const char *message) {
     double last = 0;
     double next;
     for (int i = MAX_H3_RES; i >= 0; i--) {

--- a/src/apps/testapps/testLatLngToCell.c
+++ b/src/apps/testapps/testLatLngToCell.c
@@ -32,7 +32,7 @@
 #include "test.h"
 #include "utility.h"
 
-static void assertExpected(H3Index h1, const LatLng* g1) {
+static void assertExpected(H3Index h1, const LatLng *g1) {
     // convert lat/lng to H3 and verify
     int res = H3_EXPORT(getResolution)(h1);
     H3Index h2;
@@ -40,7 +40,7 @@ static void assertExpected(H3Index h1, const LatLng* g1) {
     t_assert(h1 == h2, "got expected latLngToCell output");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     // check command line args
     if (argc > 1) {
         fprintf(stderr, "usage: %s\n", argv[0]);

--- a/src/apps/testapps/testLinkedGeo.c
+++ b/src/apps/testapps/testLinkedGeo.c
@@ -35,9 +35,9 @@ SUITE(linkedGeo) {
     setGeoDegs(&vertex4, 87.369975080, 166.233115768);
 
     TEST(createLinkedGeo) {
-        LinkedGeoPolygon* polygon = calloc(1, sizeof(LinkedGeoPolygon));
-        LinkedGeoLoop* loop;
-        LinkedLatLng* coord;
+        LinkedGeoPolygon *polygon = calloc(1, sizeof(LinkedGeoPolygon));
+        LinkedGeoLoop *loop;
+        LinkedLatLng *coord;
 
         loop = addNewLinkedLoop(polygon);
         t_assert(loop != NULL, "Loop created");
@@ -62,7 +62,7 @@ SUITE(linkedGeo) {
         t_assert(countLinkedCoords(polygon->last) == 2,
                  "Coord count 2 correct");
 
-        LinkedGeoPolygon* nextPolygon = addNewLinkedPolygon(polygon);
+        LinkedGeoPolygon *nextPolygon = addNewLinkedPolygon(polygon);
         t_assert(nextPolygon != NULL, "polygon created");
 
         t_assert(countLinkedPolygons(polygon) == 2, "Polygon count correct");

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -31,7 +31,7 @@ static LatLng sfVerts[] = {
     {0.6583348114025, -2.1354884206045}, {0.6581220034068, -2.1382437718946},
     {0.6594479998527, -2.1384597563896}, {0.6599990002976, -2.1376771158464}};
 
-static void createLinkedLoop(LinkedGeoLoop* loop, LatLng* verts, int numVerts) {
+static void createLinkedLoop(LinkedGeoLoop *loop, LatLng *verts, int numVerts) {
     *loop = (LinkedGeoLoop){0};
     for (int i = 0; i < numVerts; i++) {
         addLinkedCoord(loop, verts++);
@@ -150,7 +150,7 @@ SUITE(polygon) {
 
         const BBox expected = {1.1, 0.7, 0.7, 0.2};
 
-        BBox* result = calloc(sizeof(BBox), 1);
+        BBox *result = calloc(sizeof(BBox), 1);
         bboxesFromGeoPolygon(&polygon, result);
         t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
 
@@ -171,7 +171,7 @@ SUITE(polygon) {
         const BBox expected = {1.1, 0.7, 0.7, 0.2};
         const BBox expectedHole = {1.0, 0.9, 0.7, 0.3};
 
-        BBox* result = calloc(sizeof(BBox), 2);
+        BBox *result = calloc(sizeof(BBox), 2);
         bboxesFromGeoPolygon(&polygon, result);
         t_assert(bboxEquals(&result[0], &expected), "Got expected bbox");
         t_assert(bboxEquals(&result[1], &expectedHole),
@@ -280,7 +280,7 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonSingle) {
         LatLng verts[] = {{0, 0}, {0, 1}, {1, 1}};
 
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 3);
 
@@ -301,13 +301,13 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonTwoOuterLoops) {
         LatLng verts1[] = {{0, 0}, {0, 1}, {1, 1}};
 
-        LinkedGeoLoop* outer1 = malloc(sizeof(*outer1));
+        LinkedGeoLoop *outer1 = malloc(sizeof(*outer1));
         assert(outer1 != NULL);
         createLinkedLoop(outer1, &verts1[0], 3);
 
         LatLng verts2[] = {{2, 2}, {2, 3}, {3, 3}};
 
-        LinkedGeoLoop* outer2 = malloc(sizeof(*outer2));
+        LinkedGeoLoop *outer2 = malloc(sizeof(*outer2));
         assert(outer2 != NULL);
         createLinkedLoop(outer2, &verts2[0], 3);
 
@@ -331,13 +331,13 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonOneHole) {
         LatLng verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
 
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 4);
 
         LatLng verts2[] = {{1, 1}, {2, 2}, {1, 2}};
 
-        LinkedGeoLoop* inner = malloc(sizeof(*inner));
+        LinkedGeoLoop *inner = malloc(sizeof(*inner));
         assert(inner != NULL);
         createLinkedLoop(inner, &verts2[0], 3);
 
@@ -361,19 +361,19 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonTwoHoles) {
         LatLng verts[] = {{0, 0}, {0, 0.4}, {0.4, 0.4}, {0.4, 0}};
 
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 4);
 
         LatLng verts2[] = {{0.1, 0.1}, {0.2, 0.2}, {0.1, 0.2}};
 
-        LinkedGeoLoop* inner1 = malloc(sizeof(*inner1));
+        LinkedGeoLoop *inner1 = malloc(sizeof(*inner1));
         assert(inner1 != NULL);
         createLinkedLoop(inner1, &verts2[0], 3);
 
         LatLng verts3[] = {{0.2, 0.2}, {0.3, 0.3}, {0.2, 0.3}};
 
-        LinkedGeoLoop* inner2 = malloc(sizeof(*inner2));
+        LinkedGeoLoop *inner2 = malloc(sizeof(*inner2));
         assert(inner2 != NULL);
         createLinkedLoop(inner2, &verts3[0], 3);
 
@@ -397,22 +397,22 @@ SUITE(polygon) {
 
     TEST(normalizeMultiPolygonTwoDonuts) {
         LatLng verts[] = {{0, 0}, {0, 3}, {3, 3}, {3, 0}};
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 4);
 
         LatLng verts2[] = {{1, 1}, {2, 2}, {1, 2}};
-        LinkedGeoLoop* inner = malloc(sizeof(*inner));
+        LinkedGeoLoop *inner = malloc(sizeof(*inner));
         assert(inner != NULL);
         createLinkedLoop(inner, &verts2[0], 3);
 
         LatLng verts3[] = {{0, 0}, {0, -3}, {-3, -3}, {-3, 0}};
-        LinkedGeoLoop* outer2 = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer2 = malloc(sizeof(*outer));
         assert(outer2 != NULL);
         createLinkedLoop(outer2, &verts3[0], 4);
 
         LatLng verts4[] = {{-1, -1}, {-2, -2}, {-1, -2}};
-        LinkedGeoLoop* inner2 = malloc(sizeof(*inner));
+        LinkedGeoLoop *inner2 = malloc(sizeof(*inner));
         assert(inner2 != NULL);
         createLinkedLoop(inner2, &verts4[0], 3);
 
@@ -445,22 +445,22 @@ SUITE(polygon) {
 
     TEST(normalizeMultiPolygonNestedDonuts) {
         LatLng verts[] = {{0.2, 0.2}, {0.2, -0.2}, {-0.2, -0.2}, {-0.2, 0.2}};
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 4);
 
         LatLng verts2[] = {{0.1, 0.1}, {-0.1, 0.1}, {-0.1, -0.1}, {0.1, -0.1}};
-        LinkedGeoLoop* inner = malloc(sizeof(*inner));
+        LinkedGeoLoop *inner = malloc(sizeof(*inner));
         assert(inner != NULL);
         createLinkedLoop(inner, &verts2[0], 4);
 
         LatLng verts3[] = {{0.6, 0.6}, {0.6, -0.6}, {-0.6, -0.6}, {-0.6, 0.6}};
-        LinkedGeoLoop* outerBig = malloc(sizeof(*outerBig));
+        LinkedGeoLoop *outerBig = malloc(sizeof(*outerBig));
         assert(outerBig != NULL);
         createLinkedLoop(outerBig, &verts3[0], 4);
 
         LatLng verts4[] = {{0.5, 0.5}, {-0.5, 0.5}, {-0.5, -0.5}, {0.5, -0.5}};
-        LinkedGeoLoop* innerBig = malloc(sizeof(*innerBig));
+        LinkedGeoLoop *innerBig = malloc(sizeof(*innerBig));
         assert(innerBig != NULL);
         createLinkedLoop(innerBig, &verts4[0], 4);
 
@@ -490,13 +490,13 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonNoOuterLoops) {
         LatLng verts1[] = {{0, 0}, {1, 1}, {0, 1}};
 
-        LinkedGeoLoop* outer1 = malloc(sizeof(*outer1));
+        LinkedGeoLoop *outer1 = malloc(sizeof(*outer1));
         assert(outer1 != NULL);
         createLinkedLoop(outer1, &verts1[0], 3);
 
         LatLng verts2[] = {{2, 2}, {3, 3}, {2, 3}};
 
-        LinkedGeoLoop* outer2 = malloc(sizeof(*outer2));
+        LinkedGeoLoop *outer2 = malloc(sizeof(*outer2));
         assert(outer2 != NULL);
         createLinkedLoop(outer2, &verts2[0], 3);
 
@@ -519,19 +519,19 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygonAlreadyNormalized) {
         LatLng verts1[] = {{0, 0}, {0, 1}, {1, 1}};
 
-        LinkedGeoLoop* outer1 = malloc(sizeof(*outer1));
+        LinkedGeoLoop *outer1 = malloc(sizeof(*outer1));
         assert(outer1 != NULL);
         createLinkedLoop(outer1, &verts1[0], 3);
 
         LatLng verts2[] = {{2, 2}, {2, 3}, {3, 3}};
 
-        LinkedGeoLoop* outer2 = malloc(sizeof(*outer2));
+        LinkedGeoLoop *outer2 = malloc(sizeof(*outer2));
         assert(outer2 != NULL);
         createLinkedLoop(outer2, &verts2[0], 3);
 
         LinkedGeoPolygon polygon = {0};
         addLinkedLoop(&polygon, outer1);
-        LinkedGeoPolygon* next = addNewLinkedPolygon(&polygon);
+        LinkedGeoPolygon *next = addNewLinkedPolygon(&polygon);
         addLinkedLoop(next, outer2);
 
         // Should be a no-op
@@ -554,13 +554,13 @@ SUITE(polygon) {
     TEST(normalizeMultiPolygon_unassignedHole) {
         LatLng verts[] = {{0, 0}, {0, 1}, {1, 1}, {1, 0}};
 
-        LinkedGeoLoop* outer = malloc(sizeof(*outer));
+        LinkedGeoLoop *outer = malloc(sizeof(*outer));
         assert(outer != NULL);
         createLinkedLoop(outer, &verts[0], 4);
 
         LatLng verts2[] = {{2, 2}, {3, 3}, {2, 3}};
 
-        LinkedGeoLoop* inner = malloc(sizeof(*inner));
+        LinkedGeoLoop *inner = malloc(sizeof(*inner));
         assert(inner != NULL);
         createLinkedLoop(inner, &verts2[0], 3);
 

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -77,7 +77,7 @@ static void fillIndex_assertions(H3Index h) {
 
         int polygonToCellsSize =
             H3_EXPORT(maxPolygonToCellsSize)(&polygon, nextRes);
-        H3Index* polygonToCellsOut =
+        H3Index *polygonToCellsOut =
             calloc(polygonToCellsSize, sizeof(H3Index));
         H3_EXPORT(polygonToCells)(&polygon, nextRes, polygonToCellsOut);
 
@@ -85,7 +85,7 @@ static void fillIndex_assertions(H3Index h) {
             countNonNullIndexes(polygonToCellsOut, polygonToCellsSize);
 
         int64_t childrenSize = H3_EXPORT(cellToChildrenSize)(h, nextRes);
-        H3Index* children = calloc(childrenSize, sizeof(H3Index));
+        H3Index *children = calloc(childrenSize, sizeof(H3Index));
         H3_EXPORT(cellToChildren)(h, nextRes, children);
 
         int cellToChildrenCount = countNonNullIndexes(children, childrenSize);
@@ -138,7 +138,7 @@ SUITE(polygonToCells) {
 
     TEST(polygonToCells) {
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&sfGeoPolygon, 9);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&sfGeoPolygon, 9, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -149,7 +149,7 @@ SUITE(polygonToCells) {
 
     TEST(polygonToCellsHole) {
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&holeGeoPolygon, 9);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&holeGeoPolygon, 9, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -161,7 +161,7 @@ SUITE(polygonToCells) {
 
     TEST(polygonToCellsEmpty) {
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&emptyGeoPolygon, 9);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&emptyGeoPolygon, 9, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -178,7 +178,7 @@ SUITE(polygonToCells) {
         CellBoundary boundary;
         H3_EXPORT(cellToBoundary)(origin, &boundary);
 
-        LatLng* verts = calloc(boundary.numVerts + 1, sizeof(LatLng));
+        LatLng *verts = calloc(boundary.numVerts + 1, sizeof(LatLng));
         for (int i = 0; i < boundary.numVerts; i++) {
             verts[i] = boundary.verts[i];
         }
@@ -192,7 +192,7 @@ SUITE(polygonToCells) {
         someHexagon.numHoles = 0;
 
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&someHexagon, 9);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&someHexagon, 9, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -238,7 +238,7 @@ SUITE(polygonToCells) {
         expectedSize = 4228;
         int numHexagons =
             H3_EXPORT(maxPolygonToCellsSize)(&primeMeridianGeoPolygon, 7);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&primeMeridianGeoPolygon, 7, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -252,7 +252,7 @@ SUITE(polygonToCells) {
         expectedSize = 4238;
         numHexagons =
             H3_EXPORT(maxPolygonToCellsSize)(&transMeridianGeoPolygon, 7);
-        H3Index* hexagonsTM = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagonsTM = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&transMeridianGeoPolygon, 7, hexagonsTM);
         actualNumIndexes = countNonNullIndexes(hexagonsTM, numHexagons);
@@ -264,7 +264,7 @@ SUITE(polygonToCells) {
         // size
         numHexagons = H3_EXPORT(maxPolygonToCellsSize)(
             &transMeridianFilledHoleGeoPolygon, 7);
-        H3Index* hexagonsTMFH = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagonsTMFH = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)
         (&transMeridianFilledHoleGeoPolygon, 7, hexagonsTMFH);
@@ -274,7 +274,7 @@ SUITE(polygonToCells) {
         // Transmeridian hole case
         numHexagons =
             H3_EXPORT(maxPolygonToCellsSize)(&transMeridianHoleGeoPolygon, 7);
-        H3Index* hexagonsTMH = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagonsTMH = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&transMeridianHoleGeoPolygon, 7, hexagonsTMH);
         actualNumIndexes = countNonNullIndexes(hexagonsTMH, numHexagons);
@@ -300,7 +300,7 @@ SUITE(polygonToCells) {
 
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&polygon, 4);
 
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
         H3_EXPORT(polygonToCells)(&polygon, 4, hexagons);
 
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -348,7 +348,7 @@ SUITE(polygonToCells) {
         polygon.numHoles = 0;
 
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&polygon, 9);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&polygon, 9, hexagons);
 

--- a/src/apps/testapps/testPolygonToCellsReported.c
+++ b/src/apps/testapps/testPolygonToCellsReported.c
@@ -41,7 +41,7 @@ SUITE(polygonToCells_reported) {
         for (int res = 0; res < 3; res++) {
             int polygonToCellsSize =
                 H3_EXPORT(maxPolygonToCellsSize)(&worldGeoPolygon, res);
-            H3Index* polygonToCellsOut =
+            H3Index *polygonToCellsOut =
                 calloc(polygonToCellsSize, sizeof(H3Index));
 
             H3_EXPORT(polygonToCells)(&worldGeoPolygon, res, polygonToCellsOut);
@@ -50,7 +50,7 @@ SUITE(polygonToCells_reported) {
 
             int polygonToCellsSize2 =
                 H3_EXPORT(maxPolygonToCellsSize)(&worldGeoPolygon2, res);
-            H3Index* polygonToCellsOut2 =
+            H3Index *polygonToCellsOut2 =
                 calloc(polygonToCellsSize2, sizeof(H3Index));
 
             H3_EXPORT(polygonToCells)
@@ -100,7 +100,7 @@ SUITE(polygonToCells_reported) {
 
         int res = 7;
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&testPolygon, res);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&testPolygon, res, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -126,7 +126,7 @@ SUITE(polygonToCells_reported) {
 
         int res = 7;
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&testPolygon, res);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&testPolygon, res, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
@@ -149,7 +149,7 @@ SUITE(polygonToCells_reported) {
 
         int res = 13;
         int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(&testPolygon, res);
-        H3Index* hexagons = calloc(numHexagons, sizeof(H3Index));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
         H3_EXPORT(polygonToCells)(&testPolygon, res, hexagons);
         int actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);

--- a/src/apps/testapps/testVertexGraph.c
+++ b/src/apps/testapps/testVertexGraph.c
@@ -79,8 +79,8 @@ SUITE(vertexGraph) {
     TEST(addVertexNode) {
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
-        VertexNode* addedNode;
+        VertexNode *node;
+        VertexNode *addedNode;
 
         // Basic add
         addedNode = addVertexNode(&graph, &vertex1, &vertex2);
@@ -117,8 +117,8 @@ SUITE(vertexGraph) {
     TEST(addVertexNodeDupe) {
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
-        VertexNode* addedNode;
+        VertexNode *node;
+        VertexNode *addedNode;
 
         // Basic add
         addedNode = addVertexNode(&graph, &vertex1, &vertex2);
@@ -139,7 +139,7 @@ SUITE(vertexGraph) {
         // Basic lookup tested in testAddVertexNode, only test failures here
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
+        VertexNode *node;
 
         // Empty graph
         node = findNodeForEdge(&graph, &vertex1, &vertex2);
@@ -170,7 +170,7 @@ SUITE(vertexGraph) {
     TEST(findNodeForVertex) {
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
+        VertexNode *node;
 
         // Empty graph
         node = findNodeForVertex(&graph, &vertex1);
@@ -191,7 +191,7 @@ SUITE(vertexGraph) {
     TEST(removeVertexNode) {
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
+        VertexNode *node;
         int success;
 
         // Straight removal
@@ -265,8 +265,8 @@ SUITE(vertexGraph) {
     TEST(firstVertexNode) {
         VertexGraph graph;
         initVertexGraph(&graph, 10, 9);
-        VertexNode* node;
-        VertexNode* addedNode;
+        VertexNode *node;
+        VertexNode *addedNode;
 
         node = firstVertexNode(&graph);
         t_assert(node == NULL, "No node found for empty graph");
@@ -288,7 +288,7 @@ SUITE(vertexGraph) {
     TEST(singleBucketVertexGraph) {
         VertexGraph graph;
         initVertexGraph(&graph, 1, 9);
-        VertexNode* node;
+        VertexNode *node;
 
         t_assert(graph.numBuckets == 1, "1 bucket created");
 

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -27,32 +27,32 @@
 #include "vertexGraph.h"
 
 // neighbor along the ijk coordinate system of the current face, rotated
-H3Index h3NeighborRotations(H3Index origin, Direction dir, int* rotations);
+H3Index h3NeighborRotations(H3Index origin, Direction dir, int *rotations);
 
 // IJK direction of neighbor
 Direction directionForNeighbor(H3Index origin, H3Index destination);
 
 // k-ring implementation
-void _kRingInternal(H3Index origin, int k, H3Index* out, int* distances,
+void _kRingInternal(H3Index origin, int k, H3Index *out, int *distances,
                     int maxIdx, int curK);
 
 // Create a vertex graph from a set of hexagons
-void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
-                        VertexGraph* out);
+void h3SetToVertexGraph(const H3Index *h3Set, const int numHexes,
+                        VertexGraph *out);
 
 // Create a LinkedGeoPolygon from a vertex graph
-void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out);
+void _vertexGraphToLinkedGeo(VertexGraph *graph, LinkedGeoPolygon *out);
 
 // Internal function for polygonToCells that traces a geoloop with hexagons of
 // a specific size
-int _getEdgeHexagons(const GeoLoop* geoloop, int numHexagons, int res,
-                     int* numSearchHexes, H3Index* search, H3Index* found);
+int _getEdgeHexagons(const GeoLoop *geoloop, int numHexagons, int res,
+                     int *numSearchHexes, H3Index *search, H3Index *found);
 
 // The polygonToCells algorithm. Separated out because it can theoretically fail
-int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
-                            H3Index* out);
+int _polygonToCellsInternal(const GeoPolygon *geoPolygon, int res,
+                            H3Index *out);
 
 // The safe gridDiskDistances algorithm.
-void _gridDiskDistancesInternal(H3Index origin, int k, H3Index* out,
-                                int* distances, int maxIdx, int curK);
+void _gridDiskDistancesInternal(H3Index origin, int k, H3Index *out,
+                                int *distances, int maxIdx, int curK);
 #endif

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -51,10 +51,10 @@ extern const BaseCellData baseCellData[NUM_BASE_CELLS];
 // Internal functions
 int _isBaseCellPentagon(int baseCell);
 bool _isBaseCellPolarPentagon(int baseCell);
-int _faceIjkToBaseCell(const FaceIJK* h);
-int _faceIjkToBaseCellCCWrot60(const FaceIJK* h);
+int _faceIjkToBaseCell(const FaceIJK *h);
+int _faceIjkToBaseCellCCWrot60(const FaceIJK *h);
 int _baseCellToCCWrot60(int baseCell, int face);
-void _baseCellToFaceIjk(int baseCell, FaceIJK* h);
+void _baseCellToFaceIjk(int baseCell, FaceIJK *h);
 bool _baseCellIsCwOffset(int baseCell, int testFace);
 int _getBaseCellNeighbor(int baseCell, Direction dir);
 Direction _getBaseCellDirection(int originBaseCell, int destinationBaseCell);

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -34,11 +34,11 @@ typedef struct {
     double west;   ///< west longitude
 } BBox;
 
-bool bboxIsTransmeridian(const BBox* bbox);
-void bboxCenter(const BBox* bbox, LatLng* center);
-bool bboxContains(const BBox* bbox, const LatLng* point);
-bool bboxEquals(const BBox* b1, const BBox* b2);
-int bboxHexEstimate(const BBox* bbox, int res);
-int lineHexEstimate(const LatLng* origin, const LatLng* destination, int res);
+bool bboxIsTransmeridian(const BBox *bbox);
+void bboxCenter(const BBox *bbox, LatLng *center);
+bool bboxContains(const BBox *bbox, const LatLng *point);
+bool bboxEquals(const BBox *b1, const BBox *b2);
+int bboxHexEstimate(const BBox *bbox, int res);
+int lineHexEstimate(const LatLng *origin, const LatLng *destination, int res);
 
 #endif

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -86,30 +86,30 @@ typedef enum {
 
 // Internal functions
 
-void _setIJK(CoordIJK* ijk, int i, int j, int k);
-void _hex2dToCoordIJK(const Vec2d* v, CoordIJK* h);
-void _ijkToHex2d(const CoordIJK* h, Vec2d* v);
-int _ijkMatches(const CoordIJK* c1, const CoordIJK* c2);
-void _ijkAdd(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* sum);
-void _ijkSub(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* diff);
-void _ijkScale(CoordIJK* c, int factor);
-void _ijkNormalize(CoordIJK* c);
-Direction _unitIjkToDigit(const CoordIJK* ijk);
-void _upAp7(CoordIJK* ijk);
-void _upAp7r(CoordIJK* ijk);
-void _downAp7(CoordIJK* ijk);
-void _downAp7r(CoordIJK* ijk);
-void _downAp3(CoordIJK* ijk);
-void _downAp3r(CoordIJK* ijk);
-void _neighbor(CoordIJK* ijk, Direction digit);
-void _ijkRotate60ccw(CoordIJK* ijk);
-void _ijkRotate60cw(CoordIJK* ijk);
+void _setIJK(CoordIJK *ijk, int i, int j, int k);
+void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h);
+void _ijkToHex2d(const CoordIJK *h, Vec2d *v);
+int _ijkMatches(const CoordIJK *c1, const CoordIJK *c2);
+void _ijkAdd(const CoordIJK *h1, const CoordIJK *h2, CoordIJK *sum);
+void _ijkSub(const CoordIJK *h1, const CoordIJK *h2, CoordIJK *diff);
+void _ijkScale(CoordIJK *c, int factor);
+void _ijkNormalize(CoordIJK *c);
+Direction _unitIjkToDigit(const CoordIJK *ijk);
+void _upAp7(CoordIJK *ijk);
+void _upAp7r(CoordIJK *ijk);
+void _downAp7(CoordIJK *ijk);
+void _downAp7r(CoordIJK *ijk);
+void _downAp3(CoordIJK *ijk);
+void _downAp3r(CoordIJK *ijk);
+void _neighbor(CoordIJK *ijk, Direction digit);
+void _ijkRotate60ccw(CoordIJK *ijk);
+void _ijkRotate60cw(CoordIJK *ijk);
 Direction _rotate60ccw(Direction digit);
 Direction _rotate60cw(Direction digit);
-int ijkDistance(const CoordIJK* a, const CoordIJK* b);
-void ijkToIj(const CoordIJK* ijk, CoordIJ* ij);
-void ijToIjk(const CoordIJ* ij, CoordIJK* ijk);
-void ijkToCube(CoordIJK* ijk);
-void cubeToIjk(CoordIJK* ijk);
+int ijkDistance(const CoordIJK *a, const CoordIJK *b);
+void ijkToIj(const CoordIJK *ijk, CoordIJ *ij);
+void ijToIjk(const CoordIJ *ij, CoordIJK *ijk);
+void ijkToCube(CoordIJK *ijk);
+void cubeToIjk(CoordIJK *ijk);
 
 #endif

--- a/src/h3lib/include/faceijk.h
+++ b/src/h3lib/include/faceijk.h
@@ -72,18 +72,18 @@ typedef enum {
 
 // Internal functions
 
-void _geoToFaceIjk(const LatLng* g, int res, FaceIJK* h);
-void _geoToHex2d(const LatLng* g, int res, int* face, Vec2d* v);
-void _faceIjkToGeo(const FaceIJK* h, int res, LatLng* g);
-void _faceIjkToCellBoundary(const FaceIJK* h, int res, int start, int length,
-                            CellBoundary* g);
-void _faceIjkPentToCellBoundary(const FaceIJK* h, int res, int start,
-                                int length, CellBoundary* g);
-void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
-void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts);
-void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate, LatLng* g);
-Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
+void _geoToFaceIjk(const LatLng *g, int res, FaceIJK *h);
+void _geoToHex2d(const LatLng *g, int res, int *face, Vec2d *v);
+void _faceIjkToGeo(const FaceIJK *h, int res, LatLng *g);
+void _faceIjkToCellBoundary(const FaceIJK *h, int res, int start, int length,
+                            CellBoundary *g);
+void _faceIjkPentToCellBoundary(const FaceIJK *h, int res, int start,
+                                int length, CellBoundary *g);
+void _faceIjkToVerts(FaceIJK *fijk, int *res, FaceIJK *fijkVerts);
+void _faceIjkPentToVerts(FaceIJK *fijk, int *res, FaceIJK *fijkVerts);
+void _hex2dToGeo(const Vec2d *v, int face, int res, int substrate, LatLng *g);
+Overage _adjustOverageClassII(FaceIJK *fijk, int res, int pentLeading4,
                               int substrate);
-Overage _adjustPentVertOverage(FaceIJK* fijk, int res);
+Overage _adjustPentVertOverage(FaceIJK *fijk, int res);
 
 #endif

--- a/src/h3lib/include/h3Index.h
+++ b/src/h3lib/include/h3Index.h
@@ -164,14 +164,14 @@
             (((uint64_t)(digit))                                            \
              << ((MAX_H3_RES - (res)) * H3_PER_DIGIT_OFFSET)))
 
-void setH3Index(H3Index* h, int res, int baseCell, Direction initDigit);
+void setH3Index(H3Index *h, int res, int baseCell, Direction initDigit);
 int isResolutionClassIII(int r);
 
 // Internal functions
 
-int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK* fijk);
-H3Error _h3ToFaceIjk(H3Index h, FaceIJK* fijk);
-H3Index _faceIjkToH3(const FaceIJK* fijk, int res);
+int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK *fijk);
+H3Error _h3ToFaceIjk(H3Index h, FaceIJK *fijk);
+H3Index _faceIjkToH3(const FaceIJK *fijk, int res);
 Direction _h3LeadingNonZeroDigit(H3Index h);
 H3Index _h3RotatePent60ccw(H3Index h);
 H3Index _h3RotatePent60cw(H3Index h);

--- a/src/h3lib/include/iterators.h
+++ b/src/h3lib/include/iterators.h
@@ -55,7 +55,7 @@ typedef struct {
 
 DECLSPEC IterCellsChildren iterInitParent(H3Index h, int childRes);
 DECLSPEC IterCellsChildren iterInitBaseCellNum(int baseCellNum, int childRes);
-DECLSPEC void iterStepChild(IterCellsChildren* iter);
+DECLSPEC void iterStepChild(IterCellsChildren *iter);
 
 /**
  * IterCellsResolution: struct for iterating through all cells at a given
@@ -81,6 +81,6 @@ typedef struct {
 } IterCellsResolution;
 
 DECLSPEC IterCellsResolution iterInitRes(int res);
-DECLSPEC void iterStepRes(IterCellsResolution* iter);
+DECLSPEC void iterStepRes(IterCellsResolution *iter);
 
 #endif

--- a/src/h3lib/include/linkedGeo.h
+++ b/src/h3lib/include/linkedGeo.h
@@ -34,8 +34,8 @@
 // Macros for use with polygonAlgos.h
 /** Macro: Init iteration vars for LinkedGeoLoop */
 #define INIT_ITERATION_LINKED_LOOP     \
-    LinkedLatLng* currentCoord = NULL; \
-    LinkedLatLng* nextCoord = NULL
+    LinkedLatLng *currentCoord = NULL; \
+    LinkedLatLng *nextCoord = NULL
 
 /** Macro: Get the next coord in a linked loop, wrapping if needed */
 #define GET_NEXT_COORD(loop, coordToCheck) \
@@ -52,15 +52,15 @@
 /** Macro: Whether a LinkedGeoLoop is empty */
 #define IS_EMPTY_LINKED_LOOP(loop) loop->first == NULL
 
-int normalizeMultiPolygon(LinkedGeoPolygon* root);
-LinkedGeoPolygon* addNewLinkedPolygon(LinkedGeoPolygon* polygon);
-LinkedGeoLoop* addNewLinkedLoop(LinkedGeoPolygon* polygon);
-LinkedGeoLoop* addLinkedLoop(LinkedGeoPolygon* polygon, LinkedGeoLoop* loop);
-LinkedLatLng* addLinkedCoord(LinkedGeoLoop* loop, const LatLng* vertex);
-int countLinkedPolygons(LinkedGeoPolygon* polygon);
-int countLinkedLoops(LinkedGeoPolygon* polygon);
-int countLinkedCoords(LinkedGeoLoop* loop);
-void destroyLinkedGeoLoop(LinkedGeoLoop* loop);
+int normalizeMultiPolygon(LinkedGeoPolygon *root);
+LinkedGeoPolygon *addNewLinkedPolygon(LinkedGeoPolygon *polygon);
+LinkedGeoLoop *addNewLinkedLoop(LinkedGeoPolygon *polygon);
+LinkedGeoLoop *addLinkedLoop(LinkedGeoPolygon *polygon, LinkedGeoLoop *loop);
+LinkedLatLng *addLinkedCoord(LinkedGeoLoop *loop, const LatLng *vertex);
+int countLinkedPolygons(LinkedGeoPolygon *polygon);
+int countLinkedLoops(LinkedGeoPolygon *polygon);
+int countLinkedCoords(LinkedGeoLoop *loop);
+void destroyLinkedGeoLoop(LinkedGeoLoop *loop);
 
 // The following functions are created via macro in polygonAlgos.h,
 // so their signatures are documented here:
@@ -70,7 +70,7 @@ void destroyLinkedGeoLoop(LinkedGeoLoop* loop);
  * @param geoloop Input GeoLoop
  * @param bbox     Output bbox
  */
-void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
+void bboxFromLinkedGeoLoop(const LinkedGeoLoop *loop, BBox *bbox);
 
 /**
  * Take a given LinkedGeoLoop data structure and check if it
@@ -80,14 +80,14 @@ void bboxFromLinkedGeoLoop(const LinkedGeoLoop* loop, BBox* bbox);
  * @param coord         The coordinate to check
  * @return              Whether the point is contained
  */
-bool pointInsideLinkedGeoLoop(const LinkedGeoLoop* loop, const BBox* bbox,
-                              const LatLng* coord);
+bool pointInsideLinkedGeoLoop(const LinkedGeoLoop *loop, const BBox *bbox,
+                              const LatLng *coord);
 
 /**
  * Whether the winding order of a given LinkedGeoLoop is clockwise
  * @param loop  The loop to check
  * @return      Whether the loop is clockwise
  */
-bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop* loop);
+bool isClockwiseLinkedGeoLoop(const LinkedGeoLoop *loop);
 
 #endif

--- a/src/h3lib/include/localij.h
+++ b/src/h3lib/include/localij.h
@@ -23,7 +23,7 @@
 #include "coordijk.h"
 #include "h3api.h"
 
-int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out);
-int localIjkToH3(H3Index origin, const CoordIJK* ijk, H3Index* out);
+int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out);
+int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out);
 
 #endif

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -41,9 +41,9 @@
 #define IS_EMPTY_GEOFENCE(geoloop) geoloop->numVerts == 0
 
 // Defined directly in polygon.c:
-void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes);
-bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
-                        const LatLng* coord);
+void bboxesFromGeoPolygon(const GeoPolygon *polygon, BBox *bboxes);
+bool pointInsidePolygon(const GeoPolygon *geoPolygon, const BBox *bboxes,
+                        const LatLng *coord);
 
 // The following functions are created via macro in polygonAlgos.h,
 // so their signatures are documented here:
@@ -53,7 +53,7 @@ bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
  * @param geoloop Input GeoLoop
  * @param bbox     Output bbox
  */
-void bboxFromGeoLoop(const GeoLoop* loop, BBox* bbox);
+void bboxFromGeoLoop(const GeoLoop *loop, BBox *bbox);
 
 /**
  * Take a given GeoLoop data structure and check if it
@@ -63,14 +63,14 @@ void bboxFromGeoLoop(const GeoLoop* loop, BBox* bbox);
  * @param coord         The coordinate to check
  * @return              Whether the point is contained
  */
-bool pointInsideGeoLoop(const GeoLoop* loop, const BBox* bbox,
-                        const LatLng* coord);
+bool pointInsideGeoLoop(const GeoLoop *loop, const BBox *bbox,
+                        const LatLng *coord);
 
 /**
  * Whether the winding order of a given GeoLoop is clockwise
  * @param loop  The loop to check
  * @return      Whether the loop is clockwise
  */
-bool isClockwiseGeoLoop(const GeoLoop* geoloop);
+bool isClockwiseGeoLoop(const GeoLoop *geoloop);
 
 #endif

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -64,8 +64,8 @@
  * @param coord The coordinate to check
  * @return      Whether the point is contained
  */
-bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
-                                    const LatLng* coord) {
+bool GENERIC_LOOP_ALGO(pointInside)(const TYPE *loop, const BBox *bbox,
+                                    const LatLng *coord) {
     // fail fast if we're outside the bounding box
     if (!bboxContains(bbox, coord)) {
         return false;
@@ -134,7 +134,7 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE* loop, const BBox* bbox,
  * @param loop     Loop of coordinates
  * @param bbox     Output bbox
  */
-void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
+void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE *loop, BBox *bbox) {
     // Early exit if there are no vertices
     if (IS_EMPTY(loop)) {
         *bbox = (BBox){0};
@@ -188,7 +188,7 @@ void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE* loop, BBox* bbox) {
  * @param isTransmeridian   Whether the loop crosses the antimeridian
  * @return                  Whether the loop is clockwise
  */
-static bool GENERIC_LOOP_ALGO(isClockwiseNormalized)(const TYPE* loop,
+static bool GENERIC_LOOP_ALGO(isClockwiseNormalized)(const TYPE *loop,
                                                      bool isTransmeridian) {
     double sum = 0;
     LatLng a;
@@ -216,6 +216,6 @@ static bool GENERIC_LOOP_ALGO(isClockwiseNormalized)(const TYPE* loop,
  * @param loop  The loop to check
  * @return      Whether the loop is clockwise
  */
-bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE* loop) {
+bool GENERIC_LOOP_ALGO(isClockwise)(const TYPE *loop) {
     return GENERIC_LOOP_ALGO(isClockwiseNormalized)(loop, false);
 }

--- a/src/h3lib/include/vec2d.h
+++ b/src/h3lib/include/vec2d.h
@@ -32,9 +32,9 @@ typedef struct {
 
 // Internal functions
 
-double _v2dMag(const Vec2d* v);
-void _v2dIntersect(const Vec2d* p0, const Vec2d* p1, const Vec2d* p2,
-                   const Vec2d* p3, Vec2d* inter);
-bool _v2dEquals(const Vec2d* p0, const Vec2d* p1);
+double _v2dMag(const Vec2d *v);
+void _v2dIntersect(const Vec2d *p0, const Vec2d *p1, const Vec2d *p2,
+                   const Vec2d *p3, Vec2d *inter);
+bool _v2dEquals(const Vec2d *p0, const Vec2d *p1);
 
 #endif

--- a/src/h3lib/include/vec3d.h
+++ b/src/h3lib/include/vec3d.h
@@ -31,7 +31,7 @@ typedef struct {
     double z;  ///< z component
 } Vec3d;
 
-void _geoToVec3d(const LatLng* geo, Vec3d* point);
-double _pointSquareDist(const Vec3d* p1, const Vec3d* p2);
+void _geoToVec3d(const LatLng *geo, Vec3d *point);
+double _pointSquareDist(const Vec3d *p1, const Vec3d *p2);
 
 #endif

--- a/src/h3lib/include/vertexGraph.h
+++ b/src/h3lib/include/vertexGraph.h
@@ -32,38 +32,38 @@ typedef struct VertexNode VertexNode;
 struct VertexNode {
     LatLng from;
     LatLng to;
-    VertexNode* next;
+    VertexNode *next;
 };
 
 /** @struct VertexGraph
  *  @brief A data structure to store a graph of vertices
  */
 typedef struct {
-    VertexNode** buckets;
+    VertexNode **buckets;
     int numBuckets;
     int size;
     int res;
 } VertexGraph;
 
-void initVertexGraph(VertexGraph* graph, int numBuckets, int res);
+void initVertexGraph(VertexGraph *graph, int numBuckets, int res);
 
-void destroyVertexGraph(VertexGraph* graph);
+void destroyVertexGraph(VertexGraph *graph);
 
-VertexNode* addVertexNode(VertexGraph* graph, const LatLng* fromVtx,
-                          const LatLng* toVtx);
+VertexNode *addVertexNode(VertexGraph *graph, const LatLng *fromVtx,
+                          const LatLng *toVtx);
 
-int removeVertexNode(VertexGraph* graph, VertexNode* node);
+int removeVertexNode(VertexGraph *graph, VertexNode *node);
 
-VertexNode* findNodeForEdge(const VertexGraph* graph, const LatLng* fromVtx,
-                            const LatLng* toVtx);
+VertexNode *findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
+                            const LatLng *toVtx);
 
-VertexNode* findNodeForVertex(const VertexGraph* graph, const LatLng* fromVtx);
+VertexNode *findNodeForVertex(const VertexGraph *graph, const LatLng *fromVtx);
 
-VertexNode* firstVertexNode(const VertexGraph* graph);
+VertexNode *firstVertexNode(const VertexGraph *graph);
 
 // Internal functions
-uint32_t _hashVertex(const LatLng* vertex, int res, int numBuckets);
-void _initVertexNode(VertexNode* node, const LatLng* fromVtx,
-                     const LatLng* toVtx);
+uint32_t _hashVertex(const LatLng *vertex, int res, int numBuckets);
+void _initVertexNode(VertexNode *node, const LatLng *fromVtx,
+                     const LatLng *toVtx);
 
 #endif

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -176,7 +176,7 @@ int H3_EXPORT(maxGridDiskSize)(int k) { return 3 * k * (k + 1) + 1; }
  * @param  k        k >= 0
  * @param  out      zero-filled array which must be of size maxGridDiskSize(k)
  */
-void H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index* out) {
+void H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index *out) {
     H3_EXPORT(gridDiskDistances)(origin, k, out, NULL);
 }
 
@@ -197,8 +197,8 @@ void H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index* out) {
  * @param  distances   NULL or a zero-filled array which must be of size
  *                     maxGridDiskSize(k)
  */
-void H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index* out,
-                                  int* distances) {
+void H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index *out,
+                                  int *distances) {
     // Optimistically try the faster gridDiskUnsafe algorithm first
     const bool failed =
         H3_EXPORT(gridDiskDistancesUnsafe)(origin, k, out, distances);
@@ -240,8 +240,8 @@ void H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index* out,
  * maxGridDiskSize(k))
  * @param  curK        Current distance from the origin
  */
-void _gridDiskDistancesInternal(H3Index origin, int k, H3Index* out,
-                                int* distances, int maxIdx, int curK) {
+void _gridDiskDistancesInternal(H3Index origin, int k, H3Index *out,
+                                int *distances, int maxIdx, int curK) {
     if (origin == 0) return;
 
     // Put origin in the output array. out is used as a hash set.
@@ -284,8 +284,8 @@ void _gridDiskDistancesInternal(H3Index origin, int k, H3Index* out,
  *                     Elements indicate ijk distance from the origin cell to
  *                     the output cell
  */
-void H3_EXPORT(gridDiskDistancesSafe)(H3Index origin, int k, H3Index* out,
-                                      int* distances) {
+void H3_EXPORT(gridDiskDistancesSafe)(H3Index origin, int k, H3Index *out,
+                                      int *distances) {
     int maxIdx = H3_EXPORT(maxGridDiskSize)(k);
     _gridDiskDistancesInternal(origin, k, out, distances, maxIdx, 0);
 }
@@ -305,7 +305,7 @@ void H3_EXPORT(gridDiskDistancesSafe)(H3Index origin, int k, H3Index* out,
  * @return H3Index of the specified neighbor or H3_NULL if deleted k-subsequence
  *         distortion is encountered.
  */
-H3Index h3NeighborRotations(H3Index origin, Direction dir, int* rotations) {
+H3Index h3NeighborRotations(H3Index origin, Direction dir, int *rotations) {
     H3Index out = origin;
 
     for (int i = 0; i < *rotations; i++) {
@@ -481,7 +481,7 @@ Direction directionForNeighbor(H3Index origin, H3Index destination) {
  * @param out Array which must be of size maxGridDiskSize(k).
  * @return 0 if no pentagon or pentagonal distortion area was encountered.
  */
-int H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index* out) {
+int H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index *out) {
     return H3_EXPORT(gridDiskDistancesUnsafe)(origin, k, out, NULL);
 }
 
@@ -503,8 +503,8 @@ int H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index* out) {
  * @param distances Null or array which must be of size maxGridDiskSize(k).
  * @return 0 if no pentagon or pentagonal distortion area was encountered.
  */
-int H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k, H3Index* out,
-                                       int* distances) {
+int H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k, H3Index *out,
+                                       int *distances) {
     // Return codes:
     // 1 Pentagon was encountered
     // 2 Pentagon distortion (deleted k subsequence) was encountered
@@ -597,10 +597,10 @@ int H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k, H3Index* out,
  *            The memory block should be equal to maxGridDiskSize(k) * length
  * @return 0 if no pentagon is encountered. Cannot trust output otherwise
  */
-int H3_EXPORT(gridDisksUnsafe)(H3Index* h3Set, int length, int k,
-                               H3Index* out) {
+int H3_EXPORT(gridDisksUnsafe)(H3Index *h3Set, int length, int k,
+                               H3Index *out) {
     int success = 0;
-    H3Index* segment;
+    H3Index *segment;
     int segmentSize = H3_EXPORT(maxGridDiskSize)(k);
     for (int i = 0; i < length; i++) {
         // Determine the appropriate segment of the output array to operate on
@@ -624,7 +624,7 @@ int H3_EXPORT(gridDisksUnsafe)(H3Index* h3Set, int length, int k,
  * @param out Array which must be of size 6 * k (or 1 if k == 0)
  * @return 0 if successful; nonzero otherwise.
  */
-int H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index* out) {
+int H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index *out) {
     // Short-circuit on 'identity' ring
     if (k == 0) {
         out[0] = origin;
@@ -703,7 +703,7 @@ int H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index* out) {
  * @param res Hexagon resolution (0-15)
  * @return number of hexagons to allocate for
  */
-int H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon* geoPolygon, int res) {
+int H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon *geoPolygon, int res) {
     // Get the bounding box for the GeoJSON-like struct
     BBox bbox;
     const GeoLoop geoloop = geoPolygon->geoloop;
@@ -739,8 +739,8 @@ int H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon* geoPolygon, int res) {
  * @param res The Hexagon resolution (0-15)
  * @param out The slab of zeroed memory to write to. Assumed to be big enough.
  */
-void H3_EXPORT(polygonToCells)(const GeoPolygon* geoPolygon, int res,
-                               H3Index* out) {
+void H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon, int res,
+                               H3Index *out) {
     // TODO: Eliminate this wrapper with the H3 4.0.0 release
     int failure = _polygonToCellsInternal(geoPolygon, res, out);
     // The polygonToCells algorithm can theoretically fail if the allocated
@@ -772,8 +772,8 @@ void H3_EXPORT(polygonToCells)(const GeoPolygon* geoPolygon, int res,
  * @return An error code if the hash function cannot insert a found hexagon
  *         into the found array.
  */
-int _getEdgeHexagons(const GeoLoop* geoloop, int numHexagons, int res,
-                     int* numSearchHexes, H3Index* search, H3Index* found) {
+int _getEdgeHexagons(const GeoLoop *geoloop, int numHexagons, int res,
+                     int *numSearchHexes, H3Index *search, H3Index *found) {
     for (int i = 0; i < geoloop->numVerts; i++) {
         LatLng origin = geoloop->verts[i];
         LatLng destination = i == geoloop->numVerts - 1 ? geoloop->verts[0]
@@ -836,8 +836,8 @@ int _getEdgeHexagons(const GeoLoop* geoloop, int numHexagons, int res,
  * @return An error code if any of the hash operations fails to insert a hexagon
  *         into an array of memory.
  */
-int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
-                            H3Index* out) {
+int _polygonToCellsInternal(const GeoPolygon *geoPolygon, int res,
+                            H3Index *out) {
     // One of the goals of the polygonToCells algorithm is that two adjacent
     // polygons with zero overlap have zero overlapping hexagons. That the
     // hexagons are uniquely assigned. There are a few approaches to take here,
@@ -856,15 +856,15 @@ int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
     // This first part is identical to the maxPolygonToCellsSize above.
 
     // Get the bounding boxes for the polygon and any holes
-    BBox* bboxes = H3_MEMORY(malloc)((geoPolygon->numHoles + 1) * sizeof(BBox));
+    BBox *bboxes = H3_MEMORY(malloc)((geoPolygon->numHoles + 1) * sizeof(BBox));
     assert(bboxes != NULL);
     bboxesFromGeoPolygon(geoPolygon, bboxes);
 
     // Get the estimated number of hexagons and allocate some temporary memory
     // for the hexagons
     int numHexagons = H3_EXPORT(maxPolygonToCellsSize)(geoPolygon, res);
-    H3Index* search = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
-    H3Index* found = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
+    H3Index *search = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
+    H3Index *found = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
 
     // Some metadata for tracking the state of the search and found memory
     // blocks
@@ -895,7 +895,7 @@ int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
     // we're done here, otherwise we'd have to scan the whole set on each insert
     // to make sure there's no duplicates, which is very inefficient.
     for (int i = 0; i < geoPolygon->numHoles; i++) {
-        GeoLoop* hole = &(geoPolygon->holes[i]);
+        GeoLoop *hole = &(geoPolygon->holes[i]);
         failure = _getEdgeHexagons(hole, numHexagons, res, &numSearchHexes,
                                    search, found);
         // If this branch is reached, we have exceeded the maximum number of
@@ -979,7 +979,7 @@ int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
 
         // Swap the search and found pointers, copy the found hex count to the
         // search hex count, and zero everything related to the found memory.
-        H3Index* temp = search;
+        H3Index *temp = search;
         search = found;
         found = temp;
         for (int j = 0; j < numSearchHexes; j++) found[j] = 0;
@@ -1003,12 +1003,12 @@ int _polygonToCellsInternal(const GeoPolygon* geoPolygon, int res,
  * @param numHexes Number of hexagons in the set
  * @param graph    Output graph
  */
-void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
-                        VertexGraph* graph) {
+void h3SetToVertexGraph(const H3Index *h3Set, const int numHexes,
+                        VertexGraph *graph) {
     CellBoundary vertices;
-    LatLng* fromVtx;
-    LatLng* toVtx;
-    VertexNode* edge;
+    LatLng *fromVtx;
+    LatLng *toVtx;
+    VertexNode *edge;
     if (numHexes < 1) {
         // We still need to init the graph, or calls to destroyVertexGraph will
         // fail
@@ -1049,10 +1049,10 @@ void h3SetToVertexGraph(const H3Index* h3Set, const int numHexes,
  * @param graph Input graph
  * @param out   Output polygon
  */
-void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out) {
+void _vertexGraphToLinkedGeo(VertexGraph *graph, LinkedGeoPolygon *out) {
     *out = (LinkedGeoPolygon){0};
-    LinkedGeoLoop* loop;
-    VertexNode* edge;
+    LinkedGeoLoop *loop;
+    VertexNode *edge;
     LatLng nextVtx;
     // Find the next unused entry point
     while ((edge = firstVertexNode(graph)) != NULL) {
@@ -1086,8 +1086,8 @@ void _vertexGraphToLinkedGeo(VertexGraph* graph, LinkedGeoPolygon* out) {
  * @param numHexes Number of hexagons in set
  * @param out      Output polygon
  */
-void H3_EXPORT(h3SetToLinkedGeo)(const H3Index* h3Set, const int numHexes,
-                                 LinkedGeoPolygon* out) {
+void H3_EXPORT(h3SetToLinkedGeo)(const H3Index *h3Set, const int numHexes,
+                                 LinkedGeoPolygon *out) {
     VertexGraph graph;
     h3SetToVertexGraph(h3Set, numHexes, &graph);
     _vertexGraphToLinkedGeo(&graph, out);

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -843,7 +843,7 @@ bool _isBaseCellPolarPentagon(int baseCell) {
  *
  * Valid ijk+ lookup coordinates are from (0, 0, 0) to (2, 2, 2).
  */
-int _faceIjkToBaseCell(const FaceIJK* h) {
+int _faceIjkToBaseCell(const FaceIJK *h) {
     return faceIjkBaseCells[h->face][h->coord.i][h->coord.j][h->coord.k]
         .baseCell;
 }
@@ -856,14 +856,14 @@ int _faceIjkToBaseCell(const FaceIJK* h) {
  *
  * Valid ijk+ lookup coordinates are from (0, 0, 0) to (2, 2, 2).
  */
-int _faceIjkToBaseCellCCWrot60(const FaceIJK* h) {
+int _faceIjkToBaseCellCCWrot60(const FaceIJK *h) {
     return faceIjkBaseCells[h->face][h->coord.i][h->coord.j][h->coord.k]
         .ccwRot60;
 }
 
 /** @brief Find the FaceIJK given a base cell.
  */
-void _baseCellToFaceIjk(int baseCell, FaceIJK* h) {
+void _baseCellToFaceIjk(int baseCell, FaceIJK *h) {
     *h = baseCellData[baseCell].homeFijk;
 }
 
@@ -927,7 +927,7 @@ int H3_EXPORT(res0CellCount)() { return NUM_BASE_CELLS; }
  *
  * @param out H3Index* the memory to store the resulting base cells in
  */
-void H3_EXPORT(getRes0Cells)(H3Index* out) {
+void H3_EXPORT(getRes0Cells)(H3Index *out) {
     for (int bc = 0; bc < NUM_BASE_CELLS; bc++) {
         H3Index baseCell = H3_INIT;
         H3_SET_MODE(baseCell, H3_HEXAGON_MODE);

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -32,14 +32,14 @@
  * @param  bbox Bounding box to inspect
  * @return      is transmeridian
  */
-bool bboxIsTransmeridian(const BBox* bbox) { return bbox->east < bbox->west; }
+bool bboxIsTransmeridian(const BBox *bbox) { return bbox->east < bbox->west; }
 
 /**
  * Get the center of a bounding box
  * @param bbox   Input bounding box
  * @param center Output center coordinate
  */
-void bboxCenter(const BBox* bbox, LatLng* center) {
+void bboxCenter(const BBox *bbox, LatLng *center) {
     center->lat = (bbox->north + bbox->south) / 2.0;
     // If the bbox crosses the antimeridian, shift east 360 degrees
     double east = bboxIsTransmeridian(bbox) ? bbox->east + M_2PI : bbox->east;
@@ -52,7 +52,7 @@ void bboxCenter(const BBox* bbox, LatLng* center) {
  * @param  point Point to test
  * @return       Whether the point is contained
  */
-bool bboxContains(const BBox* bbox, const LatLng* point) {
+bool bboxContains(const BBox *bbox, const LatLng *point) {
     return point->lat >= bbox->south && point->lat <= bbox->north &&
            (bboxIsTransmeridian(bbox) ?
                                       // transmeridian case
@@ -68,7 +68,7 @@ bool bboxContains(const BBox* bbox, const LatLng* point) {
  * @param  b2 Bounding box 2
  * @return    Whether the boxes are equal
  */
-bool bboxEquals(const BBox* b1, const BBox* b2) {
+bool bboxEquals(const BBox *b1, const BBox *b2) {
     return b1->north == b2->north && b1->south == b2->south &&
            b1->east == b2->east && b1->west == b2->west;
 }
@@ -97,7 +97,7 @@ double _hexRadiusKm(H3Index h3Index) {
  * @param res the resolution of the H3 hexagons to fill the bounding box
  * @return the estimated number of hexagons to fill the bounding box
  */
-int bboxHexEstimate(const BBox* bbox, int res) {
+int bboxHexEstimate(const BBox *bbox, int res) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     H3_EXPORT(getPentagons)(res, pentagons);
@@ -136,7 +136,7 @@ int bboxHexEstimate(const BBox* bbox, int res) {
  *  @param res the resolution of the H3 hexagons to trace the line
  *  @return the estimated number of hexagons required to trace the line
  */
-int lineHexEstimate(const LatLng* origin, const LatLng* destination, int res) {
+int lineHexEstimate(const LatLng *origin, const LatLng *destination, int res) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     H3_EXPORT(getPentagons)(res, pentagons);

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -37,7 +37,7 @@
  * @param j The desired j component value.
  * @param k The desired k component value.
  */
-void _setIJK(CoordIJK* ijk, int i, int j, int k) {
+void _setIJK(CoordIJK *ijk, int i, int j, int k) {
     ijk->i = i;
     ijk->j = j;
     ijk->k = k;
@@ -50,7 +50,7 @@ void _setIJK(CoordIJK* ijk, int i, int j, int k) {
  * @param v The 2D cartesian coordinate vector.
  * @param h The ijk+ coordinates of the containing hex.
  */
-void _hex2dToCoordIJK(const Vec2d* v, CoordIJK* h) {
+void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
     double a1, a2;
     double x1, x2;
     int m1, m2;
@@ -149,7 +149,7 @@ void _hex2dToCoordIJK(const Vec2d* v, CoordIJK* h) {
  * @param h The ijk coordinates of the hex.
  * @param v The 2D cartesian coordinates of the hex center point.
  */
-void _ijkToHex2d(const CoordIJK* h, Vec2d* v) {
+void _ijkToHex2d(const CoordIJK *h, Vec2d *v) {
     int i = h->i - h->k;
     int j = h->j - h->k;
 
@@ -165,7 +165,7 @@ void _ijkToHex2d(const CoordIJK* h, Vec2d* v) {
  * @param c2 The second set of ijk coordinates.
  * @return 1 if the two addresses match, 0 if they do not.
  */
-int _ijkMatches(const CoordIJK* c1, const CoordIJK* c2) {
+int _ijkMatches(const CoordIJK *c1, const CoordIJK *c2) {
     return (c1->i == c2->i && c1->j == c2->j && c1->k == c2->k);
 }
 
@@ -176,7 +176,7 @@ int _ijkMatches(const CoordIJK* c1, const CoordIJK* c2) {
  * @param h2 The second set of ijk coordinates.
  * @param sum The sum of the two sets of ijk coordinates.
  */
-void _ijkAdd(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* sum) {
+void _ijkAdd(const CoordIJK *h1, const CoordIJK *h2, CoordIJK *sum) {
     sum->i = h1->i + h2->i;
     sum->j = h1->j + h2->j;
     sum->k = h1->k + h2->k;
@@ -189,7 +189,7 @@ void _ijkAdd(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* sum) {
  * @param h2 The second set of ijk coordinates.
  * @param diff The difference of the two sets of ijk coordinates (h1 - h2).
  */
-void _ijkSub(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* diff) {
+void _ijkSub(const CoordIJK *h1, const CoordIJK *h2, CoordIJK *diff) {
     diff->i = h1->i - h2->i;
     diff->j = h1->j - h2->j;
     diff->k = h1->k - h2->k;
@@ -201,7 +201,7 @@ void _ijkSub(const CoordIJK* h1, const CoordIJK* h2, CoordIJK* diff) {
  * @param c The ijk coordinates to scale.
  * @param factor The scaling factor.
  */
-void _ijkScale(CoordIJK* c, int factor) {
+void _ijkScale(CoordIJK *c, int factor) {
     c->i *= factor;
     c->j *= factor;
     c->k *= factor;
@@ -213,7 +213,7 @@ void _ijkScale(CoordIJK* c, int factor) {
  *
  * @param c The ijk coordinates to normalize.
  */
-void _ijkNormalize(CoordIJK* c) {
+void _ijkNormalize(CoordIJK *c) {
     // remove any negative values
     if (c->i < 0) {
         c->j -= c->i;
@@ -251,7 +251,7 @@ void _ijkNormalize(CoordIJK* c) {
  * @return The H3 digit (0-6) corresponding to the ijk unit vector, or
  * INVALID_DIGIT on failure.
  */
-Direction _unitIjkToDigit(const CoordIJK* ijk) {
+Direction _unitIjkToDigit(const CoordIJK *ijk) {
     CoordIJK c = *ijk;
     _ijkNormalize(&c);
 
@@ -272,7 +272,7 @@ Direction _unitIjkToDigit(const CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _upAp7(CoordIJK* ijk) {
+void _upAp7(CoordIJK *ijk) {
     // convert to CoordIJ
     int i = ijk->i - ijk->k;
     int j = ijk->j - ijk->k;
@@ -289,7 +289,7 @@ void _upAp7(CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _upAp7r(CoordIJK* ijk) {
+void _upAp7r(CoordIJK *ijk) {
     // convert to CoordIJ
     int i = ijk->i - ijk->k;
     int j = ijk->j - ijk->k;
@@ -307,7 +307,7 @@ void _upAp7r(CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _downAp7(CoordIJK* ijk) {
+void _downAp7(CoordIJK *ijk) {
     // res r unit vectors in res r+1
     CoordIJK iVec = {3, 0, 1};
     CoordIJK jVec = {1, 3, 0};
@@ -329,7 +329,7 @@ void _downAp7(CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _downAp7r(CoordIJK* ijk) {
+void _downAp7r(CoordIJK *ijk) {
     // res r unit vectors in res r+1
     CoordIJK iVec = {3, 1, 0};
     CoordIJK jVec = {0, 3, 1};
@@ -352,7 +352,7 @@ void _downAp7r(CoordIJK* ijk) {
  * @param ijk The ijk coordinates.
  * @param digit The digit direction from the original ijk coordinates.
  */
-void _neighbor(CoordIJK* ijk, Direction digit) {
+void _neighbor(CoordIJK *ijk, Direction digit) {
     if (digit > CENTER_DIGIT && digit < NUM_DIGITS) {
         _ijkAdd(ijk, &UNIT_VECS[digit], ijk);
         _ijkNormalize(ijk);
@@ -364,7 +364,7 @@ void _neighbor(CoordIJK* ijk, Direction digit) {
  *
  * @param ijk The ijk coordinates.
  */
-void _ijkRotate60ccw(CoordIJK* ijk) {
+void _ijkRotate60ccw(CoordIJK *ijk) {
     // unit vector rotations
     CoordIJK iVec = {1, 1, 0};
     CoordIJK jVec = {0, 1, 1};
@@ -385,7 +385,7 @@ void _ijkRotate60ccw(CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _ijkRotate60cw(CoordIJK* ijk) {
+void _ijkRotate60cw(CoordIJK *ijk) {
     // unit vector rotations
     CoordIJK iVec = {1, 0, 1};
     CoordIJK jVec = {1, 1, 0};
@@ -456,7 +456,7 @@ Direction _rotate60cw(Direction digit) {
  *
  * @param ijk The ijk coordinates.
  */
-void _downAp3(CoordIJK* ijk) {
+void _downAp3(CoordIJK *ijk) {
     // res r unit vectors in res r+1
     CoordIJK iVec = {2, 0, 1};
     CoordIJK jVec = {1, 2, 0};
@@ -478,7 +478,7 @@ void _downAp3(CoordIJK* ijk) {
  *
  * @param ijk The ijk coordinates.
  */
-void _downAp3r(CoordIJK* ijk) {
+void _downAp3r(CoordIJK *ijk) {
     // res r unit vectors in res r+1
     CoordIJK iVec = {2, 1, 0};
     CoordIJK jVec = {0, 2, 1};
@@ -500,7 +500,7 @@ void _downAp3r(CoordIJK* ijk) {
  * @param c1 The first set of ijk coordinates.
  * @param c2 The second set of ijk coordinates.
  */
-int ijkDistance(const CoordIJK* c1, const CoordIJK* c2) {
+int ijkDistance(const CoordIJK *c1, const CoordIJK *c2) {
     CoordIJK diff;
     _ijkSub(c1, c2, &diff);
     _ijkNormalize(&diff);
@@ -515,7 +515,7 @@ int ijkDistance(const CoordIJK* c1, const CoordIJK* c2) {
  * @param ijk The input IJK+ coordinates
  * @param ij The output IJ coordinates
  */
-void ijkToIj(const CoordIJK* ijk, CoordIJ* ij) {
+void ijkToIj(const CoordIJK *ijk, CoordIJ *ij) {
     ij->i = ijk->i - ijk->k;
     ij->j = ijk->j - ijk->k;
 }
@@ -527,7 +527,7 @@ void ijkToIj(const CoordIJK* ijk, CoordIJ* ij) {
  * @param ij The input IJ coordinates
  * @param ijk The output IJK+ coordinates
  */
-void ijToIjk(const CoordIJ* ij, CoordIJK* ijk) {
+void ijToIjk(const CoordIJ *ij, CoordIJK *ijk) {
     ijk->i = ij->i;
     ijk->j = ij->j;
     ijk->k = 0;
@@ -539,7 +539,7 @@ void ijToIjk(const CoordIJ* ij, CoordIJK* ijk) {
  * Convert IJK coordinates to cube coordinates, in place
  * @param ijk Coordinate to convert
  */
-void ijkToCube(CoordIJK* ijk) {
+void ijkToCube(CoordIJK *ijk) {
     ijk->i = -ijk->i + ijk->k;
     ijk->j = ijk->j - ijk->k;
     ijk->k = -ijk->i - ijk->j;
@@ -549,7 +549,7 @@ void ijkToCube(CoordIJK* ijk) {
  * Convert cube coordinates to IJK coordinates, in place
  * @param ijk Coordinate to convert
  */
-void cubeToIjk(CoordIJK* ijk) {
+void cubeToIjk(CoordIJK *ijk) {
     ijk->i = -ijk->i;
     ijk->k = 0;
     _ijkNormalize(ijk);

--- a/src/h3lib/lib/directedEdge.c
+++ b/src/h3lib/lib/directedEdge.c
@@ -177,7 +177,7 @@ int H3_EXPORT(isValidDirectedEdge)(H3Index edge) {
  * @param originDestination Pointer to memory to store origin and destination
  * IDs
  */
-void H3_EXPORT(directedEdgeToCells)(H3Index edge, H3Index* originDestination) {
+void H3_EXPORT(directedEdgeToCells)(H3Index edge, H3Index *originDestination) {
     originDestination[0] = H3_EXPORT(getDirectedEdgeOrigin)(edge);
     originDestination[1] = H3_EXPORT(getDirectedEdgeDestination)(edge);
 }
@@ -187,7 +187,7 @@ void H3_EXPORT(directedEdgeToCells)(H3Index edge, H3Index* originDestination) {
  * @param origin The origin hexagon H3Index to find edges for.
  * @param edges The memory to store all of the edges inside.
  */
-void H3_EXPORT(originToDirectedEdges)(H3Index origin, H3Index* edges) {
+void H3_EXPORT(originToDirectedEdges)(H3Index origin, H3Index *edges) {
     // Determine if the origin is a pentagon and special treatment needed.
     int isPent = H3_EXPORT(isPentagon)(origin);
 
@@ -210,7 +210,7 @@ void H3_EXPORT(originToDirectedEdges)(H3Index origin, H3Index* edges) {
  * @param edge The directed edge H3Index
  * @param cb The cellboundary object to store the edge coordinates.
  */
-void H3_EXPORT(directedEdgeToBoundary)(H3Index edge, CellBoundary* cb) {
+void H3_EXPORT(directedEdgeToBoundary)(H3Index edge, CellBoundary *cb) {
     // Get the origin and neighbor direction from the edge
     Direction direction = H3_GET_RESERVED_BITS(edge);
     H3Index origin = H3_EXPORT(getDirectedEdgeOrigin)(edge);

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -368,7 +368,7 @@ static const int unitScaleByCIIres[] = {
  * @param res The desired H3 resolution for the encoding.
  * @param h The FaceIJK address of the containing cell at resolution res.
  */
-void _geoToFaceIjk(const LatLng* g, int res, FaceIJK* h) {
+void _geoToFaceIjk(const LatLng *g, int res, FaceIJK *h) {
     // first convert to hex2d
     Vec2d v;
     _geoToHex2d(g, res, &h->face, &v);
@@ -386,7 +386,7 @@ void _geoToFaceIjk(const LatLng* g, int res, FaceIJK* h) {
  * @param face The icosahedral face containing the spherical coordinates.
  * @param v The 2D hex coordinates of the cell containing the point.
  */
-void _geoToHex2d(const LatLng* g, int res, int* face, Vec2d* v) {
+void _geoToHex2d(const LatLng *g, int res, int *face, Vec2d *v) {
     Vec3d v3d;
     _geoToVec3d(g, &v3d);
 
@@ -444,7 +444,7 @@ void _geoToHex2d(const LatLng* g, int res, int* face, Vec2d* v) {
  *        grid relative to the specified resolution.
  * @param g The spherical coordinates of the cell center point.
  */
-void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate, LatLng* g) {
+void _hex2dToGeo(const Vec2d *v, int face, int res, int substrate, LatLng *g) {
     // calculate (r, theta) in hex2d
     double r = _v2dMag(v);
 
@@ -489,7 +489,7 @@ void _hex2dToGeo(const Vec2d* v, int face, int res, int substrate, LatLng* g) {
  * @param res The H3 resolution of the cell.
  * @param g The spherical coordinates of the cell center point.
  */
-void _faceIjkToGeo(const FaceIJK* h, int res, LatLng* g) {
+void _faceIjkToGeo(const FaceIJK *h, int res, LatLng *g) {
     Vec2d v;
     _ijkToHex2d(&h->coord, &v);
     _hex2dToGeo(&v, h->face, res, 0, g);
@@ -505,8 +505,8 @@ void _faceIjkToGeo(const FaceIJK* h, int res, LatLng* g) {
  * @param length The number of topological vertexes to return.
  * @param g The spherical coordinates of the cell boundary.
  */
-void _faceIjkPentToCellBoundary(const FaceIJK* h, int res, int start,
-                                int length, CellBoundary* g) {
+void _faceIjkPentToCellBoundary(const FaceIJK *h, int res, int start,
+                                int length, CellBoundary *g) {
     int adjRes = res;
     FaceIJK centerIJK = *h;
     FaceIJK fijkVerts[NUM_PENT_VERTS];
@@ -542,11 +542,11 @@ void _faceIjkPentToCellBoundary(const FaceIJK* h, int res, int start,
 
             int currentToLastDir = adjacentFaceDir[tmpFijk.face][lastFijk.face];
 
-            const FaceOrientIJK* fijkOrient =
+            const FaceOrientIJK *fijkOrient =
                 &faceNeighbors[tmpFijk.face][currentToLastDir];
 
             tmpFijk.face = fijkOrient->face;
-            CoordIJK* ijk = &tmpFijk.coord;
+            CoordIJK *ijk = &tmpFijk.coord;
 
             // rotate and translate for adjacent face
             for (int i = 0; i < fijkOrient->ccwRot60; i++) _ijkRotate60ccw(ijk);
@@ -565,8 +565,8 @@ void _faceIjkPentToCellBoundary(const FaceIJK* h, int res, int start,
             Vec2d v1 = {-1.5 * maxDim, 3.0 * M_SQRT3_2 * maxDim};
             Vec2d v2 = {-1.5 * maxDim, -3.0 * M_SQRT3_2 * maxDim};
 
-            Vec2d* edge0;
-            Vec2d* edge1;
+            Vec2d *edge0;
+            Vec2d *edge1;
             switch (adjacentFaceDir[tmpFijk.face][fijk.face]) {
                 case IJ:
                     edge0 = &v0;
@@ -614,7 +614,7 @@ void _faceIjkPentToCellBoundary(const FaceIJK* h, int res, int start,
  *            necessary for the substrate grid resolution.
  * @param fijkVerts Output array for the vertices
  */
-void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
+void _faceIjkPentToVerts(FaceIJK *fijk, int *res, FaceIJK *fijkVerts) {
     // the vertexes of an origin-centered pentagon in a Class II resolution on a
     // substrate grid with aperture sequence 33r. The aperture 3 gets us the
     // vertices, and the 3r gets us back to Class II.
@@ -640,7 +640,7 @@ void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
     };
 
     // get the correct set of substrate vertices for this resolution
-    CoordIJK* verts;
+    CoordIJK *verts;
     if (isResolutionClassIII(*res))
         verts = vertsCIII;
     else
@@ -678,8 +678,8 @@ void _faceIjkPentToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
  * @param length The number of topological vertexes to return.
  * @param g The spherical coordinates of the cell boundary.
  */
-void _faceIjkToCellBoundary(const FaceIJK* h, int res, int start, int length,
-                            CellBoundary* g) {
+void _faceIjkToCellBoundary(const FaceIJK *h, int res, int start, int length,
+                            CellBoundary *g) {
     int adjRes = res;
     FaceIJK centerIJK = *h;
     FaceIJK fijkVerts[NUM_HEX_VERTS];
@@ -730,8 +730,8 @@ void _faceIjkToCellBoundary(const FaceIJK* h, int res, int start, int length,
             Vec2d v2 = {-1.5 * maxDim, -3.0 * M_SQRT3_2 * maxDim};
 
             int face2 = ((lastFace == centerIJK.face) ? fijk.face : lastFace);
-            Vec2d* edge0;
-            Vec2d* edge1;
+            Vec2d *edge0;
+            Vec2d *edge1;
             switch (adjacentFaceDir[centerIJK.face][face2]) {
                 case IJ:
                     edge0 = &v0;
@@ -789,7 +789,7 @@ void _faceIjkToCellBoundary(const FaceIJK* h, int res, int start, int length,
  *            necessary for the substrate grid resolution.
  * @param fijkVerts Output array for the vertices
  */
-void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
+void _faceIjkToVerts(FaceIJK *fijk, int *res, FaceIJK *fijkVerts) {
     // the vertexes of an origin-centered cell in a Class II resolution on a
     // substrate grid with aperture sequence 33r. The aperture 3 gets us the
     // vertices, and the 3r gets us back to Class II.
@@ -817,7 +817,7 @@ void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
     };
 
     // get the correct set of substrate vertices for this resolution
-    CoordIJK* verts;
+    CoordIJK *verts;
     if (isResolutionClassIII(*res))
         verts = vertsCIII;
     else
@@ -857,11 +857,11 @@ void _faceIjkToVerts(FaceIJK* fijk, int* res, FaceIJK* fijkVerts) {
  * @return 0 if on original face (no overage); 1 if on face edge (only occurs
  *         on substrate grids); 2 if overage on new face interior
  */
-Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
+Overage _adjustOverageClassII(FaceIJK *fijk, int res, int pentLeading4,
                               int substrate) {
     Overage overage = NO_OVERAGE;
 
-    CoordIJK* ijk = &fijk->coord;
+    CoordIJK *ijk = &fijk->coord;
 
     // get the maximum dimension value; scale if a substrate grid
     int maxDim = maxDimByCIIres[res];
@@ -874,7 +874,7 @@ Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
     {
         overage = NEW_FACE;
 
-        const FaceOrientIJK* fijkOrient;
+        const FaceOrientIJK *fijkOrient;
         if (ijk->k > 0) {
             if (ijk->j > 0)  // jk "quadrant"
                 fijkOrient = &faceNeighbors[fijk->face][JK];
@@ -926,7 +926,7 @@ Overage _adjustOverageClassII(FaceIJK* fijk, int res, int pentLeading4,
  * @param fijk The FaceIJK address of the cell.
  * @param res The H3 resolution of the cell.
  */
-Overage _adjustPentVertOverage(FaceIJK* fijk, int res) {
+Overage _adjustPentVertOverage(FaceIJK *fijk, int res) {
     int pentLeading4 = 0;
     Overage overage;
     do {

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -55,7 +55,7 @@ int H3_EXPORT(getBaseCellNumber)(H3Index h) { return H3_GET_BASE_CELL(h); }
  * @return The H3 index corresponding to the string argument, or H3_NULL if
  * invalid.
  */
-H3Index H3_EXPORT(stringToH3)(const char* str) {
+H3Index H3_EXPORT(stringToH3)(const char *str) {
     H3Index h = H3_NULL;
     // If failed, h will be unmodified and we should return H3_NULL anyways.
     sscanf(str, "%" PRIx64, &h);
@@ -68,7 +68,7 @@ H3Index H3_EXPORT(stringToH3)(const char* str) {
  * @param str The string representation of the H3 index.
  * @param sz Size of the buffer `str`
  */
-void H3_EXPORT(h3ToString)(H3Index h, char* str, size_t sz) {
+void H3_EXPORT(h3ToString)(H3Index h, char *str, size_t sz) {
     // An unsigned 64 bit integer will be expressed in at most
     // 16 digits plus 1 for the null terminator.
     if (sz < 17) {
@@ -131,7 +131,7 @@ int H3_EXPORT(isValidCell)(H3Index h) {
  * @param baseCell The H3 base cell to initialize the index to.
  * @param initDigit The H3 digit (0-7) to initialize all of the index digits to.
  */
-void setH3Index(H3Index* hp, int res, int baseCell, Direction initDigit) {
+void setH3Index(H3Index *hp, int res, int baseCell, Direction initDigit) {
     H3Index h = H3_INIT;
     H3_SET_MODE(h, H3_HEXAGON_MODE);
     H3_SET_RESOLUTION(h, res);
@@ -229,7 +229,7 @@ H3Index makeDirectChild(H3Index h, int cellNumber) {
  * @param childRes int the child level to produce
  * @param children H3Index* the memory to store the resulting addresses in
  */
-void H3_EXPORT(cellToChildren)(H3Index h, int childRes, H3Index* children) {
+void H3_EXPORT(cellToChildren)(H3Index h, int childRes, H3Index *children) {
     int64_t i = 0;
     for (IterCellsChildren iter = iterInitParent(h, childRes); iter.h;
          iterStepChild(&iter)) {
@@ -287,7 +287,7 @@ H3Index H3_EXPORT(cellToCenterChild)(H3Index h, int childRes) {
  * @return an error code on bad input data
  */
 // todo: update internal implementation for int64_t
-H3Error H3_EXPORT(compactCells)(const H3Index* h3Set, H3Index* compactedSet,
+H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
                                 const int64_t numHexes) {
     if (numHexes == 0) {
         return E_SUCCESS;
@@ -300,17 +300,17 @@ H3Error H3_EXPORT(compactCells)(const H3Index* h3Set, H3Index* compactedSet,
         }
         return E_SUCCESS;
     }
-    H3Index* remainingHexes = H3_MEMORY(malloc)(numHexes * sizeof(H3Index));
+    H3Index *remainingHexes = H3_MEMORY(malloc)(numHexes * sizeof(H3Index));
     if (!remainingHexes) {
         return E_MEMORY;
     }
     memcpy(remainingHexes, h3Set, numHexes * sizeof(H3Index));
-    H3Index* hashSetArray = H3_MEMORY(calloc)(numHexes, sizeof(H3Index));
+    H3Index *hashSetArray = H3_MEMORY(calloc)(numHexes, sizeof(H3Index));
     if (!hashSetArray) {
         H3_MEMORY(free)(remainingHexes);
         return E_MEMORY;
     }
-    H3Index* compactedSetOffset = compactedSet;
+    H3Index *compactedSetOffset = compactedSet;
     int numRemainingHexes = numHexes;
     while (numRemainingHexes) {
         res = H3_GET_RESOLUTION(remainingHexes[0]);
@@ -374,7 +374,7 @@ H3Error H3_EXPORT(compactCells)(const H3Index* h3Set, H3Index* compactedSet,
                    numRemainingHexes * sizeof(remainingHexes[0]));
             break;
         }
-        H3Index* compactableHexes =
+        H3Index *compactableHexes =
             H3_MEMORY(calloc)(maxCompactableCount, sizeof(H3Index));
         if (!compactableHexes) {
             H3_MEMORY(free)(remainingHexes);
@@ -471,8 +471,8 @@ H3Error H3_EXPORT(compactCells)(const H3Index* h3Set, H3Index* compactedSet,
  * @return              An error code if output array is too small or any cell
  *                      is smaller than the output resolution.
  */
-H3Error H3_EXPORT(uncompactCells)(const H3Index* compactedSet,
-                                  const int64_t numCompacted, H3Index* outSet,
+H3Error H3_EXPORT(uncompactCells)(const H3Index *compactedSet,
+                                  const int64_t numCompacted, H3Index *outSet,
                                   const int64_t numOut, const int res) {
     int64_t i = 0;
 
@@ -498,9 +498,9 @@ H3Error H3_EXPORT(uncompactCells)(const H3Index* compactedSet,
  * @param   out           The number of hexagons to allocate memory for
  * @returns E_SUCCESS on success, or another value on error
  */
-H3Error H3_EXPORT(uncompactCellsSize)(const H3Index* compactedSet,
+H3Error H3_EXPORT(uncompactCellsSize)(const H3Index *compactedSet,
                                       const int64_t numCompacted, const int res,
-                                      int64_t* out) {
+                                      int64_t *out) {
     int64_t numOut = 0;
     for (int64_t i = 0; i < numCompacted; i++) {
         if (compactedSet[i] == H3_NULL) continue;
@@ -628,7 +628,7 @@ H3Index _h3Rotate60cw(H3Index h) {
  * @param res The cell resolution.
  * @return The encoded H3Index (or H3_NULL on failure).
  */
-H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
+H3Index _faceIjkToH3(const FaceIJK *fijk, int res) {
     // initialize the index
     H3Index h = H3_INIT;
     H3_SET_MODE(h, H3_HEXAGON_MODE);
@@ -654,7 +654,7 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
     // build the H3Index from finest res up
     // adjust r for the fact that the res 0 base cell offsets the indexing
     // digits
-    CoordIJK* ijk = &fijkBC.coord;
+    CoordIJK *ijk = &fijkBC.coord;
     for (int r = res - 1; r >= 0; r--) {
         CoordIJK lastIJK = *ijk;
         CoordIJK lastCenter;
@@ -725,7 +725,7 @@ H3Index _faceIjkToH3(const FaceIJK* fijk, int res) {
  * @param out The encoded H3Index.
  * @returns E_SUCCESS (0) on success, another value otherwise
  */
-H3Error H3_EXPORT(latLngToCell)(const LatLng* g, int res, H3Index* out) {
+H3Error H3_EXPORT(latLngToCell)(const LatLng *g, int res, H3Index *out) {
     if (res < 0 || res > MAX_H3_RES) {
         return E_RES_DOMAIN;
     }
@@ -750,8 +750,8 @@ H3Error H3_EXPORT(latLngToCell)(const LatLng* g, int res, H3Index* out) {
  *        and normalized base cell coordinates.
  * @return Returns 1 if the possibility of overage exists, otherwise 0.
  */
-int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK* fijk) {
-    CoordIJK* ijk = &fijk->coord;
+int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK *fijk) {
+    CoordIJK *ijk = &fijk->coord;
     int res = H3_GET_RESOLUTION(h);
 
     // center base cell hierarchy is entirely on this face
@@ -781,7 +781,7 @@ int _h3ToFaceIjkWithInitializedFijk(H3Index h, FaceIJK* fijk) {
  * @param h The H3Index.
  * @param fijk The corresponding FaceIJK address.
  */
-H3Error _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
+H3Error _h3ToFaceIjk(H3Index h, FaceIJK *fijk) {
     int baseCell = H3_GET_BASE_CELL(h);
     if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
         // Base cells less than zero can not be represented in an index
@@ -838,7 +838,7 @@ H3Error _h3ToFaceIjk(H3Index h, FaceIJK* fijk) {
  * @param h3 The H3 index.
  * @param g The spherical coordinates of the H3 cell center.
  */
-H3Error H3_EXPORT(cellToLatLng)(H3Index h3, LatLng* g) {
+H3Error H3_EXPORT(cellToLatLng)(H3Index h3, LatLng *g) {
     FaceIJK fijk;
     H3Error e = _h3ToFaceIjk(h3, &fijk);
     if (e) {
@@ -854,7 +854,7 @@ H3Error H3_EXPORT(cellToLatLng)(H3Index h3, LatLng* g) {
  * @param h3 The H3 index.
  * @param cb The boundary of the H3 cell in spherical coordinates.
  */
-H3Error H3_EXPORT(cellToBoundary)(H3Index h3, CellBoundary* cb) {
+H3Error H3_EXPORT(cellToBoundary)(H3Index h3, CellBoundary *cb) {
     FaceIJK fijk;
     H3Error e = _h3ToFaceIjk(h3, &fijk);
     if (e) {
@@ -891,7 +891,7 @@ int H3_EXPORT(maxFaceCount)(H3Index h3) {
  * @param h3 The H3 index
  * @param out Output array. Must be of size maxFaceCount(h3).
  */
-void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int* out) {
+void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
     int res = H3_GET_RESOLUTION(h3);
     int isPent = H3_EXPORT(isPentagon)(h3);
 
@@ -932,7 +932,7 @@ void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int* out) {
 
     // add each vertex face, using the output array as a hash set
     for (int i = 0; i < vertexCount; i++) {
-        FaceIJK* vert = &fijkVerts[i];
+        FaceIJK *vert = &fijkVerts[i];
 
         // Adjust overage, determining whether this vertex is
         // on another face
@@ -965,7 +965,7 @@ int H3_EXPORT(pentagonCount)() { return NUM_PENTAGONS; }
  * @param res The resolution to produce pentagons at.
  * @param out Output array. Must be of size pentagonCount().
  */
-void H3_EXPORT(getPentagons)(int res, H3Index* out) {
+void H3_EXPORT(getPentagons)(int res, H3Index *out) {
     int i = 0;
     for (int bc = 0; bc < NUM_BASE_CELLS; bc++) {
         if (_isBaseCellPentagon(bc)) {

--- a/src/h3lib/lib/iterators.c
+++ b/src/h3lib/lib/iterators.c
@@ -24,13 +24,13 @@
 #include "h3Index.h"
 
 // extract the `res` digit (0--7) of the current cell
-static int _getResDigit(IterCellsChildren* it, int res) {
+static int _getResDigit(IterCellsChildren *it, int res) {
     return H3_GET_INDEX_DIGIT(it->h, res);
 }
 
 // increment the digit (0--7) at location `res`
 // H3_PER_DIGIT_OFFSET == 3
-static void _incrementResDigit(IterCellsChildren* it, int res) {
+static void _incrementResDigit(IterCellsChildren *it, int res) {
     H3Index val = 1;
     val <<= H3_PER_DIGIT_OFFSET * (MAX_H3_RES - res);
     it->h += val;
@@ -241,7 +241,7 @@ IterCellsChildren iterInitParent(H3Index h, int childRes) {
  * When the iteration is over, IterCellsChildren.h will be H3_NULL.
  * Handles iterating through hexagon and pentagon cells.
  */
-void iterStepChild(IterCellsChildren* it) {
+void iterStepChild(IterCellsChildren *it) {
     // once h == H3_NULL, the iterator returns an infinite sequence of H3_NULL
     if (it->h == H3_NULL) return;
 
@@ -303,7 +303,7 @@ IterCellsResolution iterInitRes(int res) {
     return itR;
 }
 
-void iterStepRes(IterCellsResolution* itR) {
+void iterStepRes(IterCellsResolution *itR) {
     // reached the end of over iterator; emits H3_NULL from now on
     if (itR->h == H3_NULL) return;
 

--- a/src/h3lib/lib/linkedGeo.c
+++ b/src/h3lib/lib/linkedGeo.c
@@ -31,9 +31,9 @@
  * @param  polygon Polygon to add link to
  * @return         Pointer to new polygon
  */
-LinkedGeoPolygon* addNewLinkedPolygon(LinkedGeoPolygon* polygon) {
+LinkedGeoPolygon *addNewLinkedPolygon(LinkedGeoPolygon *polygon) {
     assert(polygon->next == NULL);
-    LinkedGeoPolygon* next = H3_MEMORY(calloc)(1, sizeof(*next));
+    LinkedGeoPolygon *next = H3_MEMORY(calloc)(1, sizeof(*next));
     assert(next != NULL);
     polygon->next = next;
     return next;
@@ -44,8 +44,8 @@ LinkedGeoPolygon* addNewLinkedPolygon(LinkedGeoPolygon* polygon) {
  * @param  polygon Polygon to add loop to
  * @return         Pointer to loop
  */
-LinkedGeoLoop* addNewLinkedLoop(LinkedGeoPolygon* polygon) {
-    LinkedGeoLoop* loop = H3_MEMORY(calloc)(1, sizeof(*loop));
+LinkedGeoLoop *addNewLinkedLoop(LinkedGeoPolygon *polygon) {
+    LinkedGeoLoop *loop = H3_MEMORY(calloc)(1, sizeof(*loop));
     assert(loop != NULL);
     return addLinkedLoop(polygon, loop);
 }
@@ -55,8 +55,8 @@ LinkedGeoLoop* addNewLinkedLoop(LinkedGeoPolygon* polygon) {
  * @param  polygon Polygon to add loop to
  * @return         Pointer to loop
  */
-LinkedGeoLoop* addLinkedLoop(LinkedGeoPolygon* polygon, LinkedGeoLoop* loop) {
-    LinkedGeoLoop* last = polygon->last;
+LinkedGeoLoop *addLinkedLoop(LinkedGeoPolygon *polygon, LinkedGeoLoop *loop) {
+    LinkedGeoLoop *last = polygon->last;
     if (last == NULL) {
         assert(polygon->first == NULL);
         polygon->first = loop;
@@ -73,11 +73,11 @@ LinkedGeoLoop* addLinkedLoop(LinkedGeoPolygon* polygon, LinkedGeoLoop* loop) {
  * @param  vertex Coordinate to add
  * @return        Pointer to the coordinate
  */
-LinkedLatLng* addLinkedCoord(LinkedGeoLoop* loop, const LatLng* vertex) {
-    LinkedLatLng* coord = H3_MEMORY(malloc)(sizeof(*coord));
+LinkedLatLng *addLinkedCoord(LinkedGeoLoop *loop, const LatLng *vertex) {
+    LinkedLatLng *coord = H3_MEMORY(malloc)(sizeof(*coord));
     assert(coord != NULL);
     *coord = (LinkedLatLng){.vertex = *vertex, .next = NULL};
-    LinkedLatLng* last = loop->last;
+    LinkedLatLng *last = loop->last;
     if (last == NULL) {
         assert(loop->first == NULL);
         loop->first = coord;
@@ -93,9 +93,9 @@ LinkedLatLng* addLinkedCoord(LinkedGeoLoop* loop, const LatLng* vertex) {
  * responsible for freeing memory allocated to input loop struct.
  * @param loop Loop to free
  */
-void destroyLinkedGeoLoop(LinkedGeoLoop* loop) {
-    LinkedLatLng* nextCoord;
-    for (LinkedLatLng* currentCoord = loop->first; currentCoord != NULL;
+void destroyLinkedGeoLoop(LinkedGeoLoop *loop) {
+    LinkedLatLng *nextCoord;
+    for (LinkedLatLng *currentCoord = loop->first; currentCoord != NULL;
          currentCoord = nextCoord) {
         nextCoord = currentCoord->next;
         H3_MEMORY(free)(currentCoord);
@@ -107,14 +107,14 @@ void destroyLinkedGeoLoop(LinkedGeoLoop* loop) {
  * responsible for freeing memory allocated to input polygon struct.
  * @param polygon Pointer to the first polygon in the structure
  */
-void H3_EXPORT(destroyLinkedPolygon)(LinkedGeoPolygon* polygon) {
+void H3_EXPORT(destroyLinkedPolygon)(LinkedGeoPolygon *polygon) {
     // flag to skip the input polygon
     bool skip = true;
-    LinkedGeoPolygon* nextPolygon;
-    LinkedGeoLoop* nextLoop;
-    for (LinkedGeoPolygon* currentPolygon = polygon; currentPolygon != NULL;
+    LinkedGeoPolygon *nextPolygon;
+    LinkedGeoLoop *nextLoop;
+    for (LinkedGeoPolygon *currentPolygon = polygon; currentPolygon != NULL;
          currentPolygon = nextPolygon) {
-        for (LinkedGeoLoop* currentLoop = currentPolygon->first;
+        for (LinkedGeoLoop *currentLoop = currentPolygon->first;
              currentLoop != NULL; currentLoop = nextLoop) {
             destroyLinkedGeoLoop(currentLoop);
             nextLoop = currentLoop->next;
@@ -135,7 +135,7 @@ void H3_EXPORT(destroyLinkedPolygon)(LinkedGeoPolygon* polygon) {
  * @param  polygon Starting polygon
  * @return         Count
  */
-int countLinkedPolygons(LinkedGeoPolygon* polygon) {
+int countLinkedPolygons(LinkedGeoPolygon *polygon) {
     int count = 0;
     while (polygon != NULL) {
         count++;
@@ -149,8 +149,8 @@ int countLinkedPolygons(LinkedGeoPolygon* polygon) {
  * @param  polygon Polygon to count loops for
  * @return         Count
  */
-int countLinkedLoops(LinkedGeoPolygon* polygon) {
-    LinkedGeoLoop* loop = polygon->first;
+int countLinkedLoops(LinkedGeoPolygon *polygon) {
+    LinkedGeoLoop *loop = polygon->first;
     int count = 0;
     while (loop != NULL) {
         count++;
@@ -164,8 +164,8 @@ int countLinkedLoops(LinkedGeoPolygon* polygon) {
  * @param  loop Loop to count coordinates for
  * @return      Count
  */
-int countLinkedCoords(LinkedGeoLoop* loop) {
-    LinkedLatLng* coord = loop->first;
+int countLinkedCoords(LinkedGeoLoop *loop) {
+    LinkedLatLng *coord = loop->first;
     int count = 0;
     while (coord != NULL) {
         count++;
@@ -182,9 +182,9 @@ int countLinkedCoords(LinkedGeoLoop* loop) {
  * @param  polygonCount Number of polygons in the test array
  * @return              Number of polygons containing the loop
  */
-static int countContainers(const LinkedGeoLoop* loop,
-                           const LinkedGeoPolygon** polygons,
-                           const BBox** bboxes, const int polygonCount) {
+static int countContainers(const LinkedGeoLoop *loop,
+                           const LinkedGeoPolygon **polygons,
+                           const BBox **bboxes, const int polygonCount) {
     int containerCount = 0;
     for (int i = 0; i < polygonCount; i++) {
         if (loop != polygons[i]->first &&
@@ -203,11 +203,11 @@ static int countContainers(const LinkedGeoLoop* loop,
  * @param  polygonCount Number of polygons in the list
  * @return              Deepest container, or null if list is empty
  */
-static const LinkedGeoPolygon* findDeepestContainer(
-    const LinkedGeoPolygon** polygons, const BBox** bboxes,
+static const LinkedGeoPolygon *findDeepestContainer(
+    const LinkedGeoPolygon **polygons, const BBox **bboxes,
     const int polygonCount) {
     // Set the initial return value to the first candidate
-    const LinkedGeoPolygon* parent = polygonCount > 0 ? polygons[0] : NULL;
+    const LinkedGeoPolygon *parent = polygonCount > 0 ? polygons[0] : NULL;
 
     // If we have multiple polygons, they must be nested inside each other.
     // Find the innermost polygon by taking the one with the most containers
@@ -236,19 +236,19 @@ static const LinkedGeoPolygon* findDeepestContainer(
  * @param  polygonCount Number of polygons to check
  * @return              Pointer to parent polygon, or null if not found
  */
-static const LinkedGeoPolygon* findPolygonForHole(
-    const LinkedGeoLoop* loop, const LinkedGeoPolygon* polygon,
-    const BBox* bboxes, const int polygonCount) {
+static const LinkedGeoPolygon *findPolygonForHole(
+    const LinkedGeoLoop *loop, const LinkedGeoPolygon *polygon,
+    const BBox *bboxes, const int polygonCount) {
     // Early exit with no polygons
     if (polygonCount == 0) {
         return NULL;
     }
     // Initialize arrays for candidate loops and their bounding boxes
-    const LinkedGeoPolygon** candidates =
-        H3_MEMORY(malloc)(polygonCount * sizeof(LinkedGeoPolygon*));
+    const LinkedGeoPolygon **candidates =
+        H3_MEMORY(malloc)(polygonCount * sizeof(LinkedGeoPolygon *));
     assert(candidates != NULL);
-    const BBox** candidateBBoxes =
-        H3_MEMORY(malloc)(polygonCount * sizeof(BBox*));
+    const BBox **candidateBBoxes =
+        H3_MEMORY(malloc)(polygonCount * sizeof(BBox *));
     assert(candidateBBoxes != NULL);
 
     // Find all polygons that contain the loop
@@ -267,7 +267,7 @@ static const LinkedGeoPolygon* findPolygonForHole(
     }
 
     // The most deeply nested container is the immediate parent
-    const LinkedGeoPolygon* parent =
+    const LinkedGeoPolygon *parent =
         findDeepestContainer(candidates, candidateBBoxes, candidateCount);
 
     // Free allocated memory
@@ -290,7 +290,7 @@ static const LinkedGeoPolygon* findPolygonForHole(
  * @param root Root polygon including all loops
  * @return     0 on success, or an error code > 0 for invalid input
  */
-int normalizeMultiPolygon(LinkedGeoPolygon* root) {
+int normalizeMultiPolygon(LinkedGeoPolygon *root) {
     // We assume that the input is a single polygon with loops;
     // if it has multiple polygons, don't touch it
     if (root->next) {
@@ -304,24 +304,24 @@ int normalizeMultiPolygon(LinkedGeoPolygon* root) {
     }
 
     int resultCode = NORMALIZATION_SUCCESS;
-    LinkedGeoPolygon* polygon = NULL;
-    LinkedGeoLoop* next;
+    LinkedGeoPolygon *polygon = NULL;
+    LinkedGeoLoop *next;
     int innerCount = 0;
     int outerCount = 0;
 
     // Create an array to hold all of the inner loops. Note that
     // this array will never be full, as there will always be fewer
     // inner loops than outer loops.
-    LinkedGeoLoop** innerLoops =
-        H3_MEMORY(malloc)(loopCount * sizeof(LinkedGeoLoop*));
+    LinkedGeoLoop **innerLoops =
+        H3_MEMORY(malloc)(loopCount * sizeof(LinkedGeoLoop *));
     assert(innerLoops != NULL);
 
     // Create an array to hold the bounding boxes for the outer loops
-    BBox* bboxes = H3_MEMORY(malloc)(loopCount * sizeof(BBox));
+    BBox *bboxes = H3_MEMORY(malloc)(loopCount * sizeof(BBox));
     assert(bboxes != NULL);
 
     // Get the first loop and unlink it from root
-    LinkedGeoLoop* loop = root->first;
+    LinkedGeoLoop *loop = root->first;
     *root = (LinkedGeoPolygon){0};
 
     // Iterate over all loops, moving inner loops into an array and
@@ -344,8 +344,8 @@ int normalizeMultiPolygon(LinkedGeoPolygon* root) {
 
     // Find polygon for each inner loop and assign the hole to it
     for (int i = 0; i < innerCount; i++) {
-        polygon = (LinkedGeoPolygon*)findPolygonForHole(innerLoops[i], root,
-                                                        bboxes, outerCount);
+        polygon = (LinkedGeoPolygon *)findPolygonForHole(innerLoops[i], root,
+                                                         bboxes, outerCount);
         if (polygon) {
             addLinkedLoop(polygon, innerLoops[i]);
         } else {

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -128,7 +128,7 @@ const bool FAILED_DIRECTIONS[7][7] = {
  * @param out ijk+ coordinates of the index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
+int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
     int res = H3_GET_RESOLUTION(origin);
 
     if (res != H3_GET_RESOLUTION(h3)) {
@@ -287,7 +287,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK* out) {
  * @param out The index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int localIjkToH3(H3Index origin, const CoordIJK* ijk, H3Index* out) {
+int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
     int res = H3_GET_RESOLUTION(origin);
     int originBaseCell = H3_GET_BASE_CELL(origin);
     if (originBaseCell < 0 ||  // LCOV_EXCL_BR_LINE
@@ -486,7 +486,7 @@ int localIjkToH3(H3Index origin, const CoordIJK* ijk, H3Index* out) {
  * @return 0 on success, or another value on failure.
  */
 int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
-                                       CoordIJ* out) {
+                                       CoordIJ *out) {
     // This function is currently experimental. Once ready to be part of the
     // non-experimental API, this function (with the experimental prefix) will
     // be marked as deprecated and to be removed in the next major version. It
@@ -519,8 +519,8 @@ int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
  * @param index Index will be placed here on success.
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(experimentalLocalIjToH3)(H3Index origin, const CoordIJ* ij,
-                                       H3Index* out) {
+int H3_EXPORT(experimentalLocalIjToH3)(H3Index origin, const CoordIJ *ij,
+                                       H3Index *out) {
     // This function is currently experimental. Once ready to be part of the
     // non-experimental API, this function (with the experimental prefix) will
     // be marked as deprecated and to be removed in the next major version. It
@@ -580,7 +580,7 @@ int H3_EXPORT(gridPathCellsSize)(H3Index start, H3Index end) {
  * @param k   Floating-point K coord
  * @param ijk IJK coord struct, modified in place
  */
-static void cubeRound(double i, double j, double k, CoordIJK* ijk) {
+static void cubeRound(double i, double j, double k, CoordIJK *ijk) {
     int ri = round(i);
     int rj = round(j);
     int rk = round(k);
@@ -624,7 +624,7 @@ static void cubeRound(double i, double j, double k, CoordIJK* ijk) {
  * @param out Output array, which must be of size gridPathCellsSize(start, end)
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index* out) {
+int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
     int distance = H3_EXPORT(gridDistance)(start, end);
     // Early exit if we can't calculate the line
     if (distance < 0) {

--- a/src/h3lib/lib/polygon.c
+++ b/src/h3lib/lib/polygon.c
@@ -47,7 +47,7 @@
  * @param polygon Input GeoPolygon
  * @param bboxes  Output bboxes, one for the outer loop and one for each hole
  */
-void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes) {
+void bboxesFromGeoPolygon(const GeoPolygon *polygon, BBox *bboxes) {
     bboxFromGeoLoop(&polygon->geoloop, &bboxes[0]);
     for (int i = 0; i < polygon->numHoles; i++) {
         bboxFromGeoLoop(&polygon->holes[i], &bboxes[i + 1]);
@@ -63,8 +63,8 @@ void bboxesFromGeoPolygon(const GeoPolygon* polygon, BBox* bboxes) {
  * @param coord      The coordinate to check
  * @return           Whether the point is contained
  */
-bool pointInsidePolygon(const GeoPolygon* geoPolygon, const BBox* bboxes,
-                        const LatLng* coord) {
+bool pointInsidePolygon(const GeoPolygon *geoPolygon, const BBox *bboxes,
+                        const LatLng *coord) {
     // Start with contains state of primary geoloop
     bool contains =
         pointInsideGeoLoop(&(geoPolygon->geoloop), &bboxes[0], coord);

--- a/src/h3lib/lib/vec2d.c
+++ b/src/h3lib/lib/vec2d.c
@@ -27,7 +27,7 @@
  * @param v The 2D cartesian vector.
  * @return The magnitude of the vector.
  */
-double _v2dMag(const Vec2d* v) { return sqrt(v->x * v->x + v->y * v->y); }
+double _v2dMag(const Vec2d *v) { return sqrt(v->x * v->x + v->y * v->y); }
 
 /**
  * Finds the intersection between two lines. Assumes that the lines intersect
@@ -38,8 +38,8 @@ double _v2dMag(const Vec2d* v) { return sqrt(v->x * v->x + v->y * v->y); }
  * @param p3 The second endpoint of the second line.
  * @param inter The intersection point.
  */
-void _v2dIntersect(const Vec2d* p0, const Vec2d* p1, const Vec2d* p2,
-                   const Vec2d* p3, Vec2d* inter) {
+void _v2dIntersect(const Vec2d *p0, const Vec2d *p1, const Vec2d *p2,
+                   const Vec2d *p3, Vec2d *inter) {
     Vec2d s1, s2;
     s1.x = p1->x - p0->x;
     s1.y = p1->y - p0->y;
@@ -61,6 +61,6 @@ void _v2dIntersect(const Vec2d* p0, const Vec2d* p1, const Vec2d* p2,
  * @param v2 Second vector to compare
  * @return Whether the vectors are equal
  */
-bool _v2dEquals(const Vec2d* v1, const Vec2d* v2) {
+bool _v2dEquals(const Vec2d *v1, const Vec2d *v2) {
     return v1->x == v2->x && v1->y == v2->y;
 }

--- a/src/h3lib/lib/vec3d.c
+++ b/src/h3lib/lib/vec3d.c
@@ -36,7 +36,7 @@ double _square(double x) { return x * x; }
  * @param v2 The second 3D coordinate.
  * @return The square of the distance between the given points.
  */
-double _pointSquareDist(const Vec3d* v1, const Vec3d* v2) {
+double _pointSquareDist(const Vec3d *v1, const Vec3d *v2) {
     return _square(v1->x - v2->x) + _square(v1->y - v2->y) +
            _square(v1->z - v2->z);
 }
@@ -47,7 +47,7 @@ double _pointSquareDist(const Vec3d* v1, const Vec3d* v2) {
  * @param geo The latitude and longitude of the point.
  * @param v The 3D coordinate of the point.
  */
-void _geoToVec3d(const LatLng* geo, Vec3d* v) {
+void _geoToVec3d(const LatLng *geo, Vec3d *v) {
     double r = cos(geo->lat);
 
     v->z = sin(geo->lat);

--- a/src/h3lib/lib/vertex.c
+++ b/src/h3lib/lib/vertex.c
@@ -272,7 +272,7 @@ H3Index H3_EXPORT(cellToVertex)(H3Index cell, int vertexNum) {
  * @param cell      Cell to get the vertexes for
  * @param vertexes  Array to hold vertex output. Must have length >= 6.
  */
-void H3_EXPORT(cellToVertexes)(H3Index cell, H3Index* vertexes) {
+void H3_EXPORT(cellToVertexes)(H3Index cell, H3Index *vertexes) {
     // Get all vertexes. If the cell is a pentagon, will fill the final slot
     // with H3_NULL.
     for (int i = 0; i < NUM_HEX_VERTS; i++) {
@@ -285,7 +285,7 @@ void H3_EXPORT(cellToVertexes)(H3Index cell, H3Index* vertexes) {
  * @param vertex H3 index describing a vertex
  * @param coord  Output geo coordinate
  */
-void H3_EXPORT(vertexToLatLng)(H3Index vertex, LatLng* coord) {
+void H3_EXPORT(vertexToLatLng)(H3Index vertex, LatLng *coord) {
     // Get the vertex number and owner from the vertex
     int vertexNum = H3_GET_RESERVED_BITS(vertex);
     H3Index owner = vertex;

--- a/src/h3lib/lib/vertexGraph.c
+++ b/src/h3lib/lib/vertexGraph.c
@@ -34,9 +34,9 @@
  * @param  numBuckets Number of buckets to include in the graph
  * @param  res        Resolution of the hexagons whose vertices we're storing
  */
-void initVertexGraph(VertexGraph* graph, int numBuckets, int res) {
+void initVertexGraph(VertexGraph *graph, int numBuckets, int res) {
     if (numBuckets > 0) {
-        graph->buckets = H3_MEMORY(calloc)(numBuckets, sizeof(VertexNode*));
+        graph->buckets = H3_MEMORY(calloc)(numBuckets, sizeof(VertexNode *));
         assert(graph->buckets != NULL);
     } else {
         graph->buckets = NULL;
@@ -51,8 +51,8 @@ void initVertexGraph(VertexGraph* graph, int numBuckets, int res) {
  * responsible for freeing memory allocated to the VertexGraph struct itself.
  * @param graph Graph to destroy
  */
-void destroyVertexGraph(VertexGraph* graph) {
-    VertexNode* node;
+void destroyVertexGraph(VertexGraph *graph) {
+    VertexNode *node;
     while ((node = firstVertexNode(graph)) != NULL) {
         removeVertexNode(graph, node);
     }
@@ -70,15 +70,15 @@ void destroyVertexGraph(VertexGraph* graph) {
  * @param  numBuckets Number of buckets in the graph
  * @return            Integer hash
  */
-uint32_t _hashVertex(const LatLng* vertex, int res, int numBuckets) {
+uint32_t _hashVertex(const LatLng *vertex, int res, int numBuckets) {
     // Simple hash: Take the sum of the lat and lng with a precision level
     // determined by the resolution, converted to int, modulo bucket count.
     return (uint32_t)fmod(fabs((vertex->lat + vertex->lng) * pow(10, 15 - res)),
                           numBuckets);
 }
 
-void _initVertexNode(VertexNode* node, const LatLng* fromVtx,
-                     const LatLng* toVtx) {
+void _initVertexNode(VertexNode *node, const LatLng *fromVtx,
+                     const LatLng *toVtx) {
     node->from = *fromVtx;
     node->to = *toVtx;
     node->next = NULL;
@@ -91,16 +91,16 @@ void _initVertexNode(VertexNode* node, const LatLng* fromVtx,
  * @param toVtx   End vertex
  * @return        Pointer to the new node
  */
-VertexNode* addVertexNode(VertexGraph* graph, const LatLng* fromVtx,
-                          const LatLng* toVtx) {
+VertexNode *addVertexNode(VertexGraph *graph, const LatLng *fromVtx,
+                          const LatLng *toVtx) {
     // Make the new node
-    VertexNode* node = H3_MEMORY(malloc)(sizeof(VertexNode));
+    VertexNode *node = H3_MEMORY(malloc)(sizeof(VertexNode));
     assert(node != NULL);
     _initVertexNode(node, fromVtx, toVtx);
     // Determine location
     uint32_t index = _hashVertex(fromVtx, graph->res, graph->numBuckets);
     // Check whether there's an existing node in that spot
-    VertexNode* currentNode = graph->buckets[index];
+    VertexNode *currentNode = graph->buckets[index];
     if (currentNode == NULL) {
         // Set bucket to the new node
         graph->buckets[index] = node;
@@ -132,10 +132,10 @@ VertexNode* addVertexNode(VertexGraph* graph, const LatLng* fromVtx,
  * @param node  Node to remove
  * @return      0 on success, 1 on failure (node not found)
  */
-int removeVertexNode(VertexGraph* graph, VertexNode* node) {
+int removeVertexNode(VertexGraph *graph, VertexNode *node) {
     // Determine location
     uint32_t index = _hashVertex(&node->from, graph->res, graph->numBuckets);
-    VertexNode* currentNode = graph->buckets[index];
+    VertexNode *currentNode = graph->buckets[index];
     int found = 0;
     if (currentNode != NULL) {
         if (currentNode == node) {
@@ -168,12 +168,12 @@ int removeVertexNode(VertexGraph* graph, VertexNode* node) {
  * @param  toVtx   End vertex, or NULL if we don't care
  * @return         Pointer to the vertex node, if found
  */
-VertexNode* findNodeForEdge(const VertexGraph* graph, const LatLng* fromVtx,
-                            const LatLng* toVtx) {
+VertexNode *findNodeForEdge(const VertexGraph *graph, const LatLng *fromVtx,
+                            const LatLng *toVtx) {
     // Determine location
     uint32_t index = _hashVertex(fromVtx, graph->res, graph->numBuckets);
     // Check whether there's an existing node in that spot
-    VertexNode* node = graph->buckets[index];
+    VertexNode *node = graph->buckets[index];
     if (node != NULL) {
         // Look through the list and see if we find the edge
         do {
@@ -194,7 +194,7 @@ VertexNode* findNodeForEdge(const VertexGraph* graph, const LatLng* fromVtx,
  * @param  fromVtx Start vertex
  * @return         Pointer to the vertex node, if found
  */
-VertexNode* findNodeForVertex(const VertexGraph* graph, const LatLng* fromVtx) {
+VertexNode *findNodeForVertex(const VertexGraph *graph, const LatLng *fromVtx) {
     return findNodeForEdge(graph, fromVtx, NULL);
 }
 
@@ -203,8 +203,8 @@ VertexNode* findNodeForVertex(const VertexGraph* graph, const LatLng* fromVtx) {
  * @param  graph Graph to iterate
  * @return       Vertex node, or NULL if at the end
  */
-VertexNode* firstVertexNode(const VertexGraph* graph) {
-    VertexNode* node = NULL;
+VertexNode *firstVertexNode(const VertexGraph *graph) {
+    VertexNode *node = NULL;
     int currentIndex = 0;
     while (node == NULL) {
         if (currentIndex < graph->numBuckets) {


### PR DESCRIPTION
Fixes #467. There are two commits in this PR, the first has manual changes to `.clang-format` and `CMakeLists.txt`, the other is after running `make format`. It should be possible to verify that by checking out the first commit, reviewing those few changes, and running `make format`.

Also apply [CMP0015](https://cmake.org/cmake/help/latest/policy/CMP0015.html) to opt out of some backwards compatibility in CMake relating to how source files with unrecognized extensions (such as `h3api.h.in`) are handled.