### PR TITLE
Website: Add top level nav

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,9 +22,26 @@ module.exports = {
       },
       items: [
         {
-          to: 'docs/',
-          activeBasePath: 'docs',
-          label: 'Docs',
+          to: 'docs',
+          activeBaseRegex: 'docs(/)$',
+          label: 'Intro',
+          position: 'left',
+        },
+        {
+          to: 'docs/api/indexing',
+          activeBasePath: 'docs/api',
+          label: 'API',
+          position: 'left',
+        },
+        {
+          to: 'docs/community/bindings',
+          activeBasePath: 'docs/community',
+          label: 'Bindings',
+          position: 'left',
+        },
+        {
+          to: 'docs/core-library/restable',
+          label: 'Resolutions',
           position: 'left',
         },
         {


### PR DESCRIPTION
Add top level navigation to the documentation site. One of the most requested pages (don't have analytics to tell us which other ones are highly visited) is the resolution reference table, so that one needs to be top level and easy to access. I guessed about the other ones that would be important to a reader.