### PR TITLE
CMake: fix installation of filters on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,7 +710,7 @@ configure_package_config_file(
 install(
     TARGETS ${INSTALL_TARGETS}
     EXPORT "${TARGETS_EXPORT_NAME}"
-    RUNTIME DESTINATION "bin"
+    DESTINATION "bin"
     COMPONENT h3
 )
 


### PR DESCRIPTION
bundle targets produce a configuration error is they don't have a BUNDLE DESTINATION in install target since https://cmake.org/cmake/help/latest/policy/CMP0006.html.
By removing RUNTIME, we set DESTINATION for all types.