### PR TITLE
Fix potential segfault in gridDisk due to invalid digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The public API of this library consists of the functions declared in file
 
 ## [Unreleased]
 
+### Fixed
+- `gridDisk` of invalid indexes should not crash. (#498)
+
 ### Added
 - Vertex mode and associated functions:
     - `cellToVertex(cell, vertexNum)`

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -360,7 +360,16 @@ SUITE(gridDisk) {
         int k = 1000;
         int kSz = H3_EXPORT(maxGridDiskSize)(k);
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
-        H3_EXPORT(gridDisk)(0x7fffffffffffffff, 1000, neighbors);
+        H3_EXPORT(gridDisk)(0x7fffffffffffffff, k, neighbors);
+        // Assertion is should not crash - should return an error in the future
+        free(neighbors);
+    }
+
+    TEST(gridDiskInvalidDigit) {
+        int k = 2;
+        int kSz = H3_EXPORT(maxGridDiskSize)(k);
+        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
+        H3_EXPORT(gridDisk)(0x4d4b00fe5c5c3030, k, neighbors);
         // Assertion is should not crash - should return an error in the future
         free(neighbors);
     }

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -346,7 +346,10 @@ H3Index h3NeighborRotations(H3Index origin, Direction dir, int *rotations) {
         } else {
             Direction oldDigit = H3_GET_INDEX_DIGIT(out, r + 1);
             Direction nextDir;
-            if (isResolutionClassIII(r + 1)) {
+            if (oldDigit == INVALID_DIGIT) {
+                // Only possible on invalid input
+                return H3_NULL;
+            } else if (isResolutionClassIII(r + 1)) {
                 H3_SET_INDEX_DIGIT(out, r + 1, NEW_DIGIT_II[oldDigit][dir]);
                 nextDir = NEW_ADJUSTMENT_II[oldDigit][dir];
             } else {


### PR DESCRIPTION
h3NeighborRotations would index off the end of the NEW_DIGIT_II table (and others) if the input index had invalid digits in it. This can result in a crash.

Detected via AFL fuzzer and then narrowed down what was happening with UBSan. The segfault itself only reproduces with certain build configurations.