### PR TITLE
Add error return codes to h3Index.c (part 1)

### DIFF
--- a/examples/distance.c
+++ b/examples/distance.c
@@ -48,9 +48,11 @@ double haversineDistance(double th1, double ph1, double th2, double ph2) {
 
 int main(int argc, char *argv[]) {
     // 1455 Market St @ resolution 15
-    H3Index h3HQ1 = stringToH3("8f2830828052d25");
+    H3Index h3HQ1;
+    stringToH3("8f2830828052d25", &h3HQ1);
     // 555 Market St @ resolution 15
-    H3Index h3HQ2 = stringToH3("8f283082a30e623");
+    H3Index h3HQ2;
+    stringToH3("8f283082a30e623", &h2HQ2);
 
     LatLng geoHQ1, geoHQ2;
     cellToLatLng(h3HQ1, &geoHQ1);

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
     stringToH3("8f2830828052d25", &h3HQ1);
     // 555 Market St @ resolution 15
     H3Index h3HQ2;
-    stringToH3("8f283082a30e623", &h2HQ2);
+    stringToH3("8f283082a30e623", &h3HQ2);
 
     LatLng geoHQ1, geoHQ2;
     cellToLatLng(h3HQ1, &geoHQ1);

--- a/src/apps/filters/cellToBoundary.c
+++ b/src/apps/filters/cellToBoundary.c
@@ -103,7 +103,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, kmlArg.found);
         }
     }

--- a/src/apps/filters/cellToLatLng.c
+++ b/src/apps/filters/cellToLatLng.c
@@ -102,7 +102,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, kmlArg.found);
         }
     }

--- a/src/apps/filters/gridDisk.c
+++ b/src/apps/filters/gridDisk.c
@@ -99,7 +99,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, k, printDistancesArg.found);
         }
     }

--- a/src/apps/filters/gridDiskUnsafe.c
+++ b/src/apps/filters/gridDiskUnsafe.c
@@ -91,7 +91,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, k);
         }
     }

--- a/src/apps/filters/h3ToComponents.c
+++ b/src/apps/filters/h3ToComponents.c
@@ -129,7 +129,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, verboseArg.found);
         }
     }

--- a/src/apps/filters/h3ToLocalIj.c
+++ b/src/apps/filters/h3ToLocalIj.c
@@ -89,7 +89,8 @@ int main(int argc, char *argv[]) {
                     error("reading H3 index from stdin");
             }
 
-            H3Index h3 = H3_EXPORT(stringToH3)(buff);
+            H3Index h3;
+            H3_EXPORT(stringToH3)(buff, &h3);
             doCell(h3, origin);
         }
     }

--- a/src/apps/testapps/testCellToBoundary.c
+++ b/src/apps/testapps/testCellToBoundary.c
@@ -110,7 +110,8 @@ int main(int argc, char *argv[]) {
                 error("reading input H3 index from stdin");
         }
 
-        H3Index h3 = H3_EXPORT(stringToH3)(buff);
+        H3Index h3;
+        t_assertSuccess(H3_EXPORT(stringToH3)(buff, &h3));
 
         CellBoundary b;
         readBoundary(stdin, &b);

--- a/src/apps/testapps/testCellToCenterChild.c
+++ b/src/apps/testapps/testCellToCenterChild.c
@@ -47,8 +47,11 @@ SUITE(cellToCenterChild) {
                     "resolution");
                 t_assert(H3_EXPORT(getResolution)(centerChild) == childRes,
                          "center child should have correct resolution");
+                H3Index parent;
+                t_assertSuccess(
+                    H3_EXPORT(cellToParent)(centerChild, res, &parent));
                 t_assert(
-                    H3_EXPORT(cellToParent)(centerChild, res) == h3Index,
+                    parent == h3Index,
                     "parent at original resolution should be initial index");
             }
         }

--- a/src/apps/testapps/testCellToChildren.c
+++ b/src/apps/testapps/testCellToChildren.c
@@ -63,11 +63,17 @@ static void assertSetsEqual(H3Index *set1, int len1, H3Index *set2, int len2) {
     assertSubset(set2, len2, set1, len1);
 }
 
-static void checkChildren(H3Index h, int res, H3Index *expected,
-                          int numExpected) {
-    int64_t numChildren = H3_EXPORT(cellToChildrenSize)(h, res);
+static void checkChildren(H3Index h, int res, H3Error expectedError,
+                          H3Index *expected, int numExpected) {
+    int64_t numChildren;
+    H3Error numChildrenError =
+        H3_EXPORT(cellToChildrenSize)(h, res, &numChildren);
+    t_assert(numChildrenError == expectedError, "Expected error code");
+    if (expectedError != E_SUCCESS) {
+        return;
+    }
     H3Index *children = calloc(numChildren, sizeof(H3Index));
-    H3_EXPORT(cellToChildren)(h, res, children);
+    t_assertSuccess(H3_EXPORT(cellToChildren)(h, res, children));
 
     assertSetsEqual(children, numChildren, expected, numExpected);
 
@@ -84,7 +90,8 @@ SUITE(cellToChildren_new) {
                               0x89283080dd3ffff, 0x89283080dd7ffff,
                               0x89283080ddbffff};
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_SUCCESS, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 
     TEST(multipleResSteps) {
@@ -110,7 +117,8 @@ SUITE(cellToChildren_new) {
             0x8a283080dc1ffff, 0x8a283080dd0ffff, 0x8a283080dc2ffff,
             0x8a283080dd67fff};
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_SUCCESS, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 
     TEST(sameRes) {
@@ -119,7 +127,8 @@ SUITE(cellToChildren_new) {
 
         H3Index expected[] = {h};
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_SUCCESS, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 
     TEST(childResTooCoarse) {
@@ -128,7 +137,8 @@ SUITE(cellToChildren_new) {
 
         H3Index expected[] = {0};  // empty set; zeros are ignored
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_RES_DOMAIN, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 
     TEST(childResTooFine) {
@@ -137,7 +147,8 @@ SUITE(cellToChildren_new) {
 
         H3Index expected[] = {0};  // empty set; zeros are ignored
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_RES_DOMAIN, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 
     TEST(pentagonChildren) {
@@ -160,6 +171,7 @@ SUITE(cellToChildren_new) {
             0x830832fffffffff, 0x830833fffffffff, 0x830834fffffffff,
             0x830835fffffffff, 0x830836fffffffff};
 
-        checkChildren(h, res, expected, sizeof(expected) / sizeof(H3Index));
+        checkChildren(h, res, E_SUCCESS, expected,
+                      sizeof(expected) / sizeof(H3Index));
     }
 }

--- a/src/apps/testapps/testCellToChildrenSize.c
+++ b/src/apps/testapps/testCellToChildrenSize.c
@@ -23,33 +23,37 @@ SUITE(cellToChildrenSize) {
     TEST(cellToChildrenSize_hexagon) {
         H3Index h = 0x87283080dffffff;  // res 7 *hexagon*
 
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 3) == 0,
+        int64_t sz;
+        t_assert(H3_EXPORT(cellToChildrenSize)(h, 3, &sz) == E_RES_DOMAIN,
                  "got expected size for coarser res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 7) == 1,
-                 "got expected size for same res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 8) == 7,
-                 "got expected size for child res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 9) == 7 * 7,
-                 "got expected size for grandchild res");
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 7, &sz));
+        t_assert(sz == 1, "got expected size for same res");
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 8, &sz));
+        t_assert(sz == 7, "got expected size for child res");
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 9, &sz));
+        t_assert(sz == 7 * 7, "got expected size for grandchild res");
     }
 
     TEST(cellToChildrenSize_pentagon) {
         H3Index h = 0x870800000ffffff;  // res 7 *pentagon*
 
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 3) == 0,
+        int64_t sz;
+        t_assert(H3_EXPORT(cellToChildrenSize)(h, 3, &sz) == E_RES_DOMAIN,
                  "got expected size for coarser res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 7) == 1,
-                 "got expected size for same res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 8) == 6,
-                 "got expected size for child res");
-        t_assert(H3_EXPORT(cellToChildrenSize)(h, 9) == (5 * 7) + (1 * 6),
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 7, &sz));
+        t_assert(sz == 1, "got expected size for same res");
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 8, &sz));
+        t_assert(sz == 6, "got expected size for child res");
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 9, &sz));
+        t_assert(sz == (5 * 7) + (1 * 6),
                  "got expected size for grandchild res");
     }
 
     TEST(cellToChildrenSize_largest_hexagon) {
         H3Index h = 0x806dfffffffffff;      // res 0 *hexagon*
         int64_t expected = 4747561509943L;  // 7^15
-        int64_t out = H3_EXPORT(cellToChildrenSize)(h, 15);
+        int64_t out;
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 15, &out));
 
         t_assert(out == expected,
                  "got right size for children 15 levels below");
@@ -58,7 +62,8 @@ SUITE(cellToChildrenSize) {
     TEST(cellToChildrenSize_largest_pentagon) {
         H3Index h = 0x8009fffffffffff;      // res 0 *pentagon*
         int64_t expected = 3956301258286L;  // 1 + 5*(7^15 - 1)/6
-        int64_t out = H3_EXPORT(cellToChildrenSize)(h, 15);
+        int64_t out;
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h, 15, &out));
 
         t_assert(out == expected,
                  "got right size for children 15 levels below");

--- a/src/apps/testapps/testCellToLatLng.c
+++ b/src/apps/testapps/testCellToLatLng.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
             error("parsing input (should be \"H3Index lat lng\")");
 
         H3Index h3;
-        h3 = H3_EXPORT(stringToH3)(h3Str);
+        t_assertSuccess(H3_EXPORT(stringToH3)(h3Str, &h3));
 
         LatLng coord;
         setGeoDegs(&coord, latDegs, lngDegs);

--- a/src/apps/testapps/testCellToParent.c
+++ b/src/apps/testapps/testCellToParent.c
@@ -30,7 +30,8 @@ SUITE(cellToParent) {
         for (int res = 1; res < 15; res++) {
             for (int step = 0; step < res; step++) {
                 t_assertSuccess(H3_EXPORT(latLngToCell)(&sf, res, &child));
-                parent = H3_EXPORT(cellToParent)(child, res - step);
+                t_assertSuccess(
+                    H3_EXPORT(cellToParent)(child, res - step, &parent));
                 t_assertSuccess(H3_EXPORT(latLngToCell)(&sf, res - step,
                                                         &comparisonParent));
 
@@ -43,13 +44,14 @@ SUITE(cellToParent) {
         H3Index child;
         t_assertSuccess(H3_EXPORT(latLngToCell)(&sf, 5, &child));
 
-        t_assert(H3_EXPORT(cellToParent)(child, 6) == 0,
+        H3Index parent;
+        t_assert(H3_EXPORT(cellToParent)(child, 6, &parent) == E_RES_MISMATCH,
                  "Higher resolution fails");
-        t_assert(H3_EXPORT(cellToParent)(child, -1) == 0,
+        t_assert(H3_EXPORT(cellToParent)(child, -1, &parent) == E_RES_DOMAIN,
                  "Invalid resolution fails");
-        t_assert(H3_EXPORT(cellToParent)(child, 15) == 0,
+        t_assert(H3_EXPORT(cellToParent)(child, 15, &parent) == E_RES_MISMATCH,
                  "Invalid resolution fails");
-        t_assert(H3_EXPORT(cellToParent)(child, 16) == 0,
+        t_assert(H3_EXPORT(cellToParent)(child, 16, &parent) == E_RES_DOMAIN,
                  "Invalid resolution fails");
     }
 }

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -163,10 +163,12 @@ SUITE(compactCells) {
         // Arbitrary index
         setH3Index(&h3, res, 0, 2);
 
-        int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1) + 1;
+        int64_t arrSize;
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h3, res + 1, &arrSize));
+        arrSize++;
         H3Index *children = calloc(arrSize, sizeof(H3Index));
 
-        H3_EXPORT(cellToChildren)(h3, res + 1, children);
+        t_assertSuccess(H3_EXPORT(cellToChildren)(h3, res + 1, children));
         // duplicate one index
         children[arrSize - 1] = children[0];
 
@@ -188,10 +190,12 @@ SUITE(compactCells) {
         // Arbitrary pentagon parent cell
         setH3Index(&h3, res, 4, 0);
 
-        int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1) + 1;
+        int64_t arrSize;
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h3, res + 1, &arrSize));
+        arrSize++;
         H3Index *children = calloc(arrSize, sizeof(H3Index));
 
-        H3_EXPORT(cellToChildren)(h3, res + 1, children);
+        t_assertSuccess(H3_EXPORT(cellToChildren)(h3, res + 1, children));
         // duplicate one index
         children[arrSize - 1] = H3_EXPORT(cellToCenterChild)(h3, res + 1);
 
@@ -215,10 +219,11 @@ SUITE(compactCells) {
         // Arbitrary index
         setH3Index(&h3, res, 0, 2);
 
-        int64_t arrSize = H3_EXPORT(cellToChildrenSize)(h3, res + 1);
+        int64_t arrSize;
+        t_assertSuccess(H3_EXPORT(cellToChildrenSize)(h3, res + 1, &arrSize));
         H3Index *children = calloc(arrSize, sizeof(H3Index));
 
-        H3_EXPORT(cellToChildren)(h3, res + 1, children);
+        t_assertSuccess(H3_EXPORT(cellToChildren)(h3, res + 1, children));
         // duplicate one index
         children[arrSize - 1] = children[0];
 

--- a/src/apps/testapps/testDirectedEdge.c
+++ b/src/apps/testapps/testDirectedEdge.c
@@ -131,7 +131,7 @@ SUITE(directedEdge) {
         H3Index edge;
 
         for (int res = 0; res < MAX_H3_RES; res++) {
-            H3_EXPORT(getPentagons)(res, pentagons);
+            t_assertSuccess(H3_EXPORT(getPentagons)(res, pentagons));
             for (int p = 0; p < NUM_PENTAGONS; p++) {
                 pentagon = pentagons[p];
                 H3_EXPORT(gridDisk)(pentagon, 1, ring);

--- a/src/apps/testapps/testGetIcosahedronFaces.c
+++ b/src/apps/testapps/testGetIcosahedronFaces.c
@@ -27,11 +27,12 @@
 #include "utility.h"
 
 static int countFaces(H3Index h3, int expectedMax) {
-    int sz = H3_EXPORT(maxFaceCount)(h3);
+    int sz;
+    t_assertSuccess(H3_EXPORT(maxFaceCount)(h3, &sz));
     t_assert(sz == expectedMax, "got expected max face count");
     int *faces = calloc(sz, sizeof(int));
 
-    H3_EXPORT(getIcosahedronFaces)(h3, faces);
+    t_assertSuccess(H3_EXPORT(getIcosahedronFaces)(h3, faces));
 
     int validCount = 0;
     for (int i = 0; i < sz; i++) {

--- a/src/apps/testapps/testH3Api.c
+++ b/src/apps/testapps/testH3Api.c
@@ -63,7 +63,7 @@ SUITE(h3Api) {
         H3Index h3;
         CellBoundary b;
         for (int i = 0; i < numHexes; i++) {
-            h3 = H3_EXPORT(stringToH3)(hexes[i]);
+            t_assertSuccess(H3_EXPORT(stringToH3)(hexes[i], &h3));
             H3_EXPORT(cellToBoundary)(h3, &b);
             t_assert(b.numVerts == 7, "got expected vertex count");
         }
@@ -71,7 +71,8 @@ SUITE(h3Api) {
 
     TEST(cellToBoundary_classIIIEdgeVertex_exact) {
         // Bug test for https://github.com/uber/h3/issues/45
-        H3Index h3 = H3_EXPORT(stringToH3)("894cc536537ffff");
+        H3Index h3;
+        t_assertSuccess(H3_EXPORT(stringToH3)("894cc536537ffff", &h3));
         CellBoundary boundary;
         boundary.numVerts = 7;
         setGeoDegs(&boundary.verts[0], 18.043333154, -66.27836523500002);

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -185,7 +185,7 @@ SUITE(h3Index) {
         t_assert(H3_EXPORT(stringToH3)("", &h3) == E_FAILED,
                  "no index from nothing");
         t_assert(H3_EXPORT(stringToH3)("**", &h3) == E_FAILED,
-                 "got an index from junk");
+                 "no index from junk");
         t_assertSuccess(H3_EXPORT(stringToH3)("ffffffffffffffff", &h3));
         t_assert(h3 == 0xffffffffffffffff, "failed on large input");
     }

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -183,7 +183,7 @@ SUITE(h3Index) {
     TEST(stringToH3) {
         H3Index h3;
         t_assert(H3_EXPORT(stringToH3)("", &h3) == E_FAILED,
-                 "got an index from nothing");
+                 "no index from nothing");
         t_assert(H3_EXPORT(stringToH3)("**", &h3) == E_FAILED,
                  "got an index from junk");
         t_assertSuccess(H3_EXPORT(stringToH3)("ffffffffffffffff", &h3));

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -187,7 +187,7 @@ SUITE(h3Index) {
         t_assert(H3_EXPORT(stringToH3)("**", &h3) == E_FAILED,
                  "no index from junk");
         t_assertSuccess(H3_EXPORT(stringToH3)("ffffffffffffffff", &h3));
-        t_assert(h3 == 0xffffffffffffffff, "failed on large input");
+        t_assert(h3 == 0xffffffffffffffff, "got expected on large input");
     }
 
     TEST(setH3Index) {

--- a/src/apps/testapps/testH3Index.c
+++ b/src/apps/testapps/testH3Index.c
@@ -168,24 +168,26 @@ SUITE(h3Index) {
     TEST(h3ToString) {
         const size_t bufSz = 17;
         char buf[17] = {0};
-        H3_EXPORT(h3ToString)(0x1234, buf, bufSz - 1);
-        // Buffer should be unmodified because the size was too small
-        t_assert(buf[0] == 0, "h3ToString failed on buffer too small");
-        H3_EXPORT(h3ToString)(0xcafe, buf, bufSz);
+        t_assert(
+            H3_EXPORT(h3ToString)(0x1234, buf, bufSz - 1) == E_MEMORY_BOUNDS,
+            "h3ToString failed on buffer too small");
+        t_assertSuccess(H3_EXPORT(h3ToString)(0xcafe, buf, bufSz));
         t_assert(strcmp(buf, "cafe") == 0,
                  "h3ToString failed to produce base 16 results");
-        H3_EXPORT(h3ToString)(0xffffffffffffffff, buf, bufSz);
+        t_assertSuccess(H3_EXPORT(h3ToString)(0xffffffffffffffff, buf, bufSz));
         t_assert(strcmp(buf, "ffffffffffffffff") == 0,
                  "h3ToString failed on large input");
         t_assert(buf[bufSz - 1] == 0, "didn't null terminate");
     }
 
     TEST(stringToH3) {
-        t_assert(H3_EXPORT(stringToH3)("") == 0, "got an index from nothing");
-        t_assert(H3_EXPORT(stringToH3)("**") == 0, "got an index from junk");
-        t_assert(
-            H3_EXPORT(stringToH3)("ffffffffffffffff") == 0xffffffffffffffff,
-            "failed on large input");
+        H3Index h3;
+        t_assert(H3_EXPORT(stringToH3)("", &h3) == E_FAILED,
+                 "got an index from nothing");
+        t_assert(H3_EXPORT(stringToH3)("**", &h3) == E_FAILED,
+                 "got an index from junk");
+        t_assertSuccess(H3_EXPORT(stringToH3)("ffffffffffffffff", &h3));
+        t_assert(h3 == 0xffffffffffffffff, "failed on large input");
     }
 
     TEST(setH3Index) {

--- a/src/apps/testapps/testLatLngToCell.c
+++ b/src/apps/testapps/testLatLngToCell.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
             error("parsing input (should be \"H3Index lat lng\")");
 
         H3Index h3;
-        h3 = H3_EXPORT(stringToH3)(h3Str);
+        t_assertSuccess(H3_EXPORT(stringToH3)(h3Str, &h3));
 
         LatLng coord;
         setGeoDegs(&coord, latDegs, lngDegs);

--- a/src/apps/testapps/testPentagonIndexes.c
+++ b/src/apps/testapps/testPentagonIndexes.c
@@ -27,7 +27,7 @@ SUITE(getPentagons) {
 
         for (int res = 0; res <= 15; res++) {
             H3Index h3Indexes[PADDED_COUNT] = {0};
-            H3_EXPORT(getPentagons)(res, h3Indexes);
+            t_assertSuccess(H3_EXPORT(getPentagons)(res, h3Indexes));
 
             int numFound = 0;
 

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -84,9 +84,11 @@ static void fillIndex_assertions(H3Index h) {
         int polygonToCellsCount =
             countNonNullIndexes(polygonToCellsOut, polygonToCellsSize);
 
-        int64_t childrenSize = H3_EXPORT(cellToChildrenSize)(h, nextRes);
+        int64_t childrenSize;
+        t_assertSuccess(
+            H3_EXPORT(cellToChildrenSize)(h, nextRes, &childrenSize));
         H3Index *children = calloc(childrenSize, sizeof(H3Index));
-        H3_EXPORT(cellToChildren)(h, nextRes, children);
+        t_assertSuccess(H3_EXPORT(cellToChildren)(h, nextRes, children));
 
         int cellToChildrenCount = countNonNullIndexes(children, childrenSize);
 

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -444,7 +444,7 @@ DECLSPEC void H3_EXPORT(getRes0Cells)(H3Index *out);
 DECLSPEC int H3_EXPORT(pentagonCount)();
 
 /** @brief generates all pentagons at the specified resolution */
-DECLSPEC void H3_EXPORT(getPentagons)(int res, H3Index *out);
+DECLSPEC H3Error H3_EXPORT(getPentagons)(int res, H3Index *out);
 /** @} */
 
 /** @defgroup getResolution getResolution
@@ -472,7 +472,7 @@ DECLSPEC int H3_EXPORT(getBaseCellNumber)(H3Index h);
  * @{
  */
 /** @brief converts the canonical string format to H3Index format */
-DECLSPEC H3Index H3_EXPORT(stringToH3)(const char *str);
+DECLSPEC H3Error H3_EXPORT(stringToH3)(const char *str, H3Index *out);
 /** @} */
 
 /** @defgroup h3ToString h3ToString
@@ -480,7 +480,7 @@ DECLSPEC H3Index H3_EXPORT(stringToH3)(const char *str);
  * @{
  */
 /** @brief converts an H3Index to a canonical string */
-DECLSPEC void H3_EXPORT(h3ToString)(H3Index h, char *str, size_t sz);
+DECLSPEC H3Error H3_EXPORT(h3ToString)(H3Index h, char *str, size_t sz);
 /** @} */
 
 /** @defgroup isValidCell isValidCell
@@ -499,7 +499,8 @@ DECLSPEC int H3_EXPORT(isValidCell)(H3Index h);
  */
 /** @brief returns the parent (or grandparent, etc) cell of the given cell
  */
-DECLSPEC H3Index H3_EXPORT(cellToParent)(H3Index h, int parentRes);
+DECLSPEC H3Error H3_EXPORT(cellToParent)(H3Index h, int parentRes,
+                                         H3Index *parent);
 /** @} */
 
 /** @defgroup cellToChildren cellToChildren
@@ -508,11 +509,12 @@ DECLSPEC H3Index H3_EXPORT(cellToParent)(H3Index h, int parentRes);
  */
 /** @brief determines the exact number of children (or grandchildren, etc)
  * that would be returned for the given cell */
-DECLSPEC int64_t H3_EXPORT(cellToChildrenSize)(H3Index h, int childRes);
+DECLSPEC H3Error H3_EXPORT(cellToChildrenSize)(H3Index h, int childRes,
+                                               int64_t *out);
 
 /** @brief provides the children (or grandchildren, etc) of the given cell */
-DECLSPEC void H3_EXPORT(cellToChildren)(H3Index h, int childRes,
-                                        H3Index *children);
+DECLSPEC H3Error H3_EXPORT(cellToChildren)(H3Index h, int childRes,
+                                           H3Index *children);
 /** @} */
 
 /** @defgroup cellToCenterChild cellToCenterChild
@@ -572,10 +574,10 @@ DECLSPEC int H3_EXPORT(isPentagon)(H3Index h);
  * @{
  */
 /** @brief Max number of icosahedron faces intersected by an index */
-DECLSPEC int H3_EXPORT(maxFaceCount)(H3Index h3);
+DECLSPEC H3Error H3_EXPORT(maxFaceCount)(H3Index h3, int *out);
 
 /** @brief Find all icosahedron faces intersected by a given H3 index */
-DECLSPEC void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out);
+DECLSPEC H3Error H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out);
 /** @} */
 
 /** @defgroup areNeighborCells areNeighborCells

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -100,6 +100,7 @@ double _hexRadiusKm(H3Index h3Index) {
 int bboxHexEstimate(const BBox *bbox, int res) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
+    // TODO: Return error here
     H3_EXPORT(getPentagons)(res, pentagons);
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
     // Area of a regular hexagon is 3/2*sqrt(3) * r * r
@@ -139,6 +140,7 @@ int bboxHexEstimate(const BBox *bbox, int res) {
 int lineHexEstimate(const LatLng *origin, const LatLng *destination, int res) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
+    // TODO: Return error here
     H3_EXPORT(getPentagons)(res, pentagons);
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
 

--- a/src/h3lib/lib/directedEdge.c
+++ b/src/h3lib/lib/directedEdge.c
@@ -56,27 +56,34 @@ int H3_EXPORT(areNeighborCells)(H3Index origin, H3Index destination) {
     // of origin and destination parents and then a lookup table of the children
     // is a super-cheap way to possibly determine they are neighbors.
     int parentRes = H3_GET_RESOLUTION(origin) - 1;
-    if (parentRes > 0 && (H3_EXPORT(cellToParent)(origin, parentRes) ==
-                          H3_EXPORT(cellToParent)(destination, parentRes))) {
-        Direction originResDigit = H3_GET_INDEX_DIGIT(origin, parentRes + 1);
-        Direction destinationResDigit =
-            H3_GET_INDEX_DIGIT(destination, parentRes + 1);
-        if (originResDigit == CENTER_DIGIT ||
-            destinationResDigit == CENTER_DIGIT) {
-            return 1;
-        }
-        // These sets are the relevant neighbors in the clockwise
-        // and counter-clockwise
-        const Direction neighborSetClockwise[] = {
-            CENTER_DIGIT,  JK_AXES_DIGIT, IJ_AXES_DIGIT, J_AXES_DIGIT,
-            IK_AXES_DIGIT, K_AXES_DIGIT,  I_AXES_DIGIT};
-        const Direction neighborSetCounterclockwise[] = {
-            CENTER_DIGIT,  IK_AXES_DIGIT, JK_AXES_DIGIT, K_AXES_DIGIT,
-            IJ_AXES_DIGIT, I_AXES_DIGIT,  J_AXES_DIGIT};
-        if (neighborSetClockwise[originResDigit] == destinationResDigit ||
-            neighborSetCounterclockwise[originResDigit] ==
-                destinationResDigit) {
-            return 1;
+    if (parentRes > 0) {
+        // TODO: Return error codes here
+        H3Index originParent;
+        H3_EXPORT(cellToParent)(origin, parentRes, &originParent);
+        H3Index destinationParent;
+        H3_EXPORT(cellToParent)(destination, parentRes, &destinationParent);
+        if (originParent == destinationParent) {
+            Direction originResDigit =
+                H3_GET_INDEX_DIGIT(origin, parentRes + 1);
+            Direction destinationResDigit =
+                H3_GET_INDEX_DIGIT(destination, parentRes + 1);
+            if (originResDigit == CENTER_DIGIT ||
+                destinationResDigit == CENTER_DIGIT) {
+                return 1;
+            }
+            // These sets are the relevant neighbors in the clockwise
+            // and counter-clockwise
+            const Direction neighborSetClockwise[] = {
+                CENTER_DIGIT,  JK_AXES_DIGIT, IJ_AXES_DIGIT, J_AXES_DIGIT,
+                IK_AXES_DIGIT, K_AXES_DIGIT,  I_AXES_DIGIT};
+            const Direction neighborSetCounterclockwise[] = {
+                CENTER_DIGIT,  IK_AXES_DIGIT, JK_AXES_DIGIT, K_AXES_DIGIT,
+                IJ_AXES_DIGIT, I_AXES_DIGIT,  J_AXES_DIGIT};
+            if (neighborSetClockwise[originResDigit] == destinationResDigit ||
+                neighborSetCounterclockwise[originResDigit] ==
+                    destinationResDigit) {
+                return 1;
+            }
         }
     }
 

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -55,11 +55,15 @@ int H3_EXPORT(getBaseCellNumber)(H3Index h) { return H3_GET_BASE_CELL(h); }
  * @return The H3 index corresponding to the string argument, or H3_NULL if
  * invalid.
  */
-H3Index H3_EXPORT(stringToH3)(const char *str) {
+H3Error H3_EXPORT(stringToH3)(const char *str, H3Index *out) {
     H3Index h = H3_NULL;
     // If failed, h will be unmodified and we should return H3_NULL anyways.
-    sscanf(str, "%" PRIx64, &h);
-    return h;
+    int read = sscanf(str, "%" PRIx64, &h);
+    if (read != 1) {
+        return E_FAILED;
+    }
+    *out = h;
+    return E_SUCCESS;
 }
 
 /**
@@ -68,14 +72,15 @@ H3Index H3_EXPORT(stringToH3)(const char *str) {
  * @param str The string representation of the H3 index.
  * @param sz Size of the buffer `str`
  */
-void H3_EXPORT(h3ToString)(H3Index h, char *str, size_t sz) {
+H3Error H3_EXPORT(h3ToString)(H3Index h, char *str, size_t sz) {
     // An unsigned 64 bit integer will be expressed in at most
     // 16 digits plus 1 for the null terminator.
     if (sz < 17) {
         // Buffer is potentially not large enough.
-        return;
+        return E_MEMORY_BOUNDS;
     }
     sprintf(str, "%" PRIx64, h);
+    return E_SUCCESS;
 }
 
 /**
@@ -148,20 +153,22 @@ void setH3Index(H3Index *hp, int res, int baseCell, Direction initDigit) {
  *
  * @return H3Index of the parent, or H3_NULL if you actually asked for a child
  */
-H3Index H3_EXPORT(cellToParent)(H3Index h, int parentRes) {
+H3Error H3_EXPORT(cellToParent)(H3Index h, int parentRes, H3Index *out) {
     int childRes = H3_GET_RESOLUTION(h);
     if (parentRes < 0 || parentRes > MAX_H3_RES) {
-        return H3_NULL;
+        return E_RES_DOMAIN;
     } else if (parentRes > childRes) {
-        return H3_NULL;
+        return E_RES_MISMATCH;
     } else if (parentRes == childRes) {
-        return h;
+        *out = h;
+        return E_SUCCESS;
     }
     H3Index parentH = H3_SET_RESOLUTION(h, parentRes);
     for (int i = parentRes + 1; i <= childRes; i++) {
         H3_SET_INDEX_DIGIT(parentH, i, H3_DIGIT_MASK);
     }
-    return parentH;
+    *out = parentH;
+    return E_SUCCESS;
 }
 
 /**
@@ -191,16 +198,17 @@ static bool _hasChildAtRes(H3Index h, int childRes) {
  * @return int      Exact number of children (handles hexagons and pentagons
  *                  correctly)
  */
-int64_t H3_EXPORT(cellToChildrenSize)(H3Index h, int childRes) {
-    if (!_hasChildAtRes(h, childRes)) return 0;
+H3Error H3_EXPORT(cellToChildrenSize)(H3Index h, int childRes, int64_t *out) {
+    if (!_hasChildAtRes(h, childRes)) return E_RES_DOMAIN;
 
     int n = childRes - H3_GET_RESOLUTION(h);
 
     if (H3_EXPORT(isPentagon)(h)) {
-        return 1 + 5 * (_ipow(7, n) - 1) / 6;
+        *out = 1 + 5 * (_ipow(7, n) - 1) / 6;
     } else {
-        return _ipow(7, n);
+        *out = _ipow(7, n);
     }
+    return E_SUCCESS;
 }
 
 /**
@@ -229,13 +237,14 @@ H3Index makeDirectChild(H3Index h, int cellNumber) {
  * @param childRes int the child level to produce
  * @param children H3Index* the memory to store the resulting addresses in
  */
-void H3_EXPORT(cellToChildren)(H3Index h, int childRes, H3Index *children) {
+H3Error H3_EXPORT(cellToChildren)(H3Index h, int childRes, H3Index *children) {
     int64_t i = 0;
     for (IterCellsChildren iter = iterInitParent(h, childRes); iter.h;
          iterStepChild(&iter)) {
         children[i] = iter.h;
         i++;
     }
+    return E_SUCCESS;
 }
 
 /**
@@ -321,7 +330,16 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
         for (int i = 0; i < numRemainingHexes; i++) {
             H3Index currIndex = remainingHexes[i];
             if (currIndex != 0) {
-                H3Index parent = H3_EXPORT(cellToParent)(currIndex, parentRes);
+                H3Index parent;
+                H3Error parentError =
+                    H3_EXPORT(cellToParent)(currIndex, parentRes, &parent);
+                // LCOV_EXCL_START
+                // Should never be reachable as a result of the compact
+                // algorithm.
+                if (parentError) {
+                    return parentError;
+                }
+                // LCOV_EXCL_STOP
                 // Modulus hash the parent into the temp array
                 int loc = (int)(parent % numRemainingHexes);
                 int loopCount = 0;
@@ -407,7 +425,16 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
         for (int i = 0; i < numRemainingHexes; i++) {
             H3Index currIndex = remainingHexes[i];
             if (currIndex != H3_NULL) {
-                H3Index parent = H3_EXPORT(cellToParent)(currIndex, parentRes);
+                H3Index parent;
+                H3Error parentError =
+                    H3_EXPORT(cellToParent)(currIndex, parentRes, &parent);
+                // LCOV_EXCL_START
+                // Should never be reachable as a result of the compact
+                // algorithm.
+                if (parentError) {
+                    return parentError;
+                }
+                // LCOV_EXCL_STOP
                 // Modulus hash the parent into the temp array
                 // to determine if this index was included in
                 // the compactableHexes array
@@ -504,10 +531,15 @@ H3Error H3_EXPORT(uncompactCellsSize)(const H3Index *compactedSet,
     int64_t numOut = 0;
     for (int64_t i = 0; i < numCompacted; i++) {
         if (compactedSet[i] == H3_NULL) continue;
-        if (!_hasChildAtRes(compactedSet[i], res))
-            return E_RES_MISMATCH;  // Abort
 
-        numOut += H3_EXPORT(cellToChildrenSize)(compactedSet[i], res);
+        int64_t childrenSize;
+        H3Error childrenError =
+            H3_EXPORT(cellToChildrenSize)(compactedSet[i], res, &childrenSize);
+        if (childrenError) {
+            // The parent res does not contain `res`.
+            return E_RES_MISMATCH;
+        }
+        numOut += childrenSize;
     }
     *out = numOut;
     return E_SUCCESS;
@@ -876,10 +908,11 @@ H3Error H3_EXPORT(cellToBoundary)(H3Index h3, CellBoundary *cb) {
  *
  * @return int count of faces
  */
-int H3_EXPORT(maxFaceCount)(H3Index h3) {
+H3Error H3_EXPORT(maxFaceCount)(H3Index h3, int *out) {
     // a pentagon always intersects 5 faces, a hexagon never intersects more
     // than 2 (but may only intersect 1)
-    return H3_EXPORT(isPentagon)(h3) ? 5 : 2;
+    *out = H3_EXPORT(isPentagon)(h3) ? 5 : 2;
+    return E_SUCCESS;
 }
 
 /**
@@ -891,7 +924,7 @@ int H3_EXPORT(maxFaceCount)(H3Index h3) {
  * @param h3 The H3 index
  * @param out Output array. Must be of size maxFaceCount(h3).
  */
-void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
+H3Error H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
     int res = H3_GET_RESOLUTION(h3);
     int isPent = H3_EXPORT(isPentagon)(h3);
 
@@ -902,8 +935,7 @@ void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
         // Note that this would not work for res 15, but this is only run on
         // Class II pentagons, it should never be invoked for a res 15 index.
         H3Index childPentagon = makeDirectChild(h3, 0);
-        H3_EXPORT(getIcosahedronFaces)(childPentagon, out);
-        return;
+        return H3_EXPORT(getIcosahedronFaces)(childPentagon, out);
     }
 
     // convert to FaceIJK
@@ -925,7 +957,11 @@ void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
 
     // We may not use all of the slots in the output array,
     // so fill with invalid values to indicate unused slots
-    int faceCount = H3_EXPORT(maxFaceCount)(h3);
+    int faceCount;
+    H3Error maxFaceCountError = H3_EXPORT(maxFaceCount)(h3, &faceCount);
+    if (maxFaceCountError != E_SUCCESS) {
+        return maxFaceCountError;
+    }
     for (int i = 0; i < faceCount; i++) {
         out[i] = INVALID_FACE;
     }
@@ -950,6 +986,7 @@ void H3_EXPORT(getIcosahedronFaces)(H3Index h3, int *out) {
         while (out[pos] != INVALID_FACE && out[pos] != face) pos++;
         out[pos] = face;
     }
+    return E_SUCCESS;
 }
 
 /**
@@ -965,7 +1002,10 @@ int H3_EXPORT(pentagonCount)() { return NUM_PENTAGONS; }
  * @param res The resolution to produce pentagons at.
  * @param out Output array. Must be of size pentagonCount().
  */
-void H3_EXPORT(getPentagons)(int res, H3Index *out) {
+H3Error H3_EXPORT(getPentagons)(int res, H3Index *out) {
+    if (res < 0 || res > MAX_H3_RES) {
+        return E_RES_DOMAIN;
+    }
     int i = 0;
     for (int bc = 0; bc < NUM_BASE_CELLS; bc++) {
         if (_isBaseCellPentagon(bc)) {
@@ -974,6 +1014,7 @@ void H3_EXPORT(getPentagons)(int res, H3Index *out) {
             out[i++] = pentagon;
         }
     }
+    return E_SUCCESS;
 }
 
 /**

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -25,7 +25,7 @@ These functions permit moving between resolutions in the H3 grid system. The fun
 <TabItem value="c">
 
 ```c
-H3Index cellToParent(H3Index cell, int parentRes);
+H3Error cellToParent(H3Index cell, int parentRes, H3Index *parent);
 ```
 
 </TabItem>
@@ -60,7 +60,9 @@ function example() {
 </TabItem>
 </Tabs>
 
-Returns the parent (coarser) index containing `cell`.
+Provides the parent (coarser) index containing `cell`.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToChildren
 
@@ -77,7 +79,7 @@ Returns the parent (coarser) index containing `cell`.
 <TabItem value="c">
 
 ```c
-void cellToChildren(H3Index cell, int childRes, H3Index *children);
+H3Error cellToChildren(H3Index cell, int childRes, H3Index *children);
 ```
 
 </TabItem>
@@ -114,6 +116,8 @@ function example() {
 
 Populates `children` with the indexes contained by `cell` at resolution `childRes`. `children` must be an array of at least size `cellToChildrenSize(cell, childRes)`.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 ## cellToChildrenSize
 
 <Tabs
@@ -129,7 +133,7 @@ Populates `children` with the indexes contained by `cell` at resolution `childRe
 <TabItem value="c">
 
 ```c
-int64_t cellToChildrenSize(H3Index cell, int childRes);
+H3Error cellToChildrenSize(H3Index cell, int childRes, int64_t *out);
 ```
 
 </TabItem>
@@ -162,7 +166,9 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Returns the size of the `children` array needed for the given inputs to `cellToChildren`.
+Provides the size of the `children` array needed for the given inputs to `cellToChildren`.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToCenterChild
 

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -129,7 +129,7 @@ Returns the base cell number of the index.
 <TabItem value="c">
 
 ```c
-H3Index stringToH3(const char *str);
+H3Error stringToH3(const char *str, H3Index *out);
 ```
 
 </TabItem>
@@ -156,7 +156,7 @@ The H3 JavaScript binding supports only the string representation of an H3 index
 
 Converts the string representation to `H3Index` (`uint64_t`) representation.
 
-Returns 0 on error.
+Returns 0 (`E_SUCCESS`) on success.
 
 ## h3ToString
 
@@ -173,7 +173,7 @@ Returns 0 on error.
 <TabItem value="c">
 
 ```c
-void h3ToString(H3Index h, char *str, size_t sz);
+H3Error h3ToString(H3Index h, char *str, size_t sz);
 ```
 
 </TabItem>
@@ -199,6 +199,8 @@ The H3 JavaScript binding supports only the string representation of an H3 index
 </Tabs>
 
 Converts the `H3Index` representation of the index to the string representation. `str` must be at least of length 17.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## h3IsValid
 
@@ -356,7 +358,7 @@ function example() {
 
 Returns non-zero if this index represents a pentagonal cell.
 
-## h3GetFaces
+## getIcosahedronFaces
 
 <Tabs
   groupId="language"
@@ -371,35 +373,35 @@ Returns non-zero if this index represents a pentagonal cell.
 <TabItem value="c">
 
 ```c
-void h3GetFaces(H3Index h, int* out);
+H3Error getIcosahedronFaces(H3Index h, int* out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_get_faces(h)
+h3.get_icosahedron_faces(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-Collection<Integer> h3GetFaces(long h3);
-Collection<Integer> h3GetFaces(String h3Address);
+Collection<Integer> getIcosahedronFaces(long h3);
+Collection<Integer> getIcosahedronFaces(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3GetFaces(h)
+h3.getIcosahedronFaces(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3GetFaces(h);
+  return h3.getIcosahedronFaces(h);
 }
 ```
 
@@ -409,6 +411,8 @@ function example() {
 Find all icosahedron faces intersected by a given H3 index and places them in the array `out`. `out` must be at least length of `maxFaceCount(h)`.
 
 Faces are represented as integers from 0-19, inclusive. The array is sparse, and empty (no intersection) array values are represented by -1.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## maxFaceCount
 

--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -739,7 +739,7 @@ This function exists for memory management and is not exposed.
 
 Number of resolution 0 H3 indexes.
 
-## getPentagonIndexes
+## getPentagons
 
 <Tabs
   groupId="language"
@@ -754,35 +754,35 @@ Number of resolution 0 H3 indexes.
 <TabItem value="c">
 
 ```c
-void getPentagonIndexes(int res, H3Index *out);
+H3Error getPentagons(int res, H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_pentagon_indexes(res)
+h3.get_pentagons(res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-Collection<Long> getPentagonIndexes(int res);
-Collection<String> h3.getPentagonIndexesAddresses(int res);
+Collection<Long> h3.getPentagons(int res);
+Collection<String> h3.getPentagonsAddresses(int res);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getPentagonIndexes(res)
+h3.getPentagons(res)
 ```
 
 ```js live
 function example() {
   const res = 5;
-  return h3.getPentagonIndexes(res);
+  return h3.getPentagons(res);
 }
 ```
 
@@ -791,6 +791,8 @@ function example() {
 
 All the pentagon H3 indexes at the specified resolution.
 `out` must be an array of at least size `pentagonIndexCount()`.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## pentagonIndexCount
 


### PR DESCRIPTION
Applies the error return codes RFC to h3Index.c with the exception of some commonly used functions that return true/false.