### PR TITLE
Add error return codes to gridDisk functions

### DIFF
--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -35,7 +35,7 @@ SUITE(compactCells) {
 
         // Generate a set of hexagons to compact
         H3Index *sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
-        H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded);
+        t_assertSuccess(H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded));
 
         H3Index *compressed = calloc(hexCount, sizeof(H3Index));
         t_assertSuccess(

--- a/src/apps/testapps/testDirectedEdge.c
+++ b/src/apps/testapps/testDirectedEdge.c
@@ -35,7 +35,7 @@ SUITE(directedEdge) {
         H3Index sf;
         t_assertSuccess(H3_EXPORT(latLngToCell)(&sfGeo, 9, &sf));
         H3Index ring[7] = {0};
-        H3_EXPORT(gridRingUnsafe)(sf, 1, ring);
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 1, ring));
 
         t_assert(H3_EXPORT(areNeighborCells)(sf, sf) == 0,
                  "an index does not neighbor itself");
@@ -50,7 +50,7 @@ SUITE(directedEdge) {
                  "got the expected number of neighbors from a k-ring of 1");
 
         H3Index largerRing[19] = {0};
-        H3_EXPORT(gridRingUnsafe)(sf, 2, largerRing);
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 2, largerRing));
 
         neighbors = 0;
         for (int i = 0; i < H3_EXPORT(maxGridDiskSize)(2); i++) {
@@ -82,7 +82,7 @@ SUITE(directedEdge) {
         H3Index sf;
         t_assertSuccess(H3_EXPORT(latLngToCell)(&sfGeo, 9, &sf));
         H3Index ring[7] = {0};
-        H3_EXPORT(gridRingUnsafe)(sf, 1, ring);
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 1, ring));
         H3Index sf2 = ring[0];
 
         H3Index edge = H3_EXPORT(cellsToDirectedEdge)(sf, sf2);
@@ -99,7 +99,7 @@ SUITE(directedEdge) {
                  "got the destination last in the pair request");
 
         H3Index largerRing[19] = {0};
-        H3_EXPORT(gridRingUnsafe)(sf, 2, largerRing);
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 2, largerRing));
         H3Index sf3 = largerRing[0];
 
         H3Index notEdge = H3_EXPORT(cellsToDirectedEdge)(sf, sf3);
@@ -134,7 +134,7 @@ SUITE(directedEdge) {
             t_assertSuccess(H3_EXPORT(getPentagons)(res, pentagons));
             for (int p = 0; p < NUM_PENTAGONS; p++) {
                 pentagon = pentagons[p];
-                H3_EXPORT(gridDisk)(pentagon, 1, ring);
+                t_assertSuccess(H3_EXPORT(gridDisk)(pentagon, 1, ring));
 
                 for (int i = 0; i < 7; i++) {
                     H3Index neighbor = ring[i];
@@ -154,7 +154,7 @@ SUITE(directedEdge) {
         H3Index sf;
         t_assertSuccess(H3_EXPORT(latLngToCell)(&sfGeo, 9, &sf));
         H3Index ring[7] = {0};
-        H3_EXPORT(gridRingUnsafe)(sf, 1, ring);
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 1, ring));
         H3Index sf2 = ring[0];
 
         H3Index edge = H3_EXPORT(cellsToDirectedEdge)(sf, sf2);

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -33,12 +33,13 @@ static void gridDisk_equals_gridDiskDistancesSafe_assertions(H3Index h3) {
 
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
         int *distances = calloc(kSz, sizeof(int));
-        H3_EXPORT(gridDiskDistances)(h3, k, neighbors, distances);
+        t_assertSuccess(
+            H3_EXPORT(gridDiskDistances)(h3, k, neighbors, distances));
 
         H3Index *internalNeighbors = calloc(kSz, sizeof(H3Index));
         int *internalDistances = calloc(kSz, sizeof(int));
-        H3_EXPORT(gridDiskDistancesSafe)
-        (h3, k, internalNeighbors, internalDistances);
+        t_assertSuccess(H3_EXPORT(gridDiskDistancesSafe)(
+            h3, k, internalNeighbors, internalDistances));
 
         int found = 0;
         int internalFound = 0;
@@ -85,7 +86,7 @@ SUITE(gridDisk) {
                                 0x8013fffffffffff, 0x8027fffffffffff,
                                 0x8049fffffffffff, 0x8051fffffffffff,
                                 0x8037fffffffffff};
-        H3_EXPORT(gridDiskDistances)(sfHex0, 1, k1, k1Dist);
+        t_assertSuccess(H3_EXPORT(gridDiskDistances)(sfHex0, 1, k1, k1Dist));
 
         for (int i = 0; i < 7; i++) {
             t_assert(k1[i] != 0, "index is populated");
@@ -113,7 +114,7 @@ SUITE(gridDisk) {
                                 0x801ffffffffffff,
                                 0x8019fffffffffff,
                                 0};
-        H3_EXPORT(gridDiskDistances)(polar, 1, k2, k2Dist);
+        t_assertSuccess(H3_EXPORT(gridDiskDistances)(polar, 1, k2, k2Dist));
 
         int k2present = 0;
         for (int i = 0; i < 7; i++) {
@@ -145,7 +146,7 @@ SUITE(gridDisk) {
                                 0x8108bffffffffff,
                                 0x8109bffffffffff,
                                 0};
-        H3_EXPORT(gridDiskDistances)(polar, 1, k2, k2Dist);
+        t_assertSuccess(H3_EXPORT(gridDiskDistances)(polar, 1, k2, k2Dist));
 
         int k2present = 0;
         for (int i = 0; i < 7; i++) {
@@ -210,7 +211,7 @@ SUITE(gridDisk) {
         int expectedK2Dist[37] = {2, 3, 2, 1, 3, 3, 3, 2, 2, 3, 1, 3, 0,
                                   2, 3, 3, 2, 2, 3, 1, 3, 3, 2, 2, 3, 1,
                                   2, 3, 1, 3, 3, 0, 0, 0, 0, 0, 0};
-        H3_EXPORT(gridDiskDistances)(polar, 3, k2, k2Dist);
+        t_assertSuccess(H3_EXPORT(gridDiskDistances)(polar, 3, k2, k2Dist));
 
         int k2present = 0;
         for (int i = 0; i < 37; i++) {
@@ -288,7 +289,7 @@ SUITE(gridDisk) {
                                   0x81137ffffffffff,
                                   0,
                                   0};
-        H3_EXPORT(gridDiskDistances)(pent, 4, k2, k2Dist);
+        t_assertSuccess(H3_EXPORT(gridDiskDistances)(pent, 4, k2, k2Dist));
 
         int k2present = 0;
         for (int i = 0; i < 61; i++) {
@@ -360,7 +361,7 @@ SUITE(gridDisk) {
         int k = 1000;
         int kSz = H3_EXPORT(maxGridDiskSize)(k);
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
-        H3_EXPORT(gridDisk)(0x7fffffffffffffff, k, neighbors);
+        t_assertSuccess(H3_EXPORT(gridDisk)(0x7fffffffffffffff, k, neighbors));
         // Assertion is should not crash - should return an error in the future
         free(neighbors);
     }
@@ -369,7 +370,7 @@ SUITE(gridDisk) {
         int k = 2;
         int kSz = H3_EXPORT(maxGridDiskSize)(k);
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
-        H3_EXPORT(gridDisk)(0x4d4b00fe5c5c3030, k, neighbors);
+        t_assertSuccess(H3_EXPORT(gridDisk)(0x4d4b00fe5c5c3030, k, neighbors));
         // Assertion is should not crash - should return an error in the future
         free(neighbors);
     }

--- a/src/apps/testapps/testGridDisksUnsafe.c
+++ b/src/apps/testapps/testGridDisksUnsafe.c
@@ -30,24 +30,18 @@ SUITE(gridDisksUnsafe) {
     H3Index withPentagon[] = {0x8029fffffffffff, 0x801dfffffffffff};
 
     TEST(identityGridDiskCells) {
-        int err;
-
         H3Index k0[] = {0};
-        err = H3_EXPORT(gridDisksUnsafe)(sfHexPtr, 1, 0, k0);
+        t_assertSuccess(H3_EXPORT(gridDisksUnsafe)(sfHexPtr, 1, 0, k0));
 
-        t_assert(err == 0, "No error on gridDisksUnsafe");
         t_assert(k0[0] == sfHex, "generated identity k-ring");
     }
 
     TEST(ring1of1) {
-        int err;
         H3Index allKrings[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-        err = H3_EXPORT(gridDisksUnsafe)(k1, 6, 1, allKrings);
-
-        t_assert(err == 0, "No error on gridDisksUnsafe");
+        t_assertSuccess(H3_EXPORT(gridDisksUnsafe)(k1, 6, 1, allKrings));
 
         for (int i = 0; i < 42; i++) {
             t_assert(allKrings[i] != 0, "index is populated");
@@ -60,11 +54,8 @@ SUITE(gridDisksUnsafe) {
     }
 
     TEST(ring2of1) {
-        int err;
         H3Index *allKrings2 = calloc(6 * (1 + 6 + 12), sizeof(H3Index));
-        err = H3_EXPORT(gridDisksUnsafe)(k1, 6, 2, allKrings2);
-
-        t_assert(err == 0, "No error on gridDisksUnsafe");
+        t_assertSuccess(H3_EXPORT(gridDisksUnsafe)(k1, 6, 2, allKrings2));
 
         for (int i = 0; i < (6 * (1 + 6 + 12)); i++) {
             t_assert(allKrings2[i] != 0, "index is populated");
@@ -79,11 +70,10 @@ SUITE(gridDisksUnsafe) {
     }
 
     TEST(failed) {
-        int err;
         H3Index *allKrings = calloc(2 * (1 + 6), sizeof(H3Index));
-        err = H3_EXPORT(gridDisksUnsafe)(withPentagon, 2, 1, allKrings);
-
-        t_assert(err != 0, "Expected error on gridDisksUnsafe");
+        t_assert(H3_EXPORT(gridDisksUnsafe)(withPentagon, 2, 1, allKrings) ==
+                     E_PENTAGON,
+                 "Expected error on gridDisksUnsafe");
         free(allKrings);
     }
 }

--- a/src/apps/testapps/testGridDistanceExhaustive.c
+++ b/src/apps/testapps/testGridDistanceExhaustive.c
@@ -47,7 +47,8 @@ static void gridDistance_gridDisk_assertions(H3Index h3) {
     H3Index *neighbors = calloc(sz, sizeof(H3Index));
     int *distances = calloc(sz, sizeof(int));
 
-    H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances);
+    t_assertSuccess(
+        H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances));
 
     for (int i = 0; i < sz; i++) {
         if (neighbors[i] == 0) {

--- a/src/apps/testapps/testGridPathCellsExhaustive.c
+++ b/src/apps/testapps/testGridPathCellsExhaustive.c
@@ -87,7 +87,7 @@ static void gridPathCells_gridDisk_assertions(H3Index h3) {
     }
 
     H3Index *neighbors = calloc(sz, sizeof(H3Index));
-    H3_EXPORT(gridDisk)(h3, maxK, neighbors);
+    t_assertSuccess(H3_EXPORT(gridDisk)(h3, maxK, neighbors));
 
     for (int i = 0; i < sz; i++) {
         if (neighbors[i] == 0) {

--- a/src/apps/testapps/testGridRingUnsafe.c
+++ b/src/apps/testapps/testGridRingUnsafe.c
@@ -27,25 +27,17 @@ SUITE(gridRingUnsafe) {
     t_assertSuccess(H3_EXPORT(latLngToCell)(&sf, 9, &sfHex));
 
     TEST(identityGridRing) {
-        int err;
-
         H3Index k0[] = {0};
-        err = H3_EXPORT(gridRingUnsafe)(sfHex, 0, k0);
-
-        t_assert(err == 0, "No error on gridRingUnsafe");
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sfHex, 0, k0));
         t_assert(k0[0] == sfHex, "generated identity k-ring");
     }
 
     TEST(ring1) {
-        int err;
-
         H3Index k1[] = {0, 0, 0, 0, 0, 0};
         H3Index expectedK1[] = {0x89283080ddbffff, 0x89283080c37ffff,
                                 0x89283080c27ffff, 0x89283080d53ffff,
                                 0x89283080dcfffff, 0x89283080dc3ffff};
-        err = H3_EXPORT(gridRingUnsafe)(sfHex, 1, k1);
-
-        t_assert(err == 0, "No error on gridRingUnsafe");
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sfHex, 1, k1));
 
         for (int i = 0; i < 6; i++) {
             t_assert(k1[i] != 0, "index is populated");
@@ -60,17 +52,13 @@ SUITE(gridRingUnsafe) {
     }
 
     TEST(ring2) {
-        int err;
-
         H3Index k2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         H3Index expectedK2[] = {
             0x89283080ca7ffff, 0x89283080cafffff, 0x89283080c33ffff,
             0x89283080c23ffff, 0x89283080c2fffff, 0x89283080d5bffff,
             0x89283080d43ffff, 0x89283080d57ffff, 0x89283080d1bffff,
             0x89283080dc7ffff, 0x89283080dd7ffff, 0x89283080dd3ffff};
-        err = H3_EXPORT(gridRingUnsafe)(sfHex, 2, k2);
-
-        t_assert(err == 0, "No error on gridRingUnsafe");
+        t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sfHex, 2, k2));
 
         for (int i = 0; i < 12; i++) {
             t_assert(k2[i] != 0, "index is populated");
@@ -85,34 +73,24 @@ SUITE(gridRingUnsafe) {
     }
 
     TEST(nearPentagonRing1) {
-        int err;
-
         H3Index nearPentagon = 0x837405fffffffff;
         H3Index kp1[] = {0, 0, 0, 0, 0, 0};
-        err = H3_EXPORT(gridRingUnsafe)(nearPentagon, 1, kp1);
-
-        t_assert(err != 0, "Should return an error when hitting a pentagon");
+        t_assert(H3_EXPORT(gridRingUnsafe)(nearPentagon, 1, kp1) == E_PENTAGON,
+                 "Should return an error when hitting a pentagon");
     }
 
     TEST(nearPentagonRing2) {
-        int err;
-
         H3Index nearPentagon = 0x837405fffffffff;
         H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        err = H3_EXPORT(gridRingUnsafe)(nearPentagon, 2, kp2);
-
-        t_assert(err != 0, "Should return an error when hitting a pentagon");
+        t_assert(H3_EXPORT(gridRingUnsafe)(nearPentagon, 2, kp2) == E_PENTAGON,
+                 "Should return an error when hitting a pentagon");
     }
 
     TEST(onPentagon) {
-        int err;
-
         H3Index nearPentagon;
         setH3Index(&nearPentagon, 0, 4, 0);
         H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        err = H3_EXPORT(gridRingUnsafe)(nearPentagon, 2, kp2);
-
-        t_assert(err != 0,
+        t_assert(H3_EXPORT(gridRingUnsafe)(nearPentagon, 2, kp2) == E_PENTAGON,
                  "Should return an error when starting at a pentagon");
     }
 
@@ -138,16 +116,16 @@ SUITE(gridRingUnsafe) {
                         int kSz = H3_EXPORT(maxGridDiskSize)(k);
 
                         H3Index *ring = calloc(ringSz, sizeof(H3Index));
-                        int failed =
+                        H3Error failed =
                             H3_EXPORT(gridRingUnsafe)(children[j], k, ring);
 
                         if (!failed) {
                             H3Index *internalNeighbors =
                                 calloc(kSz, sizeof(H3Index));
                             int *internalDistances = calloc(kSz, sizeof(int));
-                            H3_EXPORT(gridDiskDistancesSafe)
-                            (children[j], k, internalNeighbors,
-                             internalDistances);
+                            t_assertSuccess(H3_EXPORT(gridDiskDistancesSafe)(
+                                children[j], k, internalNeighbors,
+                                internalDistances));
 
                             int found = 0;
                             int internalFound = 0;

--- a/src/apps/testapps/testH3Memory.c
+++ b/src/apps/testapps/testH3Memory.c
@@ -99,19 +99,20 @@ SUITE(h3Memory) {
         H3Index *gridDiskOutput = calloc(hexCount, sizeof(H3Index));
 
         resetMemoryCounters(0);
-        H3_EXPORT(gridDisk)(sunnyvale, k, gridDiskOutput);
+        t_assertSuccess(H3_EXPORT(gridDisk)(sunnyvale, k, gridDiskOutput));
         t_assert(actualAllocCalls == 0, "gridDisk did not call alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 
         resetMemoryCounters(0);
-        H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput);
+        t_assertSuccess(H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput));
         t_assert(actualAllocCalls == 1, "gridDisk called alloc");
         t_assert(actualFreeCalls == 1, "gridDisk called free");
 
         resetMemoryCounters(0);
         failAlloc = true;
         memset(gridDiskOutput, 0, hexCount * sizeof(H3Index));
-        H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput);
+        t_assert(H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput) == E_MEMORY,
+                 "gridDisk returns E_MEMORY");
         t_assert(actualAllocCalls == 1, "gridDisk called alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 
@@ -131,7 +132,7 @@ SUITE(h3Memory) {
         // Generate a set of hexagons to compact
         H3Index *sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
         resetMemoryCounters(0);
-        H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded);
+        t_assertSuccess(H3_EXPORT(gridDisk)(sunnyvale, k, sunnyvaleExpanded));
         t_assert(actualAllocCalls == 0, "gridDisk did not call alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 

--- a/src/apps/testapps/testH3NeighborRotations.c
+++ b/src/apps/testapps/testH3NeighborRotations.c
@@ -57,13 +57,14 @@ void doCell(H3Index h, int maxK, TestOutput *testOutput) {
 
         H3_EXPORT(gridDiskDistancesSafe)
         (h, k, gridDiskInternalOutput, gridDiskInternalDistances);
-        int gridDiskUnsafeFailed =
+        H3Error gridDiskUnsafeFailed =
             H3_EXPORT(gridDiskUnsafe)(h, k, gridDiskUnsafeOutput);
 
-        if (gridDiskUnsafeFailed == 2) {
+        if (gridDiskUnsafeFailed == E_FAILED) {
+            // TODO: Unreachable
             testOutput->ret2++;
             continue;
-        } else if (gridDiskUnsafeFailed == 0) {
+        } else if (gridDiskUnsafeFailed == E_SUCCESS) {
             testOutput->ret0++;
             int startIdx = 0;
             // i is the current ring number
@@ -95,7 +96,7 @@ void doCell(H3Index h, int maxK, TestOutput *testOutput) {
 
                 startIdx += n;
             }
-        } else if (gridDiskUnsafeFailed == 1) {
+        } else if (gridDiskUnsafeFailed == E_PENTAGON) {
             testOutput->ret1++;
             int foundPent = 0;
             for (int i = 0; i < maxSz; i++) {

--- a/src/apps/testapps/testH3ToLocalIjExhaustive.c
+++ b/src/apps/testapps/testH3ToLocalIjExhaustive.c
@@ -135,7 +135,8 @@ void localIjToH3_gridDisk_assertions(H3Index h3) {
     H3Index *neighbors = calloc(sz, sizeof(H3Index));
     int *distances = calloc(sz, sizeof(int));
 
-    H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances);
+    t_assertSuccess(
+        H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances));
 
     for (int i = 0; i < sz; i++) {
         if (neighbors[i] == 0) {

--- a/src/apps/testapps/testVertexExhaustive.c
+++ b/src/apps/testapps/testVertexExhaustive.c
@@ -79,7 +79,7 @@ static void cellToVertex_neighbor_assertions(H3Index h3) {
     H3Index originVerts[NUM_HEX_VERTS] = {0};
     H3Index neighborVerts[NUM_HEX_VERTS] = {0};
 
-    H3_EXPORT(gridDisk)(h3, 1, neighbors);
+    t_assertSuccess(H3_EXPORT(gridDisk)(h3, 1, neighbors));
     H3_EXPORT(cellToVertexes)(h3, originVerts);
 
     for (int i = 0; i < 7; i++) {

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -50,6 +50,6 @@ H3Error _getEdgeHexagons(const GeoLoop *geoloop, int64_t numHexagons, int res,
                          H3Index *found);
 
 // The safe gridDiskDistances algorithm.
-void _gridDiskDistancesInternal(H3Index origin, int k, H3Index *out,
-                                int *distances, int maxIdx, int curK);
+H3Error _gridDiskDistancesInternal(H3Index origin, int k, H3Index *out,
+                                   int *distances, int maxIdx, int curK);
 #endif

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -229,25 +229,26 @@ DECLSPEC H3Error H3_EXPORT(cellToBoundary)(H3Index h3, CellBoundary *gp);
 DECLSPEC int H3_EXPORT(maxGridDiskSize)(int k);
 
 /** @brief hexagons neighbors in all directions, assuming no pentagons */
-DECLSPEC int H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index *out);
+DECLSPEC H3Error H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index *out);
 /** @} */
 
 /** @brief hexagons neighbors in all directions, assuming no pentagons,
  * reporting distance from origin */
-DECLSPEC int H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k,
-                                                H3Index *out, int *distances);
+DECLSPEC H3Error H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k,
+                                                    H3Index *out,
+                                                    int *distances);
 
 /** @brief hexagons neighbors in all directions reporting distance from origin
  */
-DECLSPEC void H3_EXPORT(gridDiskDistancesSafe)(H3Index origin, int k,
-                                               H3Index *out, int *distances);
+DECLSPEC H3Error H3_EXPORT(gridDiskDistancesSafe)(H3Index origin, int k,
+                                                  H3Index *out, int *distances);
 
 /** @brief collection of hex rings sorted by ring for all given hexagons */
-DECLSPEC int H3_EXPORT(gridDisksUnsafe)(H3Index *h3Set, int length, int k,
-                                        H3Index *out);
+DECLSPEC H3Error H3_EXPORT(gridDisksUnsafe)(H3Index *h3Set, int length, int k,
+                                            H3Index *out);
 
 /** @brief hexagon neighbors in all directions */
-DECLSPEC void H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index *out);
+DECLSPEC H3Error H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index *out);
 /** @} */
 
 /** @defgroup gridDiskDistances gridDiskDistances
@@ -256,8 +257,8 @@ DECLSPEC void H3_EXPORT(gridDisk)(H3Index origin, int k, H3Index *out);
  */
 /** @brief hexagon neighbors in all directions, reporting distance from origin
  */
-DECLSPEC void H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index *out,
-                                           int *distances);
+DECLSPEC H3Error H3_EXPORT(gridDiskDistances)(H3Index origin, int k,
+                                              H3Index *out, int *distances);
 /** @} */
 
 /** @defgroup gridRingUnsafe gridRingUnsafe
@@ -265,7 +266,7 @@ DECLSPEC void H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index *out,
  * @{
  */
 /** @brief hollow hexagon ring at some origin */
-DECLSPEC int H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index *out);
+DECLSPEC H3Error H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index *out);
 /** @} */
 
 /** @defgroup polygonToCells polygonToCells
@@ -286,9 +287,9 @@ DECLSPEC H3Error H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon,
  * @{
  */
 /** @brief Create a LinkedGeoPolygon from a set of contiguous hexagons */
-DECLSPEC void H3_EXPORT(h3SetToLinkedGeo)(const H3Index *h3Set,
-                                          const int numHexes,
-                                          LinkedGeoPolygon *out);
+DECLSPEC H3Error H3_EXPORT(h3SetToLinkedGeo)(const H3Index *h3Set,
+                                             const int numHexes,
+                                             LinkedGeoPolygon *out);
 
 /** @brief Free all memory created for a LinkedGeoPolygon */
 DECLSPEC void H3_EXPORT(destroyLinkedPolygon)(LinkedGeoPolygon *polygon);


### PR DESCRIPTION
Adds the ability for the gridDisk series of functions (but not `maxGridDiskSize`, which may need to be updated to return int64_t) to return errors.