### PR TITLE
Add error returns to gridPath/gridDistance functions

### DIFF
--- a/examples/distance.c
+++ b/examples/distance.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     cellToLatLng(h3HQ2, &geoHQ2);
 
     int64_t distance;
-    gridDistance(h3HQ1, h3HQ2, &distance);
+    assert(gridDistance(h3HQ1, h3HQ2, &distance) == E_SUCCESS);
 
     printf(
         "origin: (%lf, %lf)\n"

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -21,8 +21,8 @@
 // mean Earth radius
 #define R 6371.0088
 
-#include <h3/h3api.h>
 #include <assert.h>
+#include <h3/h3api.h>
 #include <math.h>
 #include <stdio.h>
 

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -58,13 +58,16 @@ int main(int argc, char *argv[]) {
     cellToLatLng(h3HQ1, &geoHQ1);
     cellToLatLng(h3HQ2, &geoHQ2);
 
+    int64_t distance;
+    gridDistance(h3HQ1, h3HQ2, &distance);
+
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
         "grid distance: %d\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
-        radsToDegs(geoHQ2.lng), gridDistance(h3HQ1, h3HQ2),
+        radsToDegs(geoHQ2.lng), distance,
         haversineDistance(geoHQ1.lat, geoHQ1.lng, geoHQ2.lat, geoHQ2.lng));
     // Output:
     // origin: (37.775236, -122.419755)

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -22,6 +22,7 @@
 #define R 6371.0088
 
 #include <h3/h3api.h>
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 

--- a/src/apps/benchmarks/benchmarkGridPathCells.c
+++ b/src/apps/benchmarks/benchmarkGridPathCells.c
@@ -23,8 +23,9 @@ H3Index endFar = 0x8929a5653c3ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index *out =
-    calloc(H3_EXPORT(gridPathCellsSize)(startIndex, endFar), sizeof(H3Index));
+int64_t size;
+H3_EXPORT(gridPathCellsSize)(startIndex, endFar, &size);
+H3Index *out = calloc(size, sizeof(H3Index));
 
 BENCHMARK(gridPathCellsNear, 10000, {
     H3_EXPORT(gridPathCells)(startIndex, endNear, out);

--- a/src/apps/testapps/testGridDistance.c
+++ b/src/apps/testapps/testGridDistance.c
@@ -63,15 +63,21 @@ SUITE(gridDistance) {
         H3Index p6;
         setH3Index(&p6, 1, 14, 6);
 
-        t_assert(H3_EXPORT(gridDistance)(bc, p) == 3, "distance onto pentagon");
-        t_assert(H3_EXPORT(gridDistance)(bc, p2) == 2, "distance onto p2");
-        t_assert(H3_EXPORT(gridDistance)(bc, p3) == 3, "distance onto p3");
+        int64_t distance;
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc, p, &distance));
+        t_assert(distance == 3, "distance onto pentagon");
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc, p2, &distance));
+        t_assert(distance == 2, "distance onto p2");
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc, p3, &distance));
+        t_assert(distance == 3, "distance onto p3");
         // TODO works correctly but is rejected due to possible pentagon
         // distortion.
-        //    t_assert(H3_EXPORT(gridDistance)(bc, p4) == 3, "distance onto
-        //    p4"); t_assert(H3_EXPORT(gridDistance)(bc, p5) == 4, "distance
-        //    onto p5");
-        t_assert(H3_EXPORT(gridDistance)(bc, p6) == 2, "distance onto p6");
+        // t_assertSuccess(H3_EXPORT(gridDistance)(bc, p4, &distance));
+        // t_assert(distance == 3, "distance onto p4");
+        // t_assertSuccess(H3_EXPORT(gridDistance)(bc, p5, &distance));
+        // t_assert(distance == 4, "distance onto p5");
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc, p6, &distance));
+        t_assert(distance == 2, "distance onto p6");
     }
 
     TEST(testIndexDistance2) {
@@ -80,20 +86,24 @@ SUITE(gridDistance) {
         H3Index destination = 0x821ce7fffffffffL;
 
         // TODO doesn't work because of pentagon distortion. Both should be 5.
-        t_assert(H3_EXPORT(gridDistance)(destination, origin) == -1,
+        int64_t distance;
+        t_assert(H3_EXPORT(gridDistance)(destination, origin, &distance) !=
+                     E_SUCCESS,
                  "distance in res 2 across pentagon");
-        t_assert(H3_EXPORT(gridDistance)(origin, destination) == -1,
+        t_assert(H3_EXPORT(gridDistance)(origin, destination, &distance) !=
+                     E_SUCCESS,
                  "distance in res 2 across pentagon (reversed)");
     }
 
     TEST(gridDistanceBaseCells) {
-        t_assert(H3_EXPORT(gridDistance)(bc1, pent1) == 1,
-                 "distance to neighbor is 1 (15, 4)");
-        t_assert(H3_EXPORT(gridDistance)(bc1, bc2) == 1,
-                 "distance to neighbor is 1 (15, 8)");
-        t_assert(H3_EXPORT(gridDistance)(bc1, bc3) == 1,
-                 "distance to neighbor is 1 (15, 31)");
-        t_assert(H3_EXPORT(gridDistance)(pent1, bc3) == -1,
+        int64_t distance;
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc1, pent1, &distance));
+        t_assert(distance == 1, "distance to neighbor is 1 (15, 4)");
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc1, bc2, &distance));
+        t_assert(distance == 1, "distance to neighbor is 1 (15, 8)");
+        t_assertSuccess(H3_EXPORT(gridDistance)(bc1, bc3, &distance));
+        t_assert(distance == 1, "distance to neighbor is 1 (15, 31)");
+        t_assert(H3_EXPORT(gridDistance)(pent1, bc3, &distance) != E_SUCCESS,
                  "distance to neighbor is invalid");
     }
 
@@ -119,8 +129,9 @@ SUITE(gridDistance) {
     }
 
     TEST(gridDistanceResolutionMismatch) {
-        t_assert(H3_EXPORT(gridDistance)(0x832830fffffffffL,
-                                         0x822837fffffffffL) == -1,
+        int64_t distance;
+        t_assert(H3_EXPORT(gridDistance)(0x832830fffffffffL, 0x822837fffffffffL,
+                                         &distance) == E_RES_MISMATCH,
                  "cannot compare at different resolutions");
     }
 
@@ -130,14 +141,15 @@ SUITE(gridDistance) {
         H3Index edge = H3_EXPORT(cellsToDirectedEdge)(origin, dest);
 
         t_assert(0 != edge, "test edge is valid");
-        t_assert(H3_EXPORT(gridDistance)(edge, origin) == 0,
-                 "edge has zero distance to origin");
-        t_assert(H3_EXPORT(gridDistance)(origin, edge) == 0,
-                 "origin has zero distance to edge");
+        int64_t distance;
+        t_assertSuccess(H3_EXPORT(gridDistance)(edge, origin, &distance));
+        t_assert(distance == 0, "edge has zero distance to origin");
+        t_assertSuccess(H3_EXPORT(gridDistance)(origin, edge, &distance));
+        t_assert(distance == 0, "origin has zero distance to edge");
 
-        t_assert(H3_EXPORT(gridDistance)(edge, dest) == 1,
-                 "edge has distance to destination");
-        t_assert(H3_EXPORT(gridDistance)(dest, edge) == 1,
-                 "destination has distance to edge");
+        t_assertSuccess(H3_EXPORT(gridDistance)(edge, dest, &distance));
+        t_assert(distance == 1, "edge has distance to destination");
+        t_assertSuccess(H3_EXPORT(gridDistance)(dest, edge, &distance));
+        t_assert(distance == 1, "destination has distance to edge");
     }
 }

--- a/src/apps/testapps/testGridDistance.c
+++ b/src/apps/testapps/testGridDistance.c
@@ -152,4 +152,16 @@ SUITE(gridDistance) {
         t_assertSuccess(H3_EXPORT(gridDistance)(dest, edge, &distance));
         t_assert(distance == 1, "destination has distance to edge");
     }
+
+    TEST(gridDistanceInvalid) {
+        H3Index invalid = 0xffffffffffffffff;
+        int64_t distance;
+        t_assert(H3_EXPORT(gridDistance)(invalid, invalid, &distance) ==
+                     E_CELL_INVALID,
+                 "distance from invalid cell");
+
+        t_assert(
+            H3_EXPORT(gridDistance)(bc1, invalid, &distance) == E_RES_MISMATCH,
+            "distance to invalid cell");
+    }
 }

--- a/src/apps/testapps/testGridDistanceExhaustive.c
+++ b/src/apps/testapps/testGridDistanceExhaustive.c
@@ -35,7 +35,9 @@
 static const int MAX_DISTANCES[] = {1, 2, 5, 12, 19, 26};
 
 static void gridDistance_identity_assertions(H3Index h3) {
-    t_assert(H3_EXPORT(gridDistance)(h3, h3) == 0, "distance to self is 0");
+    int64_t distance;
+    t_assertSuccess(H3_EXPORT(gridDistance)(h3, h3, &distance));
+    t_assert(distance == 0, "distance to self is 0");
 }
 
 static void gridDistance_gridDisk_assertions(H3Index h3) {
@@ -54,12 +56,16 @@ static void gridDistance_gridDisk_assertions(H3Index h3) {
             continue;
         }
 
-        int calculatedDistance = H3_EXPORT(gridDistance)(h3, neighbors[i]);
+        int64_t calculatedDistance;
+        H3Error calculatedError =
+            H3_EXPORT(gridDistance)(h3, neighbors[i], &calculatedDistance);
 
         // Don't consider indexes where gridDistance reports failure to
         // generate
-        t_assert(calculatedDistance == distances[i] || calculatedDistance == -1,
-                 "gridDiskDistances matches gridDistance");
+        if (calculatedError == E_SUCCESS) {
+            t_assert(calculatedDistance == distances[i],
+                     "gridDiskDistances matches gridDistance");
+        }
     }
 
     free(distances);

--- a/src/apps/testapps/testGridPathCells.c
+++ b/src/apps/testapps/testGridPathCells.c
@@ -34,7 +34,9 @@ SUITE(gridPathCells) {
         H3Index start = 0x85285aa7fffffff;
         H3Index end = 0x851d9b1bfffffff;
 
-        int lineSz = H3_EXPORT(gridPathCellsSize)(start, end);
-        t_assert(lineSz < 0, "Line not computable across multiple icosa faces");
+        int64_t size;
+        H3Error lineError = H3_EXPORT(gridPathCellsSize)(start, end, &size);
+        t_assert(lineError == E_FAILED,
+                 "Line not computable across multiple icosa faces");
     }
 }

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -50,7 +50,7 @@ SUITE(h3ToLocalIj) {
 
     TEST(ijkBaseCells) {
         CoordIJK ijk;
-        t_assert(h3ToLocalIjk(pent1, bc1, &ijk) == 0,
+        t_assert(h3ToLocalIjk(pent1, bc1, &ijk) == E_SUCCESS,
                  "got ijk for base cells 4 and 15");
         t_assert(_ijkMatches(&ijk, &UNIT_VECS[2]) == 1,
                  "neighboring base cell at 0,1,0");
@@ -60,30 +60,30 @@ SUITE(h3ToLocalIj) {
         CoordIJ ij = {.i = 0, .j = 0};
         H3Index origin = 0x8029fffffffffff;
         H3Index retrieved;
-        t_assert(
-            H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) == 0,
-            "got origin back");
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) ==
+                     E_SUCCESS,
+                 "got origin back");
         t_assert(retrieved == 0x8029fffffffffff, "origin matches self");
         ij.i = 1;
-        t_assert(
-            H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) == 0,
-            "got offset index");
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) ==
+                     E_SUCCESS,
+                 "got offset index");
         t_assert(retrieved == 0x8051fffffffffff,
                  "modified index matches expected");
         ij.i = 2;
-        t_assert(
-            H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) != 0,
-            "out of range base cell (1)");
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) ==
+                     E_FAILED,
+                 "out of range base cell (1)");
         ij.i = 0;
         ij.j = 2;
-        t_assert(
-            H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) != 0,
-            "out of range base cell (2)");
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) ==
+                     E_FAILED,
+                 "out of range base cell (2)");
         ij.i = -2;
         ij.j = -2;
-        t_assert(
-            H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) != 0,
-            "out of range base cell (3)");
+        t_assert(H3_EXPORT(experimentalLocalIjToH3)(origin, &ij, &retrieved) ==
+                     E_FAILED,
+                 "out of range base cell (3)");
     }
 
     TEST(ijOutOfRange) {
@@ -126,30 +126,32 @@ SUITE(h3ToLocalIj) {
         t_assert(H3_EXPORT(experimentalH3ToLocalIj)(bc1, bc3, &ij) == 0,
                  "found IJ (4)");
         t_assert(ij.i == -1 && ij.j == 0, "ij correct (4)");
-        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(pent1, bc3, &ij) != 0,
-                 "found IJ (5)");
+        t_assert(
+            H3_EXPORT(experimentalH3ToLocalIj)(pent1, bc3, &ij) == E_FAILED,
+            "found IJ (5)");
     }
 
     TEST(experimentalH3ToLocalIjInvalid) {
         CoordIJ ij;
         H3Index invalidIndex = 0x7fffffffffffffff;
         H3_SET_RESOLUTION(invalidIndex, H3_GET_RESOLUTION(bc1));
-        t_assert(
-            H3_EXPORT(experimentalH3ToLocalIj)(bc1, invalidIndex, &ij) != 0,
-            "invalid index");
+        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(bc1, invalidIndex, &ij) ==
+                     E_CELL_INVALID,
+                 "invalid index");
         t_assert(H3_EXPORT(experimentalH3ToLocalIj)(0x7fffffffffffffff, bc1,
-                                                    &ij) != 0,
+                                                    &ij) == E_RES_MISMATCH,
                  "invalid origin");
-        t_assert(H3_EXPORT(experimentalH3ToLocalIj)(
-                     0x7fffffffffffffff, 0x7fffffffffffffff, &ij) != 0,
-                 "invalid origin and index");
+        t_assert(
+            H3_EXPORT(experimentalH3ToLocalIj)(
+                0x7fffffffffffffff, 0x7fffffffffffffff, &ij) == E_CELL_INVALID,
+            "invalid origin and index");
     }
 
     TEST(experimentalLocalIjToH3Invalid) {
         CoordIJ ij = {0, 0};
         H3Index index;
         t_assert(H3_EXPORT(experimentalLocalIjToH3)(0x7fffffffffffffff, &ij,
-                                                    &index) != 0,
+                                                    &index) == E_CELL_INVALID,
                  "invalid origin for ijToH3");
     }
 

--- a/src/apps/testapps/testH3ToLocalIj.c
+++ b/src/apps/testapps/testH3ToLocalIj.c
@@ -100,7 +100,7 @@ SUITE(h3ToLocalIj) {
 
         for (int i = 0; i < numCoords; i++) {
             H3Index result;
-            const int err = H3_EXPORT(experimentalLocalIjToH3)(
+            const H3Error err = H3_EXPORT(experimentalLocalIjToH3)(
                 expected[0], &coords[i], &result);
             if (expected[i] == H3_NULL) {
                 t_assert(err != 0, "coordinates out of range");

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -692,7 +692,8 @@ DECLSPEC int H3_EXPORT(isValidVertex)(H3Index vertex);
  * @{
  */
 /** @brief Returns grid distance between two indexes */
-DECLSPEC int H3_EXPORT(gridDistance)(H3Index origin, H3Index h3);
+DECLSPEC H3Error H3_EXPORT(gridDistance)(H3Index origin, H3Index h3,
+                                         int64_t *distance);
 /** @} */
 
 /** @defgroup gridPathCells gridPathCells
@@ -700,10 +701,12 @@ DECLSPEC int H3_EXPORT(gridDistance)(H3Index origin, H3Index h3);
  * @{
  */
 /** @brief Number of indexes in a line connecting two indexes */
-DECLSPEC int H3_EXPORT(gridPathCellsSize)(H3Index start, H3Index end);
+DECLSPEC H3Error H3_EXPORT(gridPathCellsSize)(H3Index start, H3Index end,
+                                              int64_t *size);
 
 /** @brief Line of h3 indexes connecting two indexes */
-DECLSPEC int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out);
+DECLSPEC H3Error H3_EXPORT(gridPathCells)(H3Index start, H3Index end,
+                                          H3Index *out);
 /** @} */
 
 /** @defgroup experimentalH3ToLocalIj experimentalH3ToLocalIj
@@ -711,8 +714,8 @@ DECLSPEC int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out);
  * @{
  */
 /** @brief Returns two dimensional coordinates for the given index */
-DECLSPEC int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
-                                                CoordIJ *out);
+DECLSPEC H3Error H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
+                                                    CoordIJ *out);
 /** @} */
 
 /** @defgroup experimentalLocalIjToH3 experimentalLocalIjToH3
@@ -720,9 +723,9 @@ DECLSPEC int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
  * @{
  */
 /** @brief Returns index for the given two dimensional coordinates */
-DECLSPEC int H3_EXPORT(experimentalLocalIjToH3)(H3Index origin,
-                                                const CoordIJ *ij,
-                                                H3Index *out);
+DECLSPEC H3Error H3_EXPORT(experimentalLocalIjToH3)(H3Index origin,
+                                                    const CoordIJ *ij,
+                                                    H3Index *out);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/h3lib/include/localij.h
+++ b/src/h3lib/include/localij.h
@@ -23,7 +23,7 @@
 #include "coordijk.h"
 #include "h3api.h"
 
-int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out);
-int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out);
+H3Error h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out);
+H3Error localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out);
 
 #endif

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -547,9 +547,7 @@ H3Error H3_EXPORT(gridDistance)(H3Index origin, H3Index h3, int64_t *out) {
     CoordIJK originIjk, h3Ijk;
     H3Error originError = h3ToLocalIjk(origin, origin, &originIjk);
     if (originError) {
-        // Currently there are no tests that would cause getting the coordinates
-        // for an index the same as the origin to fail.
-        return originError;  // LCOV_EXCL_LINE
+        return originError;
     }
     H3Error destError = h3ToLocalIjk(origin, h3, &h3Ijk);
     if (destError) {
@@ -678,7 +676,9 @@ H3Error H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
         cubeToIjk(&currentIjk);
         H3Error currentError = localIjkToH3(start, &currentIjk, &out[n]);
         if (currentError) {
-            return currentError;
+            // Expected to be unreachable since cells between `start` and `end`
+            // should have valid local IJK coordinates.
+            return currentError;  // LCOV_EXCL_LINE
         }
     }
 

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -646,12 +646,12 @@ H3Error H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
 
     // Convert H3 addresses to IJK coords
     H3Error startError = h3ToLocalIjk(start, start, &startIjk);
-    if (startError) {
+    if (startError) {  // LCOV_EXCL_BR_LINE
         // Unreachable because this was called as part of gridDistance
         return startError;  // LCOV_EXCL_LINE
     }
     H3Error endError = h3ToLocalIjk(start, end, &endIjk);
-    if (endError) {
+    if (endError) {  // LCOV_EXCL_BR_LINE
         // Unreachable because this was called as part of gridDistance
         return endError;  // LCOV_EXCL_LINE
     }
@@ -675,7 +675,7 @@ H3Error H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
         // Convert cube -> ijk -> h3 index
         cubeToIjk(&currentIjk);
         H3Error currentError = localIjkToH3(start, &currentIjk, &out[n]);
-        if (currentError) {
+        if (currentError) {  // LCOV_EXCL_BR_LINE
             // Expected to be unreachable since cells between `start` and `end`
             // should have valid local IJK coordinates.
             return currentError;  // LCOV_EXCL_LINE

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -128,11 +128,11 @@ const bool FAILED_DIRECTIONS[7][7] = {
  * @param out ijk+ coordinates of the index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
+H3Error h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
     int res = H3_GET_RESOLUTION(origin);
 
     if (res != H3_GET_RESOLUTION(h3)) {
-        return 1;
+        return E_RES_MISMATCH;
     }
 
     int originBaseCell = H3_GET_BASE_CELL(origin);
@@ -141,11 +141,11 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
     if (originBaseCell < 0 ||  // LCOV_EXCL_BR_LINE
         originBaseCell >= NUM_BASE_CELLS) {
         // Base cells less than zero can not be represented in an index
-        return 1;
+        return E_CELL_INVALID;
     }
     if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {  // LCOV_EXCL_BR_LINE
         // Base cells less than zero can not be represented in an index
-        return 1;
+        return E_CELL_INVALID;
     }
 
     // Direction from origin base cell to index base cell
@@ -155,7 +155,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
         dir = _getBaseCellDirection(originBaseCell, baseCell);
         if (dir == INVALID_DIGIT) {
             // Base cells are not neighbors, can't unfold.
-            return 2;
+            return E_FAILED;
         }
         revDir = _getBaseCellDirection(baseCell, originBaseCell);
         assert(revDir != INVALID_DIGIT);
@@ -201,7 +201,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
                 // TODO: We may be unfolding the pentagon incorrectly in this
                 // case; return an error code until this is guaranteed to be
                 // correct.
-                return 3;
+                return E_FAILED;
             }
 
             directionRotations = PENTAGON_ROTATIONS[originLeadingDigit][dir];
@@ -213,7 +213,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
                 // TODO: We may be unfolding the pentagon incorrectly in this
                 // case; return an error code until this is guaranteed to be
                 // correct.
-                return 4;
+                return E_FAILED;
             }
 
             pentagonRotations = PENTAGON_ROTATIONS[revDir][indexLeadingDigit];
@@ -258,7 +258,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
         if (FAILED_DIRECTIONS[originLeadingDigit][indexLeadingDigit]) {
             // TODO: We may be unfolding the pentagon incorrectly in this case;
             // return an error code until this is guaranteed to be correct.
-            return 5;
+            return E_FAILED;
         }
 
         int withinPentagonRotations =
@@ -270,7 +270,7 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
     }
 
     *out = indexFijk.coord;
-    return 0;
+    return E_SUCCESS;
 }
 
 /**
@@ -287,13 +287,13 @@ int h3ToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
  * @param out The index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
+H3Error localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
     int res = H3_GET_RESOLUTION(origin);
     int originBaseCell = H3_GET_BASE_CELL(origin);
     if (originBaseCell < 0 ||  // LCOV_EXCL_BR_LINE
         originBaseCell >= NUM_BASE_CELLS) {
         // Base cells less than zero can not be represented in an index
-        return 1;
+        return E_CELL_INVALID;
     }
     int originOnPent = _isBaseCellPentagon(originBaseCell);
 
@@ -307,17 +307,17 @@ int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
     if (res == 0) {
         if (ijk->i > 1 || ijk->j > 1 || ijk->k > 1) {
             // out of range input
-            return 1;
+            return E_FAILED;
         }
 
         const Direction dir = _unitIjkToDigit(ijk);
         const int newBaseCell = _getBaseCellNeighbor(originBaseCell, dir);
         if (newBaseCell == INVALID_BASE_CELL) {
             // Moving in an invalid direction off a pentagon.
-            return 1;
+            return E_FAILED;
         }
         H3_SET_BASE_CELL(*out, newBaseCell);
-        return 0;
+        return E_SUCCESS;
     }
 
     // we need to find the correct base cell offset (if any) for this H3 index;
@@ -355,7 +355,7 @@ int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
 
     if (ijkCopy.i > 1 || ijkCopy.j > 1 || ijkCopy.k > 1) {
         // out of range input
-        return 2;
+        return E_FAILED;
     }
 
     // lookup the correct base cell
@@ -382,7 +382,7 @@ int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
             // deleted direction. If it still happens, it means we're moving
             // into a deleted subsequence, so there is no index here.
             if (dir == K_AXES_DIGIT) {
-                return 3;
+                return E_PENTAGON;
             }
             baseCell = _getBaseCellNeighbor(originBaseCell, dir);
 
@@ -457,12 +457,12 @@ int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
         // accounted for here - instead just fail if the recovered index is
         // invalid.
         if (_h3LeadingNonZeroDigit(*out) == K_AXES_DIGIT) {
-            return 4;
+            return E_PENTAGON;
         }
     }
 
     H3_SET_BASE_CELL(*out, baseCell);
-    return 0;
+    return E_SUCCESS;
 }
 
 /**
@@ -485,21 +485,21 @@ int localIjkToH3(H3Index origin, const CoordIJK *ijk, H3Index *out) {
  * @param out ij coordinates of the index will be placed here on success
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
-                                       CoordIJ *out) {
+H3Error H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
+                                           CoordIJ *out) {
     // This function is currently experimental. Once ready to be part of the
     // non-experimental API, this function (with the experimental prefix) will
     // be marked as deprecated and to be removed in the next major version. It
     // will be replaced with a non-prefixed function name.
     CoordIJK ijk;
-    int failed = h3ToLocalIjk(origin, h3, &ijk);
+    H3Error failed = h3ToLocalIjk(origin, h3, &ijk);
     if (failed) {
         return failed;
     }
 
     ijkToIj(&ijk, out);
 
-    return 0;
+    return E_SUCCESS;
 }
 
 /**
@@ -519,8 +519,8 @@ int H3_EXPORT(experimentalH3ToLocalIj)(H3Index origin, H3Index h3,
  * @param index Index will be placed here on success.
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(experimentalLocalIjToH3)(H3Index origin, const CoordIJ *ij,
-                                       H3Index *out) {
+H3Error H3_EXPORT(experimentalLocalIjToH3)(H3Index origin, const CoordIJ *ij,
+                                           H3Index *out) {
     // This function is currently experimental. Once ready to be part of the
     // non-experimental API, this function (with the experimental prefix) will
     // be marked as deprecated and to be removed in the next major version. It
@@ -543,18 +543,20 @@ int H3_EXPORT(experimentalLocalIjToH3)(H3Index origin, const CoordIJ *ij,
  * @return The distance, or a negative number if the library could not
  * compute the distance.
  */
-int H3_EXPORT(gridDistance)(H3Index origin, H3Index h3) {
+H3Error H3_EXPORT(gridDistance)(H3Index origin, H3Index h3, int64_t *out) {
     CoordIJK originIjk, h3Ijk;
     if (h3ToLocalIjk(origin, origin, &originIjk)) {
         // Currently there are no tests that would cause getting the coordinates
         // for an index the same as the origin to fail.
-        return -1;  // LCOV_EXCL_LINE
+        return E_FAILED;  // LCOV_EXCL_LINE
     }
-    if (h3ToLocalIjk(origin, h3, &h3Ijk)) {
-        return -1;
+    H3Error h3ToLocalIjkError = h3ToLocalIjk(origin, h3, &h3Ijk);
+    if (h3ToLocalIjkError) {
+        return h3ToLocalIjkError;
     }
 
-    return ijkDistance(&originIjk, &h3Ijk);
+    *out = ijkDistance(&originIjk, &h3Ijk);
+    return E_SUCCESS;
 }
 
 /**
@@ -564,12 +566,18 @@ int H3_EXPORT(gridDistance)(H3Index origin, H3Index h3) {
  *
  * @param start Start index of the line
  * @param end End index of the line
- * @return Size of the line, or a negative number if the line cannot
- * be computed.
+ * @param size Size of the line
+ * @returns 0 on success, or another value on error
  */
-int H3_EXPORT(gridPathCellsSize)(H3Index start, H3Index end) {
-    int distance = H3_EXPORT(gridDistance)(start, end);
-    return distance >= 0 ? distance + 1 : distance;
+H3Error H3_EXPORT(gridPathCellsSize)(H3Index start, H3Index end,
+                                     int64_t *size) {
+    int64_t distance;
+    H3Error distanceError = H3_EXPORT(gridDistance)(start, end, &distance);
+    if (distanceError) {
+        return distanceError;
+    }
+    *size = distance + 1;
+    return E_SUCCESS;
 }
 
 /**
@@ -624,11 +632,12 @@ static void cubeRound(double i, double j, double k, CoordIJK *ijk) {
  * @param out Output array, which must be of size gridPathCellsSize(start, end)
  * @return 0 on success, or another value on failure.
  */
-int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
-    int distance = H3_EXPORT(gridDistance)(start, end);
+H3Error H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
+    int64_t distance;
+    H3Error distanceError = H3_EXPORT(gridDistance)(start, end, &distance);
     // Early exit if we can't calculate the line
-    if (distance < 0) {
-        return distance;
+    if (distanceError) {
+        return distanceError;
     }
 
     // Get IJK coords for the start and end. We've already confirmed
@@ -637,8 +646,14 @@ int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
     CoordIJK endIjk = {0};
 
     // Convert H3 addresses to IJK coords
-    h3ToLocalIjk(start, start, &startIjk);
-    h3ToLocalIjk(start, end, &endIjk);
+    H3Error startError = h3ToLocalIjk(start, start, &startIjk);
+    if (startError) {
+        return startError;
+    }
+    H3Error endError = h3ToLocalIjk(start, end, &endIjk);
+    if (endError) {
+        return endError;
+    }
 
     // Convert IJK to cube coordinates suitable for linear interpolation
     ijkToCube(&startIjk);
@@ -658,8 +673,11 @@ int H3_EXPORT(gridPathCells)(H3Index start, H3Index end, H3Index *out) {
                   (double)startIjk.k + kStep * n, &currentIjk);
         // Convert cube -> ijk -> h3 index
         cubeToIjk(&currentIjk);
-        localIjkToH3(start, &currentIjk, &out[n]);
+        H3Error currentError = localIjkToH3(start, &currentIjk, &out[n]);
+        if (currentError) {
+            return currentError;
+        }
     }
 
-    return 0;
+    return E_SUCCESS;
 }

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -402,7 +402,7 @@ Produces the hollow hexagonal ring centered at origin with sides of length k.
 
 Returns 0 if no pentagonal distortion was encountered.
 
-## h3Line
+## gridPathCells
 
 <Tabs
   groupId="language"
@@ -417,36 +417,36 @@ Returns 0 if no pentagonal distortion was encountered.
 <TabItem value="c">
 
 ```c
-int h3Line(H3Index start, H3Index end, H3Index* out);
+H3Error gridPathCells(H3Index start, H3Index end, H3Index* out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_line(start, end)
+h3.grid_path_cells(start, end)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> h3Line(long start, long end) throws LineUndefinedException
-List<String> h3Line(String startAddress, String endAddress) throws LineUndefinedException
+List<Long> gridPathCells(long start, long end) throws LineUndefinedException
+List<String> gridPathCells(String startAddress, String endAddress) throws LineUndefinedException
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3Line(start, end)
+h3.gridPathCells(start, end)
 ```
 
 ```js live
 function example() {
   const start = '85283473fffffff';
   const end = '8528342bfffffff';
-  return h3.h3Line(start, end);
+  return h3.gridPathCells(start, end);
 }
 ```
 
@@ -469,7 +469,7 @@ distances for indexes on opposite sides of a pentagon.
  * Lines are drawn in grid space, and may not correspond exactly to either
    Cartesian lines or great arcs.
 
-## h3LineSize
+## gridPathCellsSize
 
 <Tabs
   groupId="language"
@@ -484,7 +484,7 @@ distances for indexes on opposite sides of a pentagon.
 <TabItem value="c">
 
 ```c
-int h3LineSize(H3Index start, H3Index end);
+H3Error gridPathCellsSize(H3Index start, H3Index end, int64_t* size);
 ```
 
 </TabItem>
@@ -518,10 +518,11 @@ This function exists for memory management and is not exposed.
 </Tabs>
 
 Number of indexes in a line from the start index to the end index,
-to be used for allocating memory. Returns a negative number if the
-line cannot be computed.
+to be used for allocating memory.
 
-## h3Distance
+Returns 0 (`E_SUCCESS`) on success, or an error if the line cannot be computed.
+
+## gridDistance
 
 <Tabs
   groupId="language"
@@ -536,47 +537,48 @@ line cannot be computed.
 <TabItem value="c">
 
 ```c
-int h3Distance(H3Index origin, H3Index h3);
+H3Error gridDistance(H3Index origin, H3Index h3, int64_t *distance);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_distance(h1, h2)
+h3.grid_distance(h1, h2)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-int h3Distance(long a, long b) throws DistanceUndefinedException;
-int h3Distance(String a, String b) throws DistanceUndefinedException;
+long gridDistance(long a, long b) throws DistanceUndefinedException;
+long gridDistance(String a, String b) throws DistanceUndefinedException;
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3Distance(a, b)
+h3.gridDistance(a, b)
 ```
 
 ```js live
 function example() {
   const start = '85283473fffffff';
   const end = '8528342bfffffff';
-  return h3.h3Distance(start, end);
+  return h3.gridDistance(start, end);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Returns the distance in grid cells between the two indexes.
+Provides the distance in grid cells between the two indexes.
 
-Returns a negative number if finding the distance failed. Finding the distance can fail because the two
-indexes are not comparable (different resolutions), too far apart, or are separated by pentagonal
-distortion. This is the same set of limitations as the local IJ coordinate space functions.
+Returns 0 (`E_SUCCESS`) on success, or an error if finding the distance failed. Finding the distance
+can fail because the two indexes are not comparable (different resolutions), too far apart, or are
+separated by pentagonal distortion. This is the same set of limitations as the local IJ coordinate
+space functions.
 
 ## experimentalH3ToLocalIj
 
@@ -593,7 +595,7 @@ distortion. This is the same set of limitations as the local IJ coordinate space
 <TabItem value="c">
 
 ```c
-int experimentalH3ToLocalIj(H3Index origin, H3Index h3, CoordIJ *out);
+H3Error experimentalH3ToLocalIj(H3Index origin, H3Index h3, CoordIJ *out);
 ```
 
 </TabItem>
@@ -650,7 +652,7 @@ to be compatible across different versions of H3.
 <TabItem value="c">
 
 ```c
-int experimentalLocalIjToH3(H3Index origin, const CoordIJ *ij, H3Index *out);
+H3Error experimentalLocalIjToH3(H3Index origin, const CoordIJ *ij, H3Index *out);
 ```
 
 </TabItem>


### PR DESCRIPTION
Adds consistent error returns to the gridPathCells, gridDistance, and localIj series of functions. These functions mostly already had error codes but they were not consistent with `H3Error`.

Changes to traversal.mdx might need to be rebased with #505.

I'm moving functions to pass int64_t when it refers to a number of cells to be consistent with `getNumCells`. Would it make sense to introduce a typedef (`H3NumCells`? `H3NumIndexes`?) to avoid confusion about which type to use? Or just standardize on int64_t and let ourselves get used to that?