### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
+++ b/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
@@ -186,7 +186,7 @@ H3Error latLngToCell(double lat, double lng, int res, H3Index *result);
 There are two types of functions returning booleans in the library:
 
 * Validation functions, where the return code can be replaced with an error code. Example: `h3IsValid`
-* Property inspection functions, where the return code would be ambigous between invalid and the property being false. Example: `h3IsResClassIII`
+* Property inspection functions, where the return code would be ambiguous between invalid and the property being false. Example: `h3IsResClassIII`
 
 ### H3Error type
 
@@ -294,7 +294,7 @@ getH3UnidirectionalEdge(AN_INDEX, AN_INDEX_FAR_AWAY, &out) => E_NOT_NEIGHBORS
 
 Bindings should translate error codes into the error handling mechanism appropriate to their language. For example, Java will convert error codes into Java Exceptions.
 
-When possible, it is preferrable to retain the error code. When this is not possible it is fine to elide them. Language bindings should include error messages that are formatted as is usual in their language. An example in Java could be:
+When possible, it is preferable to retain the error code. When this is not possible it is fine to elide them. Language bindings should include error messages that are formatted as is usual in their language. An example in Java could be:
 
 ```
 public class H3Exception extends Exception {

--- a/website/docs/highlights/indexing.md
+++ b/website/docs/highlights/indexing.md
@@ -20,7 +20,7 @@ While geographic containment is approximate, logical containment in the index is
 
 This approximation allows for efficiently relating datasets indexed at different resolutions of the H3 grid. The functions for changing precision (`h3ToParent`, `h3ToChildren`) are implemented with only a few bitwise operations, making them very fast. The structure of the H3 index means that geographically close locations will tend to have numerically close indexes.
 
-The hierachical structure can also be used in analysis, when the precision or uncertainty for a location needs to be encoded in the spatial index. For example, a point from a GPS receiver could be indexed at a coarser resolution when the precision of the signal is lower, or some cells could be aggregated to a parent cell when there are too few data points in each of the finer cells.
+The hierarchical structure can also be used in analysis, when the precision or uncertainty for a location needs to be encoded in the spatial index. For example, a point from a GPS receiver could be indexed at a coarser resolution when the precision of the signal is lower, or some cells could be aggregated to a parent cell when there are too few data points in each of the finer cells.
 
 Hierarchical containment allows for use cases like making contiguous sets of cells "compact" with `compactCells`. It is then possible to `uncompactCells` to the same input set of cells, or to test whether a cell is contained by the compact set.
 

--- a/website/docs/library/errors.md
+++ b/website/docs/library/errors.md
@@ -60,7 +60,7 @@ The H3 library may always add additional error messages. Error messages not reco
 
 Bindings translate error codes into the error handling mechanism appropriate to their language. For example, Java will convert error codes into Java Exceptions.
 
-When possible, it is preferrable to retain the error code. When this is not possible it is fine to elide them. Language bindings should include error messages that are formatted as is usual in their language.
+When possible, it is preferable to retain the error code. When this is not possible it is fine to elide them. Language bindings should include error messages that are formatted as is usual in their language.
 
 ## References
 

--- a/website/versioned_docs/version-3.x/highlights/indexing.md
+++ b/website/versioned_docs/version-3.x/highlights/indexing.md
@@ -20,7 +20,7 @@ While geographic containment is approximate, logical containment in the index is
 
 This approximation allows for efficiently relating datasets indexed at different resolutions of the H3 grid. The functions for changing precision (`h3ToParent`, `h3ToChildren`) are implemented with only a few bitwise operations, making them very fast. The structure of the H3 index means that geographically close locations will tend to have numerically close indexes.
 
-The hierachical structure can also be used in analysis, when the precision or uncertainty for a location needs to be encoded in the spatial index. For example, a point from a GPS receiver could be indexed at a coarser resolution when the precision of the signal is lower, or some cells could be aggregated to a parent cell when there are too few data points in each of the finer cells.
+The hierarchical structure can also be used in analysis, when the precision or uncertainty for a location needs to be encoded in the spatial index. For example, a point from a GPS receiver could be indexed at a coarser resolution when the precision of the signal is lower, or some cells could be aggregated to a parent cell when there are too few data points in each of the finer cells.
 
 Hierarchical containment allows for use cases like making contiguous sets of cells "compact" with `compactCells`. It is then possible to `uncompactCells` to the same input set of cells, or to test whether a cell is contained by the compact set.
 


### PR DESCRIPTION
There are small typos in:
- dev-docs/RFCs/v4.0.0/error-handling-rfc.md
- website/docs/highlights/indexing.md
- website/docs/library/errors.md
- website/versioned_docs/version-3.x/highlights/indexing.md

Fixes:
- Should read `preferable` rather than `preferrable`.
- Should read `hierarchical` rather than `hierachical`.
- Should read `ambiguous` rather than `ambigous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md