### PR TITLE
Add error returns to maxGridDiskSize

### DIFF
--- a/examples/neighbors.c
+++ b/examples/neighbors.c
@@ -27,7 +27,8 @@ int main(int argc, char *argv[]) {
     // Distance away from the origin to find:
     int k = 2;
 
-    int maxNeighboring = maxGridDiskSize(k);
+    int64_t maxNeighboring;
+    maxGridDiskSize(k, &maxNeighboring);
     H3Index *neighboring = calloc(maxNeighboring, sizeof(H3Index));
     gridDisk(indexed, k, neighboring);
 

--- a/src/apps/benchmarks/benchmarkGridDiskCells.c
+++ b/src/apps/benchmarks/benchmarkGridDiskCells.c
@@ -23,7 +23,9 @@ H3Index pentagon = 0x89080000003ffff;
 
 BEGIN_BENCHMARKS();
 
-H3Index *out = malloc(H3_EXPORT(maxGridDiskSize)(40) * sizeof(H3Index));
+int64_t outSz;
+H3_EXPORT(maxGridDiskSize)(40, &outSz);
+H3Index *out = calloc(outSz, sizeof(H3Index));
 
 BENCHMARK(gridDisk10, 10000, { H3_EXPORT(gridDisk)(hex, 10, out); });
 BENCHMARK(gridDisk20, 10000, { H3_EXPORT(gridDisk)(hex, 20, out); });

--- a/src/apps/benchmarks/benchmarkGridDiskCells.c
+++ b/src/apps/benchmarks/benchmarkGridDiskCells.c
@@ -24,7 +24,10 @@ H3Index pentagon = 0x89080000003ffff;
 BEGIN_BENCHMARKS();
 
 int64_t outSz;
-H3_EXPORT(maxGridDiskSize)(40, &outSz);
+if (H3_EXPORT(maxGridDiskSize)(40, &outSz)) {
+    printf("Failed\n");
+    return 1;
+}
 H3Index *out = calloc(outSz, sizeof(H3Index));
 
 BENCHMARK(gridDisk10, 10000, { H3_EXPORT(gridDisk)(hex, 10, out); });

--- a/src/apps/filters/gridDisk.c
+++ b/src/apps/filters/gridDisk.c
@@ -36,12 +36,13 @@
 #include "utility.h"
 
 void doCell(H3Index h, int k, int printDistances) {
-    int maxSize = H3_EXPORT(maxGridDiskSize)(k);
+    int64_t maxSize;
+    H3_EXPORT(maxGridDiskSize)(k, &maxSize);
     H3Index *rings = calloc(maxSize, sizeof(H3Index));
     int *distances = calloc(maxSize, sizeof(int));
     H3_EXPORT(gridDiskDistances)(h, k, rings, distances);
 
-    for (int i = 0; i < maxSize; i++) {
+    for (int64_t i = 0; i < maxSize; i++) {
         if (rings[i] != 0) {
             h3Print(rings[i]);
             if (printDistances) {

--- a/src/apps/filters/gridDiskUnsafe.c
+++ b/src/apps/filters/gridDiskUnsafe.c
@@ -37,11 +37,12 @@
 #include "utility.h"
 
 void doCell(H3Index h, int k) {
-    int maxSize = H3_EXPORT(maxGridDiskSize)(k);
+    int64_t maxSize;
+    H3_EXPORT(maxGridDiskSize)(k, &maxSize);
     H3Index *rings = calloc(maxSize, sizeof(H3Index));
 
     if (!H3_EXPORT(gridDiskUnsafe)(h, k, rings)) {
-        for (int i = 0; i < maxSize; i++) {
+        for (int64_t i = 0; i < maxSize; i++) {
             h3Println(rings[i]);
         }
     } else {

--- a/src/apps/fuzzers/fuzzerGridDisk.c
+++ b/src/apps/fuzzers/fuzzerGridDisk.c
@@ -35,7 +35,8 @@ int main(int argc, char *argv[]) {
     }
     fclose(fp);
 
-    int sz = H3_EXPORT(maxGridDiskSize)(args.k);
+    int64_t sz;
+    H3_EXPORT(maxGridDiskSize)(args.k, &sz);
     H3Index *results = calloc(sizeof(H3Index), sz);
     if (results != NULL) {
         H3_EXPORT(gridDisk)(args.index, args.k, results);

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -30,7 +30,8 @@ H3Index uncompactableWithZero[] = {0x89283470803ffff, 0x8928347081bffff, 0,
 SUITE(compactCells) {
     TEST(roundtrip) {
         int k = 9;
-        int hexCount = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t hexCount;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &hexCount));
         int expectedCompactCount = 73;
 
         // Generate a set of hexagons to compact
@@ -42,7 +43,7 @@ SUITE(compactCells) {
             H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount));
 
         int count = 0;
-        for (int i = 0; i < hexCount; i++) {
+        for (int64_t i = 0; i < hexCount; i++) {
             if (compressed[i] != 0) {
                 count++;
             }

--- a/src/apps/testapps/testDirectedEdge.c
+++ b/src/apps/testapps/testDirectedEdge.c
@@ -41,7 +41,9 @@ SUITE(directedEdge) {
                  "an index does not neighbor itself");
 
         int neighbors = 0;
-        for (int i = 0; i < H3_EXPORT(maxGridDiskSize)(1); i++) {
+        int64_t neighborsSize;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(1, &neighborsSize));
+        for (int64_t i = 0; i < neighborsSize; i++) {
             if (ring[i] != 0 && H3_EXPORT(areNeighborCells)(sf, ring[i])) {
                 neighbors++;
             }
@@ -53,7 +55,8 @@ SUITE(directedEdge) {
         t_assertSuccess(H3_EXPORT(gridRingUnsafe)(sf, 2, largerRing));
 
         neighbors = 0;
-        for (int i = 0; i < H3_EXPORT(maxGridDiskSize)(2); i++) {
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(2, &neighborsSize));
+        for (int64_t i = 0; i < neighborsSize; i++) {
             if (largerRing[i] != 0 &&
                 H3_EXPORT(areNeighborCells)(sf, largerRing[i])) {
                 neighbors++;

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -388,10 +388,10 @@ SUITE(gridDisk) {
             "gridDiskDistances invalid k");
         t_assert(H3_EXPORT(gridDiskDistancesUnsafe)(index, -1, NULL, NULL) ==
                      E_DOMAIN,
-                 "gridDiskDistancesUnsafe invaldi k");
+                 "gridDiskDistancesUnsafe invalid k");
         t_assert(
             H3_EXPORT(gridDiskDistancesSafe)(index, -1, NULL, NULL) == E_DOMAIN,
-            "gridDiskDistancesSafe invaldi k");
+            "gridDiskDistancesSafe invalid k");
     }
 
     TEST(maxGridDiskSize_invalid) {

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -29,7 +29,8 @@
 
 static void gridDisk_equals_gridDiskDistancesSafe_assertions(H3Index h3) {
     for (int k = 0; k < 3; k++) {
-        int kSz = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
 
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
         int *distances = calloc(kSz, sizeof(int));
@@ -43,11 +44,11 @@ static void gridDisk_equals_gridDiskDistancesSafe_assertions(H3Index h3) {
 
         int found = 0;
         int internalFound = 0;
-        for (int iNeighbor = 0; iNeighbor < kSz; iNeighbor++) {
+        for (int64_t iNeighbor = 0; iNeighbor < kSz; iNeighbor++) {
             if (neighbors[iNeighbor] != 0) {
                 found++;
 
-                for (int iInternal = 0; iInternal < kSz; iInternal++) {
+                for (int64_t iInternal = 0; iInternal < kSz; iInternal++) {
                     if (internalNeighbors[iInternal] == neighbors[iNeighbor]) {
                         internalFound++;
 
@@ -360,7 +361,8 @@ SUITE(gridDisk) {
 
     TEST(gridDiskInvalid) {
         int k = 1000;
-        int kSz = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
         t_assert(H3_EXPORT(gridDisk)(0x7fffffffffffffff, k, neighbors) ==
                      E_CELL_INVALID,
@@ -370,7 +372,8 @@ SUITE(gridDisk) {
 
     TEST(gridDiskInvalidDigit) {
         int k = 2;
-        int kSz = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
         H3Index *neighbors = calloc(kSz, sizeof(H3Index));
         t_assert(H3_EXPORT(gridDisk)(0x4d4b00fe5c5c3030, k, neighbors) ==
                      E_CELL_INVALID,

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -380,4 +380,29 @@ SUITE(gridDisk) {
                  "gridDisk returns error for invalid input");
         free(neighbors);
     }
+
+    TEST(gridDiskDistances_invalidK) {
+        H3Index index = 0x811d7ffffffffff;
+        t_assert(
+            H3_EXPORT(gridDiskDistances)(index, -1, NULL, NULL) == E_DOMAIN,
+            "gridDiskDistances invalid k");
+        t_assert(H3_EXPORT(gridDiskDistancesUnsafe)(index, -1, NULL, NULL) ==
+                     E_DOMAIN,
+                 "gridDiskDistancesUnsafe invaldi k");
+        t_assert(
+            H3_EXPORT(gridDiskDistancesSafe)(index, -1, NULL, NULL) == E_DOMAIN,
+            "gridDiskDistancesSafe invaldi k");
+    }
+
+    TEST(maxGridDiskSize_invalid) {
+        int64_t sz;
+        t_assert(H3_EXPORT(maxGridDiskSize)(-1, &sz) == E_DOMAIN,
+                 "negative k is invalid");
+    }
+
+    TEST(maxGridDiskSize_large) {
+        int64_t sz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(26755, &sz));
+        t_assert(sz == 2147570341, "large (> 32 bit signed int) k works");
+    }
 }

--- a/src/apps/testapps/testGridDisksUnsafe.c
+++ b/src/apps/testapps/testGridDisksUnsafe.c
@@ -76,4 +76,9 @@ SUITE(gridDisksUnsafe) {
                  "Expected error on gridDisksUnsafe");
         free(allKrings);
     }
+
+    TEST(invalid_k) {
+        t_assert(H3_EXPORT(gridDisksUnsafe)(k1, 6, -1, NULL) == E_DOMAIN,
+                 "gridDisksUnsafe invalid k");
+    }
 }

--- a/src/apps/testapps/testGridDistanceExhaustive.c
+++ b/src/apps/testapps/testGridDistanceExhaustive.c
@@ -45,14 +45,15 @@ static void gridDistance_gridDisk_assertions(H3Index h3) {
     t_assert(r <= 5, "resolution supported by test function (gridDisk)");
     int maxK = MAX_DISTANCES[r];
 
-    int sz = H3_EXPORT(maxGridDiskSize)(maxK);
+    int64_t sz;
+    t_assertSuccess(H3_EXPORT(maxGridDiskSize)(maxK, &sz));
     H3Index *neighbors = calloc(sz, sizeof(H3Index));
     int *distances = calloc(sz, sizeof(int));
 
     t_assertSuccess(
         H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances));
 
-    for (int i = 0; i < sz; i++) {
+    for (int64_t i = 0; i < sz; i++) {
         if (neighbors[i] == 0) {
             continue;
         }

--- a/src/apps/testapps/testGridPathCellsExhaustive.c
+++ b/src/apps/testapps/testGridPathCellsExhaustive.c
@@ -81,7 +81,8 @@ static void gridPathCells_gridDisk_assertions(H3Index h3) {
     t_assert(r <= 5, "resolution supported by test function (gridDisk)");
     int maxK = MAX_DISTANCES[r];
 
-    int sz = H3_EXPORT(maxGridDiskSize)(maxK);
+    int64_t sz;
+    t_assertSuccess(H3_EXPORT(maxGridDiskSize)(maxK, &sz));
 
     if (H3_EXPORT(isPentagon)(h3)) {
         return;

--- a/src/apps/testapps/testGridRingUnsafe.c
+++ b/src/apps/testapps/testGridRingUnsafe.c
@@ -113,7 +113,8 @@ SUITE(gridRingUnsafe) {
 
                     for (int k = 0; k < 3; k++) {
                         int ringSz = k != 0 ? 6 * k : 1;
-                        int kSz = H3_EXPORT(maxGridDiskSize)(k);
+                        int64_t kSz;
+                        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
 
                         H3Index *ring = calloc(ringSz, sizeof(H3Index));
                         H3Error failed =
@@ -133,7 +134,7 @@ SUITE(gridRingUnsafe) {
                                 if (ring[iRing] != 0) {
                                     found++;
 
-                                    for (int iInternal = 0; iInternal < kSz;
+                                    for (int64_t iInternal = 0; iInternal < kSz;
                                          iInternal++) {
                                         if (internalNeighbors[iInternal] ==
                                             ring[iRing]) {

--- a/src/apps/testapps/testH3Memory.c
+++ b/src/apps/testapps/testH3Memory.c
@@ -95,7 +95,8 @@ static GeoPolygon sfGeoPolygon;
 SUITE(h3Memory) {
     TEST(gridDisk) {
         int k = 2;
-        int hexCount = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t hexCount;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &hexCount));
         H3Index *gridDiskOutput = calloc(hexCount, sizeof(H3Index));
 
         resetMemoryCounters(0);
@@ -116,7 +117,7 @@ SUITE(h3Memory) {
         t_assert(actualAllocCalls == 1, "gridDisk called alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 
-        for (int i = 0; i < hexCount; i++) {
+        for (int64_t i = 0; i < hexCount; i++) {
             t_assert(!gridDiskOutput[i],
                      "gridDisk did not produce output without alloc");
         }
@@ -126,8 +127,9 @@ SUITE(h3Memory) {
 
     TEST(compactCells) {
         int k = 9;
-        int hexCount = H3_EXPORT(maxGridDiskSize)(k);
-        int expectedCompactCount = 73;
+        int64_t hexCount;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &hexCount));
+        int64_t expectedCompactCount = 73;
 
         // Generate a set of hexagons to compact
         H3Index *sunnyvaleExpanded = calloc(hexCount, sizeof(H3Index));
@@ -170,8 +172,8 @@ SUITE(h3Memory) {
         t_assert(actualAllocCalls == 4, "alloc called four times");
         t_assert(actualFreeCalls == 4, "free called four times");
 
-        int count = 0;
-        for (int i = 0; i < hexCount; i++) {
+        int64_t count = 0;
+        for (int64_t i = 0; i < hexCount; i++) {
             if (compressed[i] != 0) {
                 count++;
             }

--- a/src/apps/testapps/testH3NeighborRotations.c
+++ b/src/apps/testapps/testH3NeighborRotations.c
@@ -50,7 +50,8 @@ typedef struct {
 
 void doCell(H3Index h, int maxK, TestOutput *testOutput) {
     for (int k = 0; k < maxK; k++) {
-        int maxSz = H3_EXPORT(maxGridDiskSize)(k);
+        int64_t maxSz;
+        H3_EXPORT(maxGridDiskSize)(k, &maxSz);
         H3Index *gridDiskInternalOutput = calloc(sizeof(H3Index), maxSz);
         H3Index *gridDiskUnsafeOutput = calloc(sizeof(H3Index), maxSz);
         int *gridDiskInternalDistances = calloc(sizeof(int), maxSz);
@@ -77,7 +78,7 @@ void doCell(H3Index h, int maxK, TestOutput *testOutput) {
                     H3Index h2 = gridDiskUnsafeOutput[ii + startIdx];
                     int found = 0;
 
-                    for (int iii = 0; iii < maxSz; iii++) {
+                    for (int64_t iii = 0; iii < maxSz; iii++) {
                         if (gridDiskInternalOutput[iii] == h2 &&
                             gridDiskInternalDistances[iii] == i) {
                             found = 1;
@@ -99,7 +100,7 @@ void doCell(H3Index h, int maxK, TestOutput *testOutput) {
         } else if (gridDiskUnsafeFailed == E_PENTAGON) {
             testOutput->ret1++;
             int foundPent = 0;
-            for (int i = 0; i < maxSz; i++) {
+            for (int64_t i = 0; i < maxSz; i++) {
                 if (H3_EXPORT(isPentagon)(gridDiskInternalOutput[i])) {
                     foundPent = 1;
                     break;

--- a/src/apps/testapps/testH3ToLocalIjExhaustive.c
+++ b/src/apps/testapps/testH3ToLocalIjExhaustive.c
@@ -132,14 +132,15 @@ void localIjToH3_gridDisk_assertions(H3Index h3) {
     t_assert(r <= 5, "resolution supported by test function (gridDisk)");
     int maxK = MAX_DISTANCES[r];
 
-    int sz = H3_EXPORT(maxGridDiskSize)(maxK);
+    int64_t sz;
+    t_assertSuccess(H3_EXPORT(maxGridDiskSize)(maxK, &sz));
     H3Index *neighbors = calloc(sz, sizeof(H3Index));
     int *distances = calloc(sz, sizeof(int));
 
     t_assertSuccess(
         H3_EXPORT(gridDiskDistances)(h3, maxK, neighbors, distances));
 
-    for (int i = 0; i < sz; i++) {
+    for (int64_t i = 0; i < sz; i++) {
         if (neighbors[i] == 0) {
             continue;
         }

--- a/src/h3lib/include/algos.h
+++ b/src/h3lib/include/algos.h
@@ -52,5 +52,5 @@ H3Error _getEdgeHexagons(const GeoLoop *geoloop, int64_t numHexagons, int res,
 
 // The safe gridDiskDistances algorithm.
 H3Error _gridDiskDistancesInternal(H3Index origin, int k, H3Index *out,
-                                   int *distances, int maxIdx, int curK);
+                                   int *distances, int64_t maxIdx, int curK);
 #endif

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -226,7 +226,7 @@ DECLSPEC H3Error H3_EXPORT(cellToBoundary)(H3Index h3, CellBoundary *gp);
  * @{
  */
 /** @brief maximum number of hexagons in k-ring */
-DECLSPEC int H3_EXPORT(maxGridDiskSize)(int k);
+DECLSPEC H3Error H3_EXPORT(maxGridDiskSize)(int k, int64_t *out);
 
 /** @brief hexagons neighbors in all directions, assuming no pentagons */
 DECLSPEC H3Error H3_EXPORT(gridDiskUnsafe)(H3Index origin, int k, H3Index *out);

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -162,7 +162,7 @@ H3Error H3_EXPORT(maxGridDiskSize)(int k, int64_t *out) {
     if (k < 0) {
         return E_DOMAIN;
     }
-    *out = 3 * k * (k + 1) + 1;
+    *out = 3 * (int64_t)k * ((int64_t)k + 1) + 1;
     return E_SUCCESS;
 }
 

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -546,6 +546,9 @@ H3Error H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k, H3Index *out,
     // Pentagon being encountered is not itself a problem; really the deleted
     // k-subsequence is the problem, but for compatibility reasons we fail on
     // the pentagon.
+    if (k < 0) {
+        return E_DOMAIN;
+    }
 
     // k must be >= 0, so origin is always needed
     int idx = 0;

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -85,7 +85,7 @@ the output array may be left as zero, which can happen when crossing a pentagon.
 <TabItem value="c">
 
 ```c
-int maxGridDiskSize(int k);
+H3Error maxGridDiskSize(int k, int64_t *out);
 ```
 
 </TabItem>


### PR DESCRIPTION
This PR also changes the signature for this function to support `k` values where the number of cells is more than an `int32_t` can represent (i.e. `k=26755, maxGridDiskSize(26755)=2147570341`)