### PR TITLE
[website] Fix LiveEditor so code is displayed in the documentation (e.g. quickstart)

### DIFF
--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -10,6 +10,7 @@ import { LiveProvider, LiveEditor, LiveError, LiveContext } from "react-live";
 import clsx from "clsx";
 import Translate from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import usePrismTheme from "@theme/hooks/usePrismTheme";
 import styles from "./styles.module.css";
 
@@ -78,8 +79,8 @@ function EditorWithHeader() {
 }
 
 export default function Playground({ children, transformCode, ...props }) {
+  const isClient = useIsBrowser();
   const {
-    isClient,
     siteConfig: {
       themeConfig: {
         liveCodeBlock: { playgroundPosition },


### PR DESCRIPTION
Hi,

I am experimenting with H3 for a project at $work, and noticed that all the live code editors were showing the same error message in the H3 website (screenshot from <https://h3geo.org/docs/quickstart#point--cell>):

![image](https://user-images.githubusercontent.com/304786/147606392-de08a050-20de-4635-84d6-7cb6d8aa3c47.png)

I think it was due this this PR in docusaurus: https://github.com/facebook/docusaurus/pull/5349

The `isClient` was removed from the context, so in the theme configuration, `isClient` is always `undefined`. That causes the `code` to be always an empty string too.

This PR uses the `useIsBrowser` used in the linked PR in docusaurus. It works for me locally after this change :+1: 

![image](https://user-images.githubusercontent.com/304786/147606561-173c482a-5bd3-454a-a41c-2a3ae9018ad2.png)


Thanks for H3 :rocket: 
-Bruno