### PR TITLE
Add docs for vertex mode, compilation options

### DIFF
--- a/website/docs/api/directededge.mdx
+++ b/website/docs/api/directededge.mdx
@@ -1,16 +1,17 @@
 ---
 id: uniedge
-title: Unidirectional edge functions
-sidebar_label: Unidirectional edges
+title: Directed edge functions
+sidebar_label: Directed edges
 slug: /api/uniedge
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Unidirectional edges allow encoding the directed edge from one cell to a neighboring cell.
+Directed edges allow encoding the directed (that is, which cell is the origin and which is the destination can be determined)
+edge from one cell to a neighboring cell.
 
-## h3IndexesAreNeighbors
+## areNeighborCells
 
 <Tabs
   groupId="language"
@@ -25,47 +26,47 @@ Unidirectional edges allow encoding the directed edge from one cell to a neighbo
 <TabItem value="c">
 
 ```c
-int h3IndexesAreNeighbors(H3Index origin, H3Index destination);
+H3Error areNeighborCells(H3Index origin, H3Index destination, int *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_indexes_are_neighbors(origin, destination)
+h3.are_neighbor_cells(origin, destination)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-boolean h3IndexesAreNeighbors(long origin, long destination);
-boolean h3IndexesAreNeighbors(String origin, String destination);
+boolean areNeighborCells(long origin, long destination);
+boolean areNeighborCells(String origin, String destination);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3IndexesAreNeighbors(origin, destination)
+h3.areNeighborCells(origin, destination)
 ```
 
 ```js live
 function example() {
   const origin = '85283473fffffff';
   const destination = '85283477fffffff';
-  return String(h3.h3IndexesAreNeighbors(origin, destination));
+  return String(h3.areNeighborCells(origin, destination));
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Returns whether or not the provided H3Indexes are neighbors.
+Returns whether or not the provided H3 cell indexes are neighbors.
 
-Returns 1 if the indexes are neighbors, 0 otherwise.
+`out` will be 1 if the indexes are neighbors, 0 otherwise.
 
-## getH3UnidirectionalEdge
+## cellsToDirectedEdge
 
 <Tabs
   groupId="language"
@@ -80,36 +81,36 @@ Returns 1 if the indexes are neighbors, 0 otherwise.
 <TabItem value="c">
 
 ```c
-H3Index getH3UnidirectionalEdge(H3Index origin, H3Index destination);
+H3Error cellsToDirectedEdge(H3Index origin, H3Index destination, H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_h3_unidirectional_edge(origin, destination)
+h3.cells_to_directed_edge(origin, destination)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long getH3UnidirectionalEdge(long origin, long destination);
-String getH3UnidirectionalEdge(String origin, String destination);
+long cellsToDirectedEdge(long origin, long destination);
+String cellsToDirectedEdge(String origin, String destination);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getH3UnidirectionalEdge(h3Index)
+h3.cellsToDirectedEdge(h3Index)
 ```
 
 ```js live
 function example() {
   const origin = '85283473fffffff';
   const destination = '85283477fffffff';
-  return h3.getH3UnidirectionalEdge(origin, destination);
+  return h3.cellsToDirectedEdge(origin, destination);
 }
 ```
 
@@ -119,9 +120,9 @@ function example() {
 Returns a unidirectional edge H3 index based on the provided origin and
 destination.
 
-Returns 0 on error.
+Returns 0 on success.
 
-## h3UnidirectionalEdgeIsValid
+## isValidDirectedEdge
 
 <Tabs
   groupId="language"
@@ -136,35 +137,35 @@ Returns 0 on error.
 <TabItem value="c">
 
 ```c
-int h3UnidirectionalEdgeIsValid(H3Index edge);
+int isValidDirectedEdge(H3Index edge);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_unidirectional_edge_is_valid(edge)
+h3.is_valid_directed_edge(edge)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-boolean h3UnidirectionalEdgeIsValid(long edge);
-boolean h3UnidirectionalEdgeIsValid(String edgeAddress);
+boolean isValidDirectedEdge(long edge);
+boolean isValidDirectedEdge(String edgeAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3UnidirectionalEdgeIsValid(edge)
+h3.isValidDirectedEdge(edge)
 ```
 
 ```js live
 function example() {
   const edge = '115283473fffffff';
-  return String(h3.h3UnidirectionalEdgeIsValid(edge));
+  return String(h3.isValidDirectedEdge(edge));
 }
 ```
 
@@ -175,7 +176,7 @@ Determines if the provided H3Index is a valid unidirectional edge index.
 
 Returns 1 if it is a unidirectional edge H3Index, otherwise 0.
 
-## getOriginH3IndexFromUnidirectionalEdge
+## getDirectedEdgeOrigin
 
 <Tabs
   groupId="language"
@@ -190,35 +191,35 @@ Returns 1 if it is a unidirectional edge H3Index, otherwise 0.
 <TabItem value="c">
 
 ```c
-H3Index getOriginH3IndexFromUnidirectionalEdge(H3Index edge);
+H3Error getDirectedEdgeOrigin(H3Index edge, H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_origin_h3_index_from_unidirectional_edge(edge)
+h3.get_directed_edge_origin(edge)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long getOriginH3IndexFromUnidirectionalEdge(long edge);
-String getOriginH3IndexFromUnidirectionalEdge(String edgeAddress);
+long getDirectedEdgeOrigin(long edge);
+String getDirectedEdgeOrigin(String edgeAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getOriginH3IndexFromUnidirectionalEdge(h3Index)
+h3.getDirectedEdgeOrigin(h3Index)
 ```
 
 ```js live
 function example() {
   const edge = '115283473fffffff';
-  return h3.getOriginH3IndexFromUnidirectionalEdge(edge);
+  return h3.getDirectedEdgeOrigin(edge);
 }
 ```
 
@@ -227,7 +228,7 @@ function example() {
 
 Returns the origin hexagon from the unidirectional edge H3Index.
 
-## getDestinationH3IndexFromUnidirectionalEdge
+## getDirectedEdgeDestination
 
 <Tabs
   groupId="language"
@@ -242,35 +243,35 @@ Returns the origin hexagon from the unidirectional edge H3Index.
 <TabItem value="c">
 
 ```c
-H3Index getDestinationH3IndexFromUnidirectionalEdge(H3Index edge);
+H3Error getDirectedEdgeDestination(H3Index edge, H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_destination_h3_index_from_unidirectional_edge(edge)
+h3.get_directed_edge_destination(edge)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long getDestinationH3IndexFromUnidirectionalEdge(long edge);
-String getDestinationH3IndexFromUnidirectionalEdge(String edgeAddress);
+long getDirectedEdgeDestination(long edge);
+String getDirectedEdgeDestination(String edgeAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getDestinationH3IndexFromUnidirectionalEdge(edge)
+h3.getDirectedEdgeDestination(edge)
 ```
 
 ```js live
 function example() {
   const edge = '115283473fffffff';
-  return h3.getDestinationH3IndexFromUnidirectionalEdge(edge);
+  return h3.getDirectedEdgeDestination(edge);
 }
 ```
 
@@ -279,7 +280,7 @@ function example() {
 
 Returns the destination hexagon from the unidirectional edge H3Index.
 
-## getH3IndexesFromUnidirectionalEdge
+## directedEdgeToCells
 
 <Tabs
   groupId="language"
@@ -294,35 +295,35 @@ Returns the destination hexagon from the unidirectional edge H3Index.
 <TabItem value="c">
 
 ```c
-void getH3IndexesFromUnidirectionalEdge(H3Index edge, H3Index* originDestination);
+H3Error directedEdgeToCells(H3Index edge, H3Index* originDestination);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_h3_indexes_from_unidirectional_edge(edge)
+h3.directed_edge_to_cells(edge)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> getH3IndexesFromUnidirectionalEdge(long edge);
-List<String> getH3IndexesFromUnidirectionalEdge(String edgeAddress);
+List<Long> directedEdgeToCells(long edge);
+List<String> directedEdgeToCells(String edgeAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getH3IndexesFromUnidirectionalEdge(edge)
+h3.directedEdgeToCells(edge)
 ```
 
 ```js live
 function example() {
   const edge = '115283473fffffff';
-  return h3.getH3IndexesFromUnidirectionalEdge(edge);
+  return h3.directedEdgeToCells(edge);
 }
 ```
 
@@ -332,7 +333,7 @@ function example() {
 Returns the origin, destination pair of hexagon IDs for the given edge ID, which are placed at `originDestination[0]` and
 `originDestination[1]` respectively.
 
-## getH3UnidirectionalEdgesFromHexagon
+## originToDirectedEdges
 
 <Tabs
   groupId="language"
@@ -347,45 +348,46 @@ Returns the origin, destination pair of hexagon IDs for the given edge ID, which
 <TabItem value="c">
 
 ```c
-void getH3UnidirectionalEdgesFromHexagon(H3Index origin, H3Index* edges);
+H3Error originToDirectedEdges(H3Index origin, H3Index* edges);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_h3_unidirectional_edges_from_hexagon(h)
+h3.origin_to_directed_edges(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<Long> getH3UnidirectionalEdgesFromHexagon(long h3);
-List<String> getH3UnidirectionalEdgesFromHexagon(String h3);
+List<Long> originToDirectedEdges(long h3);
+List<String> originToDirectedEdges(String h3);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getH3UnidirectionalEdgesFromHexagon(h3Index)
+h3.originToDirectedEdges(h3Index)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.getH3UnidirectionalEdgesFromHexagon(h);
+  return h3.originToDirectedEdges(h);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Provides all of the unidirectional edges from the current H3Index. `edges` must be of length 6,
-and the number of undirectional edges placed in the array may be less than 6.
+Provides all of the directed edges from the current H3Index. `edges` must be of length 6,
+and the number of directed edges placed in the array may be less than 6. If this is the case,
+one of the members of the array will be `0`.
 
-## getH3UnidirectionalEdgeBoundary
+## directedEdgeToBoundary
 
 <Tabs
   groupId="language"
@@ -400,35 +402,35 @@ and the number of undirectional edges placed in the array may be less than 6.
 <TabItem value="c">
 
 ```c
-void getH3UnidirectionalEdgeBoundary(H3Index edge, GeoBoundary* gb);
+H3Error directedEdgeToBoundary(H3Index edge, CellBoundary* gb);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_h3_unidirectional_edge_boundary(edge, geo_json=False)
+h3.directed_edge_to_boundary(edge, geo_json=False)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-List<LatLng> getH3UnidirectionalEdgeBoundary(long edge);
-List<LatLng> getH3UnidirectionalEdgeBoundary(String edgeAddress);
+List<LatLng> directedEdgeToBoundary(long edge);
+List<LatLng> directedEdgeToBoundary(String edgeAddress);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getH3UnidirectionalEdgeBoundary(edge, [formatAsGeoJson])
+h3.directedEdgeToBoundary(edge, [formatAsGeoJson])
 ```
 
 ```js live
 function example() {
   const edge = '115283473fffffff';
-  return h3.getH3UnidirectionalEdgeBoundary(edge);
+  return h3.directedEdgeToBoundary(edge);
 }
 ```
 

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -237,7 +237,7 @@ Returns the center child (finer) index contained by `cell` at resolution `childR
 <TabItem value="c">
 
 ```c
-H3Error compactCells(const H3Index *cellSet, H3Index *compactedSet, const int numCells);
+H3Error compactCells(const H3Index *cellSet, H3Index *compactedSet, const int64_t numCells);
 ```
 
 </TabItem>
@@ -292,7 +292,7 @@ Returns 0 (`E_SUCCESS`) on success.
 <TabItem value="c">
 
 ```c
-H3Error uncompactCells(const H3Index *compactedSet, const int numCells, H3Index *cellSet, const int maxCells, const int res);
+H3Error uncompactCells(const H3Index *compactedSet, const int64_t numCells, H3Index *cellSet, const int64_t maxCells, const int res);
 ```
 
 </TabItem>

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -62,7 +62,8 @@ function example() {
 </TabItem>
 </Tabs>
 
-Indexes the location at the specified resolution, returning the index of the cell containing the location.
+Indexes the location at the specified resolution, returning the index of the cell containing the location. This buckets
+the geographic point into the H3 grid.
 
 Returns 0 (`E_SUCCESS`) on success.
 

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 These functions provide metadata about an H3 index, such as its resolution or base cell, and provide utilities for converting into and out of the 64-bit representation of an H3 index.
 
-## h3GetResolution
+## getResolution
 
 <Tabs
   groupId="language"
@@ -25,35 +25,35 @@ These functions provide metadata about an H3 index, such as its resolution or ba
 <TabItem value="c">
 
 ```c
-int h3GetResolution(H3Index h);
+int getResolution(H3Index h);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_get_resolution(h)
+h3.get_resolution(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-int h3GetResolution(long h3);
-int h3GetResolution(String h3Address);
+int getResolution(long h3);
+int getResolution(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3GetResolution(h)
+h3.getResolution(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3GetResolution(h);
+  return h3.getResolution(h);
 }
 ```
 
@@ -62,7 +62,7 @@ function example() {
 
 Returns the resolution of the index.
 
-## h3GetBaseCell
+## getBaseCellNumber
 
 <Tabs
   groupId="language"
@@ -77,35 +77,35 @@ Returns the resolution of the index.
 <TabItem value="c">
 
 ```c
-int h3GetBaseCell(H3Index h);
+int getBaseCellNumber(H3Index h);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_get_base_cell(h)
+h3.get_base_cell_number(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-int h3GetBaseCell(long h3);
-int h3GetBaseCell(String h3Address);
+int getBaseCellNumber(long h3);
+int getBaseCellNumber(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3GetBaseCell(h)
+h3.getBaseCellNumber(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3GetBaseCell(h);
+  return h3.getBaseCellNumber(h);
 }
 ```
 
@@ -202,7 +202,7 @@ Converts the `H3Index` representation of the index to the string representation.
 
 Returns 0 (`E_SUCCESS`) on success.
 
-## h3IsValid
+## isValidCell
 
 <Tabs
   groupId="language"
@@ -217,44 +217,44 @@ Returns 0 (`E_SUCCESS`) on success.
 <TabItem value="c">
 
 ```c
-int h3IsValid(H3Index h);
+int isValidCell(H3Index h);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_is_valid(h)
+h3.is_valid_cell(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-boolean h3IsValid(long h3);
-boolean h3IsValid(String h3Address);
+boolean isValidCell(long h3);
+boolean isValidCell(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3IsValid(h)
+h3.isValidCell(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3IsValid(h);
+  return h3.isValidCell(h);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Returns non-zero if this is a valid H3 index.
+Returns non-zero if this is a valid H3 cell index.
 
-## h3IsResClassIII
+## isResClassIII
 
 <Tabs
   groupId="language"
@@ -269,35 +269,35 @@ Returns non-zero if this is a valid H3 index.
 <TabItem value="c">
 
 ```c
-int h3IsResClassIII(H3Index h);
+int isResClassIII(H3Index h);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_is_res_class_III(h)
+h3.is_res_class_III(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-boolean h3IsResClassIII(long h3);
-boolean h3IsResClassIII(String h3Address);
+boolean isResClassIII(long h3);
+boolean isResClassIII(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3IsResClassIII(h)
+h3.isResClassIII(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3IsResClassIII(h);
+  return h3.isResClassIII(h);
 }
 ```
 
@@ -306,7 +306,7 @@ function example() {
 
 Returns non-zero if this index has a resolution with Class III orientation.
 
-## h3IsPentagon
+## isPentagon
 
 <Tabs
   groupId="language"
@@ -321,35 +321,35 @@ Returns non-zero if this index has a resolution with Class III orientation.
 <TabItem value="c">
 
 ```c
-int h3IsPentagon(H3Index h);
+int isPentagon(H3Index h);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.h3_is_pentagon(h)
+h3.is_pentagon(h)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-boolean h3IsPentagon(long h3);
-boolean h3IsPentagon(String h3Address);
+boolean isPentagon(long h3);
+boolean isPentagon(String h3Address);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.h3IsPentagon(h)
+h3.isPentagon(h)
 ```
 
 ```js live
 function example() {
   const h = '85283473fffffff';
-  return h3.h3IsPentagon(h);
+  return h3.isPentagon(h);
 }
 ```
 
@@ -429,7 +429,7 @@ Returns 0 (`E_SUCCESS`) on success.
 <TabItem value="c">
 
 ```c
-int maxFaceCount(H3Index h3);
+H3Error maxFaceCount(H3Index h3, int *out);
 ```
 
 </TabItem>

--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -120,7 +120,7 @@ function example() {
 
 Converts radians to degrees.
 
-## hexAreaKm2
+## getHexagonAreaAvgKm2
 
 <Tabs
   groupId="language"
@@ -135,43 +135,43 @@ Converts radians to degrees.
 <TabItem value="c">
 
 ```c
-double hexAreaKm2(int res);
+H3Error getHexagonAreaAvgKm2(int res, double *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.hex_area(res, unit='km^2')
+h3.get_hexagon_area_avg(res, unit='km^2')
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-double hexArea(int res, AreaUnit unit);
+double getHexagonAreaAvg(int res, AreaUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.hexArea(res, h3.UNITS.km2)
+h3.getHexagonAreaAvg(res, h3.UNITS.km2)
 ```
 
 ```js live
 function example() {
   const res = 5;
-  return h3.hexArea(res, h3.UNITS.km2);
+  return h3.getHexagonAreaAvg(res, h3.UNITS.km2);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Average hexagon area in square kilometers at the given resolution.
+Average hexagon area in square kilometers at the given resolution. Excludes pentagons.
 
-## hexAreaM2
+## getHexagonAreaAvgM2
 
 <Tabs
   groupId="language"
@@ -186,93 +186,43 @@ Average hexagon area in square kilometers at the given resolution.
 <TabItem value="c">
 
 ```c
-double hexAreaM2(int res);
+H3Error getHexagonAreaAvgM2(int res, double *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.hex_area(res, unit='m^2')
+h3.get_hexagon_area_avg(res, unit='m^2')
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-double hexArea(int res, AreaUnit unit);
+double getHexagonAreaAvg(int res, AreaUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.hexArea(res, h3.UNITS.m2)
+h3.getHexagonAreaAvg(res, h3.UNITS.m2)
 ```
 
 ```js live
 function example() {
   const res = 5;
-  return h3.hexArea(res, h3.UNITS.m2);
+  return h3.getHexagonAreaAvg(res, h3.UNITS.m2);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Average hexagon area in square meters at the given resolution.
+Average hexagon area in square meters at the given resolution. Excludes pentagons.
 
-## cellAreaM2
 
-<Tabs
-  groupId="language"
-  defaultValue="c"
-  values={[
-    {label: 'C', value: 'c'},
-    {label: 'Python', value: 'python'},
-    {label: 'Java', value: 'java'},
-    {label: 'JavaScript (Live)', value: 'javascript'},
-  ]
-}>
-<TabItem value="c">
-
-```c
-double cellAreaM2(H3Index h);
-```
-
-</TabItem>
-<TabItem value="python">
-
-```py
-h3.cell_area(h, unit='m^2')
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-double cellArea(long h3, AreaUnit unit);
-int cellArea(String h3Address, AreaUnit unit);
-```
-
-</TabItem>
-<TabItem value="javascript">
-
-```js
-h3.cellArea(h, h3.UNITS.m2)
-```
-
-```js live
-function example() {
-  const h = '85283473fffffff';
-  return h3.cellArea(h, h3.UNITS.m2);
-}
-```
-
-</TabItem>
-</Tabs>
-
-Exact area of specific cell in square meters.
 
 ## cellAreaRads2
 
@@ -289,7 +239,7 @@ Exact area of specific cell in square meters.
 <TabItem value="c">
 
 ```c
-double cellAreaRads2(H3Index h);
+H3Error cellAreaRads2(H3Index h, double *out);
 ```
 
 </TabItem>
@@ -326,7 +276,7 @@ function example() {
 
 Exact area of specific cell in square radians.
 
-## edgeLengthKm
+## cellAreaKm2
 
 <Tabs
   groupId="language"
@@ -341,43 +291,44 @@ Exact area of specific cell in square radians.
 <TabItem value="c">
 
 ```c
-double edgeLengthKm(int res);
+H3Error cellAreaKm2(H3Index h, double *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.edge_length(res, unit='km')
+h3.cell_area(h, unit='km^2')
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-double edgeLength(int res, LengthUnit unit);
+double cellArea(long h3, AreaUnit unit);
+int cellArea(String h3Address, AreaUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.edgeLength(res, h3.UNITS.km)
+h3.cellArea(h, h3.UNITS.km2)
 ```
 
 ```js live
 function example() {
-  const res = 5;
-  return h3.edgeLength(res, h3.UNITS.km);
+  const h = '85283473fffffff';
+  return h3.cellArea(h, h3.UNITS.km2);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Average hexagon edge length in kilometers at the given resolution.
+Exact area of specific cell in square kilometers.
 
-## edgeLengthM
+## cellAreaM2
 
 <Tabs
   groupId="language"
@@ -392,41 +343,144 @@ Average hexagon edge length in kilometers at the given resolution.
 <TabItem value="c">
 
 ```c
-double edgeLengthM(int res);
+H3Error cellAreaM2(H3Index h, double *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.edge_length(res, unit='m')
+h3.cell_area(h, unit='m^2')
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-double edgeLength(int res, LengthUnit unit);
+double cellArea(long h3, AreaUnit unit);
+int cellArea(String h3Address, AreaUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.edgeLength(res, h3.UNITS.km)
+h3.cellArea(h, h3.UNITS.m2)
 ```
 
 ```js live
 function example() {
-  const res = 5;
-  return h3.edgeLength(res, h3.UNITS.km);
+  const h = '85283473fffffff';
+  return h3.cellArea(h, h3.UNITS.m2);
 }
 ```
 
 </TabItem>
 </Tabs>
 
-Average hexagon edge length in meters at the given resolution.
+Exact area of specific cell in square meters.
+
+## getHexagonEdgeLengthAvgKm
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error getHexagonEdgeLengthAvgKm(int res, double *out);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.get_hexagon_edge_length_avg(res, unit='km')
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+double getHexagonEdgeLengthAvg(int res, LengthUnit unit);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.getHexagonEdgeLengthAvg(res, h3.UNITS.km)
+```
+
+```js live
+function example() {
+  const res = 5;
+  return h3.getHexagonEdgeLengthAvg(res, h3.UNITS.km);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Average hexagon edge length in kilometers at the given resolution. Excludes pentagons.
+
+## getHexagonEdgeLengthAvgM
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error getHexagonEdgeLengthAvgM(int res, double *out);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.get_hexagon_edge_length_avg(res, unit='m')
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+double getHexagonEdgeLengthAvg(int res, LengthUnit unit);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.getHexagonEdgeLengthAvg(res, h3.UNITS.m)
+```
+
+```js live
+function example() {
+  const res = 5;
+  return h3.getHexagonEdgeLengthAvg(res, h3.UNITS.m);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Average hexagon edge length in meters at the given resolution. Excludes pentagons.
 
 
 ## exactEdgeLengthKm
@@ -585,7 +639,7 @@ function example() {
 
 Exact edge length of specific unidirectional edge in radians.
 
-## numHexagons
+## getNumCells
 
 <Tabs
   groupId="language"
@@ -600,34 +654,34 @@ Exact edge length of specific unidirectional edge in radians.
 <TabItem value="c">
 
 ```c
-int64_t numHexagons(int res);
+H3Error getNumCells(int res, int64_t *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.num_hexagons(res)
+h3.get_num_cells(res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-long numHexagons(int res);
+long getNumCells(int res);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.numHexagons(res)
+h3.getNumCells(res)
 ```
 
 ```js live
 function example() {
   const res = 5;
-  return h3.numHexagons(res);
+  return h3.getNumCells(res);
 }
 ```
 
@@ -636,7 +690,7 @@ function example() {
 
 Number of unique H3 indexes at the given resolution.
 
-## getRes0Indexes
+## getRes0Cells
 
 <Tabs
   groupId="language"
@@ -651,35 +705,35 @@ Number of unique H3 indexes at the given resolution.
 <TabItem value="c">
 
 ```c
-void getRes0Indexes(H3Index *out);
+H3Error getRes0Cells(H3Index *out);
 ```
 
 </TabItem>
 <TabItem value="python">
 
 ```py
-h3.get_res0_indexes(res)
+h3.get_res0_cells(res)
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-Collection<Long> getRes0Indexes(int res);
-Collection<String> getRes0IndexesAddresses(int res);
+Collection<Long> getRes0Cells(int res);
+Collection<String> getRes0CellsAddresses(int res);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.getRes0Indexes(res)
+h3.getRes0Cells(res)
 ```
 
 ```js live
 function example() {
   const res = 5;
-  return h3.getRes0Indexes(res);
+  return h3.getRes0Cells(res);
 }
 ```
 
@@ -687,9 +741,9 @@ function example() {
 </Tabs>
 
 All the resolution 0 H3 indexes.
-`out` must be an array of at least size `res0IndexCount()`.
+`out` must be an array of at least size `res0CellCount()`.
 
-## res0IndexCount
+## res0CellCount
 
 <Tabs
   groupId="language"
@@ -704,7 +758,7 @@ All the resolution 0 H3 indexes.
 <TabItem value="c">
 
 ```c
-int res0IndexCount();
+int res0CellCount();
 ```
 
 </TabItem>
@@ -737,7 +791,7 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Number of resolution 0 H3 indexes.
+Number of resolution 0 H3 indexes, which is defined as 122.
 
 ## getPentagons
 
@@ -794,7 +848,7 @@ All the pentagon H3 indexes at the specified resolution.
 
 Returns 0 (`E_SUCCESS`) on success.
 
-## pentagonIndexCount
+## pentagonCount
 
 <Tabs
   groupId="language"
@@ -809,7 +863,7 @@ Returns 0 (`E_SUCCESS`) on success.
 <TabItem value="c">
 
 ```c
-int pentagonIndexCount();
+int pentagonCount();
 ```
 
 </TabItem>

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -118,7 +118,7 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Maximum number of indices that result from the gridDisk algorithm with the given k.
+Maximum number of indices that result from the `gridDisk` algorithm with the given `k`.
 
 ## gridDiskDistances
 
@@ -224,7 +224,7 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-gridDiskUnsafe produces indexes within k distance of the origin index.
+`gridDiskUnsafe` produces indexes within `k` distance of the origin index.
 The function returns an error code when one of the returned by this
 function is a pentagon or is in the pentagon distortion area. In this case,
 the output behavior of the `out` array is undefined.
@@ -233,7 +233,7 @@ k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
 all neighboring indexes, and so on.
 
 Output is placed in the provided array in order of increasing distance from
-the origin.
+the origin. The provided array must be of size `maxGridDiskSize(k)`.
 
 Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 
@@ -283,7 +283,7 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-gridDiskDistancesUnsafe produces indexes within k distance of the origin index.
+`gridDiskDistancesUnsafe` produces indexes within `k` distance of the origin index.
 Output behavior is undefined when one of the indexes returned by this
 function is a pentagon or is in the pentagon distortion area.
 
@@ -292,9 +292,66 @@ all neighboring indexes, and so on.
 
 Output is placed in the provided array in order of increasing distance from
 the origin. The distances in hexagons is placed in the distances array at
-the same offset.
+the same offset. The provided array must be of size `maxGridDiskSize(k)`.
 
 Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
+
+## gridDiskDistancesSafe
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error gridDiskDistancesSafe(H3Index origin, int k, H3Index* out, int* distances);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.grid_disk_distances_safe(h, k)
+```
+
+</TabItem>
+<TabItem value="java">
+
+:::note
+
+This function is not exposed because the same functionality is exposed by `gridDiskSafe`
+
+:::
+
+</TabItem>
+<TabItem value="javascript">
+
+:::note
+
+This function is not exposed.
+
+:::
+
+</TabItem>
+</Tabs>
+
+`gridDiskDistancesSafe` produces indexes within `k` distance of the origin index.
+
+k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
+all neighboring indexes, and so on.
+
+Output is placed in the provided array in order of increasing distance from
+the origin. The distances in hexagons is placed in the distances array at
+the same offset. The provided array must be of size `maxGridDiskSize(k)`.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 ## gridDisksUnsafe
 
@@ -342,9 +399,9 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-gridDisksUnsafe takes an array of input hex IDs and a max k-ring and returns an
+`gridDisksUnsafe` takes an array of input hex IDs and a max k and returns an
 array of hexagon IDs sorted first by the original hex IDs and then by the
-k-ring (0 to max), with no guaranteed sorting within each k-ring group.
+grid k-ring (0 to max), with no guaranteed sorting within each grid k-ring group.
 
 Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered. Otherwise, output
 is undefined

--- a/website/docs/api/vertex.mdx
+++ b/website/docs/api/vertex.mdx
@@ -1,0 +1,224 @@
+---
+id: vertex
+title: Vertex functions
+sidebar_label: Vertexes
+slug: /api/vertex
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Vertex mode allows encoding the topological vertexes of H3 cells.
+
+## cellToVertex
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error cellToVertex(H3Index origin, int vertexNum, H3Index *out);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.cell_to_vertex(origin, vertex_num)
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+Long cellToVertex(long origin, int vertexNum);
+String cellToVertex(String origin, int vertexNum);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.cellToVertex(origin, vertexNum)
+```
+
+```js live
+function example() {
+  const h = '85283473fffffff';
+  const vertexNum = 2;
+  return h3.cellToVertex(h, vertexNum);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Returns the index for the specified cell vertex. Valid vertex numbers are between 0 and 5 (inclusive)
+for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
+
+## cellToVertexes
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error cellToVertexes(H3Index origin, H3Index *out);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.cell_to_vertexes(origin)
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+List<Long> cellToVertexes(long origin);
+List<String> cellToVertexes(String origin);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.cellToVertexes(origin)
+```
+
+```js live
+function example() {
+  const h = '85283473fffffff';
+  return h3.cellToVertexes(h);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Returns the indexes for all vertexes of the given cell index.
+
+The length of the `out` array must be 6. If the given cell index represents a pentagon, one member of the
+array will be set to `0`.
+
+## vertexToLatLng
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error vertexToLatLng(H3Index vertex, LatLng *point);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.vertex_to_latlng(vertex)
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+LatLng vertexToLatLng(long vertex);
+LatLng vertexToLatLng(String vertex);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.vertexToLatLng(vertex)
+```
+
+```js live
+function example() {
+  const h = '85283473fffffff';
+  return h3.vertexToLatLng(h);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Returns the latitude and longitude coordinates of the given vertex.
+
+## isValidVertex
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Python', value: 'python'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+int isValidVertex(H3Index vertex);
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.is_valid_vertex(vertex)
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+boolean isValidVertex(long vertex);
+boolean isValidVertex(String vertex);
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.isValidVertex(vertex)
+```
+
+```js live
+function example() {
+  const h = '85283473fffffff';
+  return h3.isValidVertex(h);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Returns 1 if the given index represents a valid H3 vertex.

--- a/website/docs/core-library/compilation-options.md
+++ b/website/docs/core-library/compilation-options.md
@@ -1,0 +1,79 @@
+---
+id: compilation-options
+title: Compilation options
+sidebar_label: Compilation options
+slug: /core-library/compilation-options
+---
+
+A number of options in CMake can be set when compiling the H3 core library. These are relevant for building
+different ways of using and testing the library and do not effect the underlying algorithms.
+
+When configuring with CMake, an option may be specified using `-D` on the command line, like so for setting
+`CMAKE_BUILD_TYPE` to `Release`:
+
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Release
+```
+
+## BUILD_ALLOC_TESTS
+
+Whether to build the parts of the [test suite](./testing) that exercise the [H3_ALLOC_PREFIX](./custom-alloc) feature.
+
+## BUILD_BENCHMARKS
+
+Whether to build the [benchmark suite](./testing#benchmarks).
+
+## BUILD_FILTERS
+
+Whether to build the [H3 command line filter](./filters) executables.
+
+## BUILD_GENERATORS
+
+Whether to build generator executables used in the development of H3. This is not required for
+building the library as the output of these generators is checked in.
+
+## BUILD_TESTING
+
+Whether to build the [test suite](./testing).
+
+## CMAKE_BUILD_TYPE
+
+Should be set to `Release` for production builds, and `Debug` in development.
+
+## ENABLE_COVERAGE
+
+Whether to compile `Debug` builds with coverage instrumentation (compatible with GCC, Clang, and lcov).
+
+## ENABLE_DOCS
+
+Whether to build the Doxygen documentation. This is not the same as the [H3 website](https://github.com/uber/h3/tree/master/website),
+but is rather the documentation for the internal C library functions.
+
+## ENABLE_FORMAT
+
+Whether to enable using clang-format-9 to format source files before building. This should be enabled
+before submitting patches for H3 as continuous integration will fail if the formatting does not match.
+
+## ENABLE_LINTING
+
+## H3_ALLOC_PREFIX
+
+Used for directing the library to use a [different set of functions for memory management](./custom-alloc).
+
+## H3_PREFIX
+
+Used for [renaming the public API](./usage#function-renaming).
+
+## PRINT_TEST_FILES
+
+If enabled, CMake will print which CTest test case corresponds to which input file.
+
+## WARNINGS_AS_ERRORS
+
+Whether to treat compiler warnings as errors. While a useful tool for ensuring software quality, this should not be enabled
+for production builds as compiler warnings can change unexpectedly between versions.
+
+## WRAP_VALGRIND
+
+Whether to wrap invocations of the test suite with `valgrind` (if available).
+

--- a/website/docs/core-library/compilation-options.md
+++ b/website/docs/core-library/compilation-options.md
@@ -6,7 +6,7 @@ slug: /core-library/compilation-options
 ---
 
 A number of options in CMake can be set when compiling the H3 core library. These are relevant for building
-different ways of using and testing the library and do not effect the underlying algorithms.
+different ways of using and testing the library and do not affect the underlying algorithms.
 
 When configuring with CMake, an option may be specified using `-D` on the command line, like so for setting
 `CMAKE_BUILD_TYPE` to `Release`:

--- a/website/docs/core-library/compilation-options.md
+++ b/website/docs/core-library/compilation-options.md
@@ -15,6 +15,12 @@ When configuring with CMake, an option may be specified using `-D` on the comman
 cmake .. -DCMAKE_BUILD_TYPE=Release
 ```
 
+Boolean options should be set to `ON` or `OFF`, like so:
+
+```bash
+cmake .. -DBUILD_TESTING=OFF
+```
+
 ## BUILD_ALLOC_TESTS
 
 Whether to build the parts of the [test suite](./testing) that exercise the [H3_ALLOC_PREFIX](./custom-alloc) feature.
@@ -54,7 +60,14 @@ but is rather the documentation for the internal C library functions.
 Whether to enable using clang-format-9 to format source files before building. This should be enabled
 before submitting patches for H3 as continuous integration will fail if the formatting does not match.
 
+Only this version of clang-format should be used to format the sources as new releases of clang-format
+can change defaults, causing unintended churn of source code formatting.
+
 ## ENABLE_LINTING
+
+Whether to enable using clang-tidy to lint source files when building. Only invoked when
+[Makefile or Ninja CMake generators](https://cmake.org/cmake/help/latest/prop_tgt/LANG_CLANG_TIDY.html)
+are used.
 
 ## H3_ALLOC_PREFIX
 

--- a/website/docs/core-library/h3indexing.md
+++ b/website/docs/core-library/h3indexing.md
@@ -48,9 +48,9 @@ An H3 Cell index (mode 1) represents a cell (hexagon or pentagon) in the H3 grid
 
 The three bits for each unused digit are set to 7.
 
-### H3 Unidirectional Edge Index
+### H3 Directed Edge Index
 
-An H3 Undirectional Edge index (mode 2) represents a single directed edge between two cells (an "origin" cell and a neighboring "destination" cell). The components of the H3 Unidirectional Edge index are packed into a 64-bit integer in order, highest bit first, as follows:
+An H3 Directed Edge index (mode 2) represents a single directed edge between two cells (an "origin" cell and a neighboring "destination" cell). The components of the H3 Directed Edge index are packed into a 64-bit integer in order, highest bit first, as follows:
 
 * 1 bit reserved and set to 0,
 * 4 bits to indicate the H3 Unidirectional Edge index mode,
@@ -59,7 +59,7 @@ An H3 Undirectional Edge index (mode 2) represents a single directed edge betwee
 
 ### H3 Vertex Index
 
-An H3 Vertex index (mode 4) represents a single topological vertex in H3 grid system, shared by three cells. Note that this does not include the distortion vertexes occasionally present in a cell's geo boundary. An H3 Vertex is arbitrarily assigned one of the three neighboring cells as its "owner", which is used to calculate the canonical index and geo coordinate for the vertex. The components of the H3 Vertex index are packed into a 64-bit integer in order, highest bit first, as follows:
+An H3 Vertex index (mode 4) represents a single topological vertex in H3 grid system, shared by three cells. Note that this does not include the distortion vertexes occasionally present in a cell's geographic boundary. An H3 Vertex is arbitrarily assigned one of the three neighboring cells as its "owner", which is used to calculate the canonical index and geographic coordinates for the vertex. The components of the H3 Vertex index are packed into a 64-bit integer in order, highest bit first, as follows:
 
 * 1 bit reserved and set to 0,
 * 4 bits to indicate the H3 Vertex index mode,

--- a/website/docs/core-library/testing.md
+++ b/website/docs/core-library/testing.md
@@ -1,0 +1,43 @@
+---
+id: testing
+title: Testing strategy
+sidebar_label: Testing strategy
+slug: /core-library/testing
+---
+
+The H3 developers try to ensure the robustness and reliability of the H3 library. Tools used to do this include unit tests with coverage reporting
+and fuzzing.
+
+The H3 library may despite these efforts behave unexpectedly; in these cases the developers
+[welcome feedback and contributions](https://github.com/uber/h3/blob/master/CONTRIBUTING.md).
+
+## Unit testing
+
+Github Actions are used to run the H3 test suite for every commit. A variety of configurations, described below, are tested.
+
+Coverage information is collected in Coveralls. Because of the self-contained nature of the H3 library, we seek
+to have as close to 100% code coverage as possible.
+
+| Operating system | Compiler    | Processor architecture | Special notes
+| ---------------- | ----------- | ---------------------- | -------------
+| Linux (Ubuntu)   | Clang       | x64                    | clang-format-9 is used to ensure all code is consistently formatted
+| Linux            | Clang       | x64                    | An additional copy of the job runs with Valgrind
+| Linux            | Clang       | x64                    | An additional copy of the job runs with coverage reporting, and excerising the `H3_PREFIX` mechanism.
+| Linux            | gcc         | x64                    | 
+| Mac OS           | Apple Clang | x64                    | 
+| Windows          | MSVC        | x64                    | Static library
+| Windows          | MSVC        | x86                    | Static library
+| Windows          | MSVC        | x64                    | Dynamic library; testing is not run in this configuration
+| Windows          | MSVC        | x86                    | Dynamic library; testing is not run in this configuration
+
+## Benchmarks
+
+H3 uses benchmarks to offer a comparison of the library's performance between revisions.
+
+Benchmarks are automatically run on Linux x64 with Clang and GCC compilers for each commit in Github Actions.
+
+## Fuzzers
+
+H3 uses fuzzers to find novel inputs that crash or result in other undefined behavior.
+
+On each commit, CI is triggered to run [oss-fuzz](https://github.com/google/oss-fuzz/tree/master/projects/h3) for H3.

--- a/website/docs/core-library/usage.md
+++ b/website/docs/core-library/usage.md
@@ -21,5 +21,5 @@ The H3 API expects valid input. Behavior of the library may be undefined when gi
 
 ## Function renaming
 
-The [`H3_PREFIX`](./compilation-options#H3_PREFIX) exists to rename all functions in the H3 public API with a prefix chosen at compile time.
-Internal functions and symbols are not renamed.
+The [`H3_PREFIX`](./compilation-options#H3_PREFIX) exists to rename all functions in the H3 public API with a prefix chosen at compile time. The default is to have no prefix.
+This can be needed when linking multiple copies of the H3 library in order to avoid naming collisions. Internal functions and symbols are not renamed.

--- a/website/docs/core-library/usage.md
+++ b/website/docs/core-library/usage.md
@@ -18,3 +18,8 @@ The file `h3api.h.in` is preprocessed into the file `h3api.h` as part of H3's bu
 ## API preconditions
 
 The H3 API expects valid input. Behavior of the library may be undefined when given invalid input. Indexes should be validated with `h3IsValid` or `h3UnidirectionalEdgeIsValid` as appropriate.
+
+## Function renaming
+
+The [`H3_PREFIX`](./compilation-options#H3_PREFIX) exists to rename all functions in the H3 public API with a prefix chosen at compile time.
+Internal functions and symbols are not renamed.

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -152,13 +152,6 @@ You can build H3 as a shared library (DLL) on Windows, but the test suite does n
 
 :::
 
-```bash
-# Installing the bare build requirements
-sudo apt install cmake make gcc libtool
-# Installing useful tools for development
-sudo apt install clang-format cmake-curses-gui lcov doxygen
-```
-
 </TabItem>
 <TabItem value="freebsd">
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -48,6 +48,7 @@ module.exports = {
       "api/hierarchy",
       "api/regions",
       "api/uniedge",
+      "api/vertex",
       "api/misc",
     ],
     Community: [
@@ -61,9 +62,11 @@ module.exports = {
       "core-library/h3Indexing",
       "core-library/coordsystems",
       "core-library/creating-bindings",
+      "core-library/filters",
+      "core-library/compilation-options",
+      "core-library/testing",
       "core-library/custom-alloc",
       "core-library/usage",
-      "core-library/filters",
       {
         type: "category",
         label: "Algorithms",


### PR DESCRIPTION
Cleanup for v4 for functions that were not added or not named correctly in the docs; also added additional text about compilation options and fixed a few minor issues.