### PR TITLE
Fix cellToLatLng docs per #572

### DIFF
--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -63,7 +63,7 @@ function example() {
 </Tabs>
 
 Indexes the location at the specified resolution, returning the index of the cell containing the location. This buckets
-the geographic point into the H3 grid.
+the geographic point into the H3 grid. See the [algorithm description](../core-library/latLngToCellDesc) for more information.
 
 Returns 0 (`E_SUCCESS`) on success.
 
@@ -117,8 +117,14 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the coordinates of the centroid of the cell in the projection space. This is approximately the centroid of the cell
-on the sphere, and is centered on the center child of the cell.
+Finds the center of the cell in grid space. See the
+[algorithm description](../core-library/cellToLatLngDesc) for
+more information.
+
+The center will drift versus the centroid
+of the cell on Earth due to distortion from the gnomonic
+projection within the icosahedron face it resides on and its
+distance from the center of the icosahedron face.
 
 Returns 0 (`E_SUCCESS`) on success.
 
@@ -172,6 +178,9 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the boundary of the cell.
+Finds the boundary of the cell. See the
+[algorithm description](../core-library/cellToBoundaryDesc)
+for more information.
+
 
 Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -117,7 +117,8 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the centroid of the cell.
+Finds the coordinates of the centroid of the cell in the projection space. This is approximately the centroid of the cell
+on the sphere, and is centered on the center child of the cell.
 
 Returns 0 (`E_SUCCESS`) on success.
 

--- a/website/versioned_docs/version-3.x/api/indexing.mdx
+++ b/website/versioned_docs/version-3.x/api/indexing.mdx
@@ -62,7 +62,8 @@ function example() {
 </TabItem>
 </Tabs>
 
-Indexes the location at the specified resolution, returning the index of the cell containing the location.
+Indexes the location at the specified resolution, returning the index of the cell containing the location. This buckets
+the geographic point into the H3 grid. See the [algorithm description](../core-library/geoToH3desc) for more information.
 
 Returns 0 on error.
 
@@ -116,8 +117,14 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the coordinates of the centroid of the cell in the projection space. This is approximately the centroid of the cell
-on the sphere, and is centered on the center child of the cell.
+Finds the center of the cell in grid space. See the
+[algorithm description](../core-library/h3ToGeoDesc) for
+more information.
+
+The center will drift versus the centroid
+of the cell on Earth due to distortion from the gnomonic
+projection within the icosahedron face it resides on and its
+distance from the center of the icosahedron face.
 
 ## h3ToGeoBoundary
 
@@ -169,4 +176,6 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the boundary of the index.
+Finds the boundary of the cell. See the
+[algorithm description](../core-library/h3ToGeoBoundaryDesc)
+for more information.

--- a/website/versioned_docs/version-3.x/api/indexing.mdx
+++ b/website/versioned_docs/version-3.x/api/indexing.mdx
@@ -116,7 +116,8 @@ function example() {
 </TabItem>
 </Tabs>
 
-Finds the centroid of the index.
+Finds the coordinates of the centroid of the cell in the projection space. This is approximately the centroid of the cell
+on the sphere, and is centered on the center child of the cell.
 
 ## h3ToGeoBoundary
 


### PR DESCRIPTION
See #572; this is not the centroid of the cell geometry on the sphere but rather the centroid of the cell in the projected grid system, unprojected onto the sphere. These can differ so we should be exact.