### PR TITLE
Add h3 flutter

### DIFF
--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -32,6 +32,10 @@ As a C library, bindings can be made to call H3 functions from different program
 ## Clojure 
 
 - [Factual/geo](https://github.com/Factual/geo)
+- 
+## Dart 
+
+- [festelo/h3_flutter](https://github.com/festelo/h3_flutter)
 
 ## ECL
 

--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -32,7 +32,7 @@ As a C library, bindings can be made to call H3 functions from different program
 ## Clojure 
 
 - [Factual/geo](https://github.com/Factual/geo)
-- 
+
 ## Dart 
 
 - [festelo/h3_flutter](https://github.com/festelo/h3_flutter)


### PR DESCRIPTION
https://github.com/festelo/h3_flutter provides bindings to C version of H3 for [Flutter](https://flutter.dev/).  

There are bindings for 40 methods from H3 - https://pub.dev/documentation/h3_flutter/latest/h3_flutter/H3-class.html
And 2 methods from geo2json - `h3SetToFeatureCollection` and `h3ToFeature`.

All these methods are covered by unit tests (which mostly were ported from h3-js lib)
