### PR TITLE
Quickstart.md: centroid -> center

### DIFF
--- a/website/docs/quickstart.md
+++ b/website/docs/quickstart.md
@@ -22,7 +22,7 @@ function example() {
 }
 ```
 
-The result is the identifier of the hexagonal cell in H3 containing this point. We can retrieve the centroid of this cell:
+The result is the identifier of the hexagonal cell in H3 containing this point. We can retrieve the center of this cell:
 
 ```js live
 function example() {


### PR DESCRIPTION
Similar to #574, don't want to use the term centroid to refer to the output of h3ToGeo/cellToLatLng. I didn't add more description as that is covered in the relevant API documentation.