### PR TITLE
FIX: Fix polyfill bug when vertex latitude exactly matches cell center

### DIFF
--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -48,26 +48,82 @@ SUITE(polygon) {
         BBox bbox;
         bboxFromGeoLoop(&geoloop, &bbox);
 
-        // For exact points on the polygon, we bias west and south,
-        // so only the southwest corner is considered in the polygon
+        // For exact points on the polygon, we bias west and south
         t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[0]),
-                 "!contains exact 0");
-        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[1]),
-                 "!contains exact 1");
-        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[2]),
-                 "!contains exact 2");
-        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[4]),
-                 "!contains exact 4");
-        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[5]),
-                 "!contains exact 5");
-
+                 "does not contain exact vertex 0");
         t_assert(pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[3]),
-                 "contains exact 3 (southwest corner)");
+                 "contains exact vertex 3");
 
         t_assert(pointInsideGeoLoop(&geoloop, &bbox, &inside),
                  "contains point inside");
         t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &somewhere),
                  "contains somewhere else");
+    }
+
+    TEST(pointInsideGeoLoopCornerCases) {
+        LatLng verts[] = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+        GeoLoop geoloop = {.numVerts = 4, .verts = verts};
+
+        BBox bbox;
+        bboxFromGeoLoop(&geoloop, &bbox);
+
+        LatLng point = {0, 0};
+
+        // Test corners. For exact points on the polygon, we bias west and
+        // north, so only the southeast corner is contained.
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "does not contain sw corner");
+        point.lat = 1;
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "does not contain nw corner ");
+        point.lng = 1;
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "does not contain ne corner ");
+        point.lat = 0;
+        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "contains se corner ");
+    }
+
+    TEST(pointInsideGeoLoopEdgeCases) {
+        LatLng verts[] = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+        GeoLoop geoloop = {.numVerts = 4, .verts = verts};
+
+        BBox bbox;
+        bboxFromGeoLoop(&geoloop, &bbox);
+
+        LatLng point;
+
+        // Test edges. Only points on south and east edges are contained.
+        point.lat = 0.5;
+        point.lng = 0;
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "does not contain point on west edge");
+        point.lat = 1;
+        point.lng = 0.5;
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "does not contain point on north edge");
+        point.lat = 0.5;
+        point.lng = 1;
+        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "contains point on east edge");
+        point.lat = 0;
+        point.lng = 0.5;
+        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "contains point on south edge");
+    }
+
+    TEST(pointInsideGeoLoopExtraEdgeCase) {
+        // This is a carefully crafted shape + point to hit an otherwise
+        // missed branch in coverage
+        LatLng verts[] = {{0, 0}, {1, 0.5}, {0, 1}};
+        GeoLoop geoloop = {.numVerts = 4, .verts = verts};
+
+        BBox bbox;
+        bboxFromGeoLoop(&geoloop, &bbox);
+
+        LatLng point = {0.5, 0.5};
+        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &point),
+                 "contains inside point matching longitude of a vertex");
     }
 
     TEST(pointInsideGeoLoopTransmeridian) {

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -48,10 +48,22 @@ SUITE(polygon) {
         BBox bbox;
         bboxFromGeoLoop(&geoloop, &bbox);
 
+        // For exact points on the polygon, we bias west and south,
+        // so only the southwest corner is considered in the polygon
         t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[0]),
-                 "contains exact");
-        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[4]),
-                 "contains exact 4");
+                 "!contains exact 0");
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[1]),
+                 "!contains exact 1");
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[2]),
+                 "!contains exact 2");
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[4]),
+                 "!contains exact 4");
+        t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[5]),
+                 "!contains exact 5");
+
+        t_assert(pointInsideGeoLoop(&geoloop, &bbox, &sfVerts[3]),
+                 "contains exact 3 (southwest corner)");
+
         t_assert(pointInsideGeoLoop(&geoloop, &bbox, &inside),
                  "contains point inside");
         t_assert(!pointInsideGeoLoop(&geoloop, &bbox, &somewhere),

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -94,7 +94,14 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE *loop, const BBox *bbox,
 
         // If the latitude matches exactly, we'll hit an edge case where
         // the ray passes through the vertex twice on successive segment
-        // checks. To avoid this, adjust the latiude northward if needed
+        // checks. To avoid this, adjust the latiude northward if needed.
+        //
+        // NOTE: This currently means that a point at the north pole cannot
+        // be contained in any polygon. This is acceptable in current usage,
+        // because the point we test in this function at present is always
+        // a cell center or vertex, and no cell has a center or vertex on the
+        // north pole. If we need to expand this algo to more generic uses we
+        // might need to handle this edge case.
         if (lat == a.lat || lat == b.lat) {
             lat += DBL_EPSILON;
         }

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -92,6 +92,13 @@ bool GENERIC_LOOP_ALGO(pointInside)(const TYPE *loop, const BBox *bbox,
             b = tmp;
         }
 
+        // If the latitude matches exactly, we'll hit an edge case where
+        // the ray passes through the vertex twice on successive segment
+        // checks. To avoid this, adjust the latiude northward if needed
+        if (lat == a.lat || lat == b.lat) {
+            lat += DBL_EPSILON;
+        }
+
         // If we're totally above or below the latitude ranges, the test
         // ray cannot intersect the line segment, so let's move on
         if (lat < a.lat || lat > b.lat) {


### PR DESCRIPTION
Fixes #595 

The issue here (I think?) is that rays cast directly through a vertex of the polygon were being counted twice, once for each adjoining segment. This uses the same "bias in an arbitrary direction" approach we used for longitude matches, which should also ensure no overlap between contiguous polygons, which I think was previously an issue.