### PR TITLE
Add E_VALUE and E_MEMORY / E_MEMORY_ALLOC

### DIFF
--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -82,26 +82,30 @@ typedef enum {
     E_SUCCESS = 0,  // Success (no error)
     E_FAILED =
         1,  // The operation failed but a more specific error is not available
-    E_DOMAIN = 2,  // Argument was outside of acceptable range (when a more
+    E_VALUE =
+        2,  // Value error (when a more specific error code is not available)
+    E_DOMAIN = 3,  // Argument was outside of acceptable range (when a more
                    // specific error code is not available)
     E_LATLNG_DOMAIN =
-        3,  // Latitude or longitude arguments were outside of acceptable range
-    E_RES_DOMAIN = 4,    // Resolution argument was outside of acceptable range
-    E_CELL_INVALID = 5,  // `H3Index` cell argument was not valid
-    E_DIR_EDGE_INVALID = 6,  // `H3Index` directed edge argument was not valid
+        4,  // Latitude or longitude arguments were outside of acceptable range
+    E_RES_DOMAIN = 5,    // Resolution argument was outside of acceptable range
+    E_CELL_INVALID = 6,  // `H3Index` cell argument was not valid
+    E_DIR_EDGE_INVALID = 7,  // `H3Index` directed edge argument was not valid
     E_UNDIR_EDGE_INVALID =
-        7,                 // `H3Index` undirected edge argument was not valid
-    E_VERTEX_INVALID = 8,  // `H3Index` vertex argument was not valid
-    E_PENTAGON = 9,  // Pentagon distortion was encountered which the algorithm
-                     // could not handle it
-    E_DUPLICATE_INPUT = 10,  // Duplicate input was encountered in the arguments
+        8,                 // `H3Index` undirected edge argument was not valid
+    E_VERTEX_INVALID = 9,  // `H3Index` vertex argument was not valid
+    E_PENTAGON = 10,  // Pentagon distortion was encountered which the algorithm
+                      // could not handle it
+    E_DUPLICATE_INPUT = 11,  // Duplicate input was encountered in the arguments
                              // and the algorithm could not handle it
-    E_NOT_NEIGHBORS = 11,    // `H3Index` cell arguments were not neighbors
+    E_NOT_NEIGHBORS = 12,    // `H3Index` cell arguments were not neighbors
     E_RES_MISMATCH =
-        12,         // `H3Index` cell arguments had incompatible resolutions
-    E_MEMORY = 13,  // Necessary memory allocation failed
-    E_MEMORY_BOUNDS = 14,  // Bounds of provided memory were not large enough
-    E_OPTION_INVALID = 15  // Mode or flags argument was not valid.
+        13,         // `H3Index` cell arguments had incompatible resolutions
+    E_MEMORY = 14,  // Error related to memory (when a more specific error code
+                    // is not available)
+    E_MEMORY_ALLOC = 15,   // Necessary memory allocation failed
+    E_MEMORY_BOUNDS = 16,  // Bounds of provided memory were not large enough
+    E_OPTION_INVALID = 17  // Mode or flags argument was not valid.
 } H3ErrorCodes;
 
 /* library version numbers generated from VERSION file */


### PR DESCRIPTION
Just to make the discussion concrete, this is what I was thinking around adding some error cases to fill out the error hierarchy. Related to https://github.com/uber/h3-py/pull/260

- E_FAILED
    + E_VALUE
        * E_DOMAIN
            - E_LATLNG_DOMAIN
            - E_RES_DOMAIN
        * E_RES_DOMAIN
        * E_CELL_INVALID
        * ...
        * E_OPTION_INVALID
    + E_MEMORY
        * E_MEMORY_ALLOC
        * E_MEMORY_BOUNDS

### Benefits

- this will line up exactly with the Python Exception hierarchy, so we won't need to document each separately; we can just have the `h3-py` documentation point to the C docs

### TODO (if accepted)

- [ ] update documentation