### PR TITLE
Added on the highlight section the fact that H3 cells are more or les…

### DIFF
--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -16,6 +16,7 @@ The H3 Core Library implements the H3 grid system. It includes functions for con
 * H3 is a hierarchical [geospatial index](/docs/highlights/indexing).
 * H3 was developed to address the [challenges of Uber's data science needs](/docs/highlights/aggregation).
 * H3 can be used to [join disparate data sets](/docs/highlights/joining).
+* H3 cells are more or less equal size at different latitudes
 * In addition to the benefits of the hexagonal grid shape, H3 includes features for [modeling flow](/docs/highlights/flowmodel).
 * H3 is well suited to apply [ML to geospatial data](/docs/highlights/ml).
 


### PR DESCRIPTION
…s equals size

One important reason to choose H3 over other global grid systems is that the cells are more or less equal size regardless of location. That makes it well suited for global analysis or global datasets.