### PR TITLE
rename E_MEMORY to E_MEMORY_ALLOC

### DIFF
--- a/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
+++ b/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
@@ -253,7 +253,7 @@ SQLite's approach to this is to define broad error categories (in 8 bits), and t
 | 10    | E_DUPLICATE_INPUT    | Duplicate input was encountered in the arguments and the algorithm could not handle it
 | 11    | E_NOT_NEIGHBORS      | `H3Index` cell arguments were not neighbors
 | 12    | E_RES_MISMATCH       | `H3Index` cell arguments had incompatible resolutions
-| 13    | E_MEMORY             | Necessary memory allocation failed
+| 13    | E_MEMORY_ALLOC       | Necessary memory allocation failed
 | 14    | E_MEMORY_BOUNDS      | Bounds of provided memory were not large enough
 
 The H3 library may always add additional error messages. Error messages not recognized by the application should be treated as `E_FAILED`. The latest version of this table is available [in the documentation](https://h3geo.org/docs/next/library/errors#table-of-error-codes).
@@ -272,7 +272,7 @@ hexRange(origin=0, k=0, &out) => E_CELL_INVALID
 hexRange(origin=AN_INDEX, k=-1, &out) => E_DOMAIN
 hexRange(origin=PENTAGON_INDEX, k=1, &out) => E_PENTAGON
 # Failed to allocate internal buffer:
-kRing(origin=AN_INDEX, k=1, &out) => E_MEMORY
+kRing(origin=AN_INDEX, k=1, &out) => E_MEMORY_ALLOC
 distanceRads({Infinity, Infinity}, {0, 0}, &out) => E_LATLNG_DOMAIN
 hexAreaKm2(res=-1) => E_RES_DOMAIN
 # Cannot parse:

--- a/src/apps/testapps/testH3Memory.c
+++ b/src/apps/testapps/testH3Memory.c
@@ -112,8 +112,9 @@ SUITE(h3Memory) {
         resetMemoryCounters(0);
         failAlloc = true;
         memset(gridDiskOutput, 0, hexCount * sizeof(H3Index));
-        t_assert(H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput) == E_MEMORY,
-                 "gridDisk returns E_MEMORY");
+        t_assert(
+            H3_EXPORT(gridDisk)(pentagon, k, gridDiskOutput) == E_MEMORY_ALLOC,
+            "gridDisk returns E_MEMORY_ALLOC");
         t_assert(actualAllocCalls == 1, "gridDisk called alloc");
         t_assert(actualFreeCalls == 0, "gridDisk did not call free");
 
@@ -144,25 +145,25 @@ SUITE(h3Memory) {
         failAlloc = true;
         H3Error err =
             H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount);
-        t_assert(err == E_MEMORY, "malloc failed (1)");
+        t_assert(err == E_MEMORY_ALLOC, "malloc failed (1)");
         t_assert(actualAllocCalls == 1, "alloc called once");
         t_assert(actualFreeCalls == 0, "free not called");
 
         resetMemoryCounters(1);
         err = H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount);
-        t_assert(err == E_MEMORY, "malloc failed (2)");
+        t_assert(err == E_MEMORY_ALLOC, "malloc failed (2)");
         t_assert(actualAllocCalls == 2, "alloc called twice");
         t_assert(actualFreeCalls == 1, "free called once");
 
         resetMemoryCounters(2);
         err = H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount);
-        t_assert(err == E_MEMORY, "malloc failed (3)");
+        t_assert(err == E_MEMORY_ALLOC, "malloc failed (3)");
         t_assert(actualAllocCalls == 3, "alloc called three times");
         t_assert(actualFreeCalls == 2, "free called twice");
 
         resetMemoryCounters(3);
         err = H3_EXPORT(compactCells)(sunnyvaleExpanded, compressed, hexCount);
-        t_assert(err == E_MEMORY, "compactCells failed (4)");
+        t_assert(err == E_MEMORY_ALLOC, "compactCells failed (4)");
         t_assert(actualAllocCalls == 4, "alloc called four times");
         t_assert(actualFreeCalls == 3, "free called three times");
 
@@ -196,19 +197,19 @@ SUITE(h3Memory) {
         resetMemoryCounters(0);
         failAlloc = true;
         H3Error err = H3_EXPORT(polygonToCells)(&sfGeoPolygon, 9, 0, hexagons);
-        t_assert(err == E_MEMORY, "polygonToCells failed (1)");
+        t_assert(err == E_MEMORY_ALLOC, "polygonToCells failed (1)");
         t_assert(actualAllocCalls == 1, "alloc called once");
         t_assert(actualFreeCalls == 0, "free not called");
 
         resetMemoryCounters(1);
         err = H3_EXPORT(polygonToCells)(&sfGeoPolygon, 9, 0, hexagons);
-        t_assert(err == E_MEMORY, "polygonToCells failed (2)");
+        t_assert(err == E_MEMORY_ALLOC, "polygonToCells failed (2)");
         t_assert(actualAllocCalls == 2, "alloc called twice");
         t_assert(actualFreeCalls == 1, "free called once");
 
         resetMemoryCounters(2);
         err = H3_EXPORT(polygonToCells)(&sfGeoPolygon, 9, 0, hexagons);
-        t_assert(err == E_MEMORY, "polygonToCells failed (3)");
+        t_assert(err == E_MEMORY_ALLOC, "polygonToCells failed (3)");
         t_assert(actualAllocCalls == 3, "alloc called three times");
         t_assert(actualFreeCalls == 2, "free called twice");
 

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -98,8 +98,8 @@ typedef enum {
                              // and the algorithm could not handle it
     E_NOT_NEIGHBORS = 11,    // `H3Index` cell arguments were not neighbors
     E_RES_MISMATCH =
-        12,         // `H3Index` cell arguments had incompatible resolutions
-    E_MEMORY = 13,  // Necessary memory allocation failed
+        12,  // `H3Index` cell arguments had incompatible resolutions
+    E_MEMORY_ALLOC = 13,   // Necessary memory allocation failed
     E_MEMORY_BOUNDS = 14,  // Bounds of provided memory were not large enough
     E_OPTION_INVALID = 15  // Mode or flags argument was not valid.
 } H3ErrorCodes;

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -218,7 +218,7 @@ H3Error H3_EXPORT(gridDiskDistances)(H3Index origin, int k, H3Index *out,
         if (distances == NULL) {
             distances = H3_MEMORY(calloc)(maxIdx, sizeof(int));
             if (!distances) {
-                return E_MEMORY;
+                return E_MEMORY_ALLOC;
             }
             H3Error result = _gridDiskDistancesInternal(origin, k, out,
                                                         distances, maxIdx, 0);
@@ -880,7 +880,7 @@ H3Error H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon, int res,
     // Get the bounding boxes for the polygon and any holes
     BBox *bboxes = H3_MEMORY(malloc)((geoPolygon->numHoles + 1) * sizeof(BBox));
     if (!bboxes) {
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
     bboxesFromGeoPolygon(geoPolygon, bboxes);
 
@@ -896,13 +896,13 @@ H3Error H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon, int res,
     H3Index *search = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
     if (!search) {
         H3_MEMORY(free)(bboxes);
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
     H3Index *found = H3_MEMORY(calloc)(numHexagons, sizeof(H3Index));
     if (!found) {
         H3_MEMORY(free)(bboxes);
         H3_MEMORY(free)(search);
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
 
     // Some metadata for tracking the state of the search and found memory

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -310,13 +310,13 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
     }
     H3Index *remainingHexes = H3_MEMORY(malloc)(numHexes * sizeof(H3Index));
     if (!remainingHexes) {
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
     memcpy(remainingHexes, h3Set, numHexes * sizeof(H3Index));
     H3Index *hashSetArray = H3_MEMORY(calloc)(numHexes, sizeof(H3Index));
     if (!hashSetArray) {
         H3_MEMORY(free)(remainingHexes);
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
     H3Index *compactedSetOffset = compactedSet;
     int numRemainingHexes = numHexes;
@@ -407,7 +407,7 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
         if (!compactableHexes) {
             H3_MEMORY(free)(remainingHexes);
             H3_MEMORY(free)(hashSetArray);
-            return E_MEMORY;
+            return E_MEMORY_ALLOC;
         }
         for (int i = 0; i < numRemainingHexes; i++) {
             if (hashSetArray[i] == 0) continue;

--- a/website/docs/library/errors.md
+++ b/website/docs/library/errors.md
@@ -51,7 +51,7 @@ The type returned by most H3 functions is `H3Error`, a 32 bit integer type with 
 | 10    | E_DUPLICATE_INPUT    | Duplicate input was encountered in the arguments and the algorithm could not handle it
 | 11    | E_NOT_NEIGHBORS      | `H3Index` cell arguments were not neighbors
 | 12    | E_RES_MISMATCH       | `H3Index` cell arguments had incompatible resolutions
-| 13    | E_MEMORY             | Necessary memory allocation failed
+| 13    | E_MEMORY_ALLOC       | Necessary memory allocation failed
 | 14    | E_MEMORY_BOUNDS      | Bounds of provided memory were not large enough
 | 15    | E_OPTION_INVALID     | Mode or flags argument was not valid
 


### PR DESCRIPTION
`E_MEMORY_ALLOC` is a slightly more descriptive name.