### PR TITLE
Use tlyly/install-graphviz on Windows CI

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
+      - uses: tlylt/install-graphviz@v1.0.0
+
       - name: Configure build
         shell: cmd
         run: cmake -Bbuild -A ${{ matrix.arch }} -DWARNINGS_AS_ERRORS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON .
@@ -57,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+
+      - uses: tlylt/install-graphviz@v1.0.0
 
       - name: Configure build
         shell: cmd


### PR DESCRIPTION
This is intended to fix the CI failure seen in #620, first seen in #617, etc.