### PR TITLE
Update changelog for #617

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Breaking changes
 - `distance*` functions (`distanceKm`, etc) renamed to `greatCircleDistance*`. (#622)
+- Error code `E_MEMORY` renamed to `E_MEMORY_ALLOC`. (#617)
 
 ## [4.0.0-rc3] - 2022-06-03
 ### Fixed

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -35,8 +35,8 @@ read -p "Next version: " NEXT_VERSION
 
 echo -e "\n * Changelog entries *"
 git diff $REVISION_RANGE -- CHANGELOG.md
-echo -e "\n * Committed merges *"
-git log --merges --oneline $REVISION_RANGE
+echo -e "\n * Committed *"
+git log --oneline $REVISION_RANGE
 
 echo
 read -p "Are all changes in the changelog [y/N]? " CHANGELOG_OK


### PR DESCRIPTION
Update the changelog for #617, which renamed an error code.

Changed the update_version.sh script to not only look at merged, since we are now using squash commits.