### PR TITLE
Remove uber/h3-go from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Documentation is available at [https://h3geo.org/](https://h3geo.org/). Develope
 
 ## Installing
 
-We recommend using prebuilt bindings if they are available for your programming language. Bindings for [Go](https://github.com/uber/h3-go), [Java](https://github.com/uber/h3-java), [JavaScript](https://github.com/uber/h3-js), [Python](https://github.com/uber/h3-py), and [others](https://h3geo.org/docs/community/bindings) are available.
+We recommend using prebuilt bindings if they are available for your programming language. Bindings for [Java](https://github.com/uber/h3-java), [JavaScript](https://github.com/uber/h3-js), [Python](https://github.com/uber/h3-py), and [others](https://h3geo.org/docs/community/bindings) are available.
 
 On macOS, you can install H3 using `brew`:
 ```


### PR DESCRIPTION
Discussed offline with the H3 Steering Committee. We're removing H3-Go from the README as it's not maintained - a link will remain on the documentation site.