### PR TITLE
Fix undefined behavior in polygonToCells test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- `polygonToCells` returns an error if Infinity is passed in. (#636)
 
 ## [4.0.0-rc4] - 2022-07-25
 ### Breaking changes

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -238,4 +238,20 @@ SUITE(BBox) {
         t_assert(!bboxEquals(&bbox, &east), "Not equals different east");
         t_assert(!bboxEquals(&bbox, &west), "Not equals different west");
     }
+
+    TEST(bboxHexEstimate_invalidRes) {
+        int64_t numHexagons;
+        BBox bbox = {1.0, 0.0, 1.0, 0.0};
+        t_assert(bboxHexEstimate(&bbox, -1, &numHexagons) == E_RES_DOMAIN,
+                 "bboxHexEstimate of invalid resolution fails");
+    }
+
+    TEST(lineHexEstimate_invalidRes) {
+        int64_t numHexagons;
+        LatLng origin = {0.0, 0.0};
+        LatLng destination = {1.0, 1.0};
+        t_assert(lineHexEstimate(&origin, &destination, -1, &numHexagons) ==
+                     E_RES_DOMAIN,
+                 "lineHexEstimate of invalid resolution fails");
+    }
 }

--- a/src/apps/testapps/testPolygon.c
+++ b/src/apps/testapps/testPolygon.c
@@ -116,7 +116,7 @@ SUITE(polygon) {
         // This is a carefully crafted shape + point to hit an otherwise
         // missed branch in coverage
         LatLng verts[] = {{0, 0}, {1, 0.5}, {0, 1}};
-        GeoLoop geoloop = {.numVerts = 4, .verts = verts};
+        GeoLoop geoloop = {.numVerts = 3, .verts = verts};
 
         BBox bbox;
         bboxFromGeoLoop(&geoloop, &bbox);

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -476,13 +476,16 @@ SUITE(polygonToCells) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&pointGeoPolygon, 9, 0,
                                                          &numHexagons));
-        t_assert(numHexagons == 13, "Point has expected 1 hexagon");
+        // 0 estimation, plus 1 vertex, plus 12 buffer
+        t_assert(numHexagons == 13, "Point has expected 13 hexagons");
 
         H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
         t_assertSuccess(
             H3_EXPORT(polygonToCells)(&pointGeoPolygon, 9, 0, hexagons));
-        t_assert(hexagons[0] == H3_NULL,
-                 "no results for polygonToCells of a single point");
+        for (int i = 0; i < numHexagons; i++) {
+            t_assert(hexagons[i] == H3_NULL,
+                     "no results for polygonToCells of a single point");
+        }
         free(hexagons);
     }
 }

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 
 #include "algos.h"
@@ -42,6 +44,10 @@ static LatLng emptyVerts[] = {{0.659966917655, -2.1364398519394},
                               {0.659966917655, -2.1364398519396}};
 static GeoLoop emptyGeoLoop = {.numVerts = 3, .verts = emptyVerts};
 static GeoPolygon emptyGeoPolygon;
+
+static LatLng invalidVerts[] = {{INFINITY, INFINITY}, {-INFINITY, -INFINITY}};
+static GeoLoop invalidGeoLoop = {.numVerts = 2, .verts = invalidVerts};
+static GeoPolygon invalidGeoPolygon;
 
 /**
  * Return true if the cell crosses the meridian.
@@ -127,6 +133,9 @@ SUITE(polygonToCells) {
 
     emptyGeoPolygon.geoloop = emptyGeoLoop;
     emptyGeoPolygon.numHoles = 0;
+
+    invalidGeoPolygon.geoloop = invalidGeoLoop;
+    invalidGeoPolygon.numHoles = 0;
 
     TEST(maxPolygonToCellsSize) {
         int64_t numHexagons;
@@ -419,5 +428,40 @@ SUITE(polygonToCells) {
         iterateAllIndexesAtRes(0, fillIndex_assertions);
         iterateAllIndexesAtRes(1, fillIndex_assertions);
         iterateAllIndexesAtRes(2, fillIndex_assertions);
+    }
+
+    TEST(getEdgeHexagonsInvalid) {
+        int64_t numHexagons = 100;
+        H3Index *search = calloc(numHexagons, sizeof(H3Index));
+        assert(search != NULL);
+        H3Index *found = calloc(numHexagons, sizeof(H3Index));
+        assert(found != NULL);
+
+        int res = 0;
+        int64_t numSearchHexes = 0;
+        H3Error err = _getEdgeHexagons(&invalidGeoLoop, numHexagons, res,
+                                       &numSearchHexes, search, found);
+        t_assert(err != E_SUCCESS,
+                 "_getEdgeHexagons returns error for invalid geoloop");
+
+        free(found);
+        free(search);
+    }
+
+    TEST(polygonToCellsInvalid) {
+        int64_t numHexagons;
+        t_assert(H3_EXPORT(maxPolygonToCellsSize)(&invalidGeoPolygon, 9, 0,
+                                                  &numHexagons) == E_FAILED,
+                 "Cannot determine cell size to invalid geo polygon");
+
+        // Chosen arbitrarily, polygonToCells should error out before this is an
+        // issue.
+        numHexagons = 0;
+        
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+        t_assert(H3_EXPORT(polygonToCells)(&invalidGeoPolygon, 9, 0,
+                                           hexagons) == E_FAILED,
+                 "Flags other than 0 are invalid for polygonToCells");
+        free(hexagons);
     }
 }

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -457,7 +457,7 @@ SUITE(polygonToCells) {
         // Chosen arbitrarily, polygonToCells should error out before this is an
         // issue.
         numHexagons = 0;
-        
+
         H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
         t_assert(H3_EXPORT(polygonToCells)(&invalidGeoPolygon, 9, 0,
                                            hexagons) == E_FAILED,

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -49,6 +49,10 @@ static LatLng invalidVerts[] = {{INFINITY, INFINITY}, {-INFINITY, -INFINITY}};
 static GeoLoop invalidGeoLoop = {.numVerts = 2, .verts = invalidVerts};
 static GeoPolygon invalidGeoPolygon;
 
+static LatLng pointVerts[] = {{0, 0}};
+static GeoLoop pointGeoLoop = {.numVerts = 1, .verts = pointVerts};
+static GeoPolygon pointGeoPolygon;
+
 /**
  * Return true if the cell crosses the meridian.
  */
@@ -136,6 +140,9 @@ SUITE(polygonToCells) {
 
     invalidGeoPolygon.geoloop = invalidGeoLoop;
     invalidGeoPolygon.numHoles = 0;
+
+    pointGeoPolygon.geoloop = pointGeoLoop;
+    pointGeoPolygon.numHoles = 0;
 
     TEST(maxPolygonToCellsSize) {
         int64_t numHexagons;
@@ -461,7 +468,21 @@ SUITE(polygonToCells) {
         H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
         t_assert(H3_EXPORT(polygonToCells)(&invalidGeoPolygon, 9, 0,
                                            hexagons) == E_FAILED,
-                 "Flags other than 0 are invalid for polygonToCells");
+                 "Invalid geo polygon cannot be evaluated");
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsPoint) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&pointGeoPolygon, 9, 0,
+                                                         &numHexagons));
+        t_assert(numHexagons == 13, "Point has expected 1 hexagon");
+
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+        t_assertSuccess(
+            H3_EXPORT(polygonToCells)(&pointGeoPolygon, 9, 0, hexagons));
+        t_assert(hexagons[0] == H3_NULL,
+                 "no results for polygonToCells of a single point");
         free(hexagons);
     }
 }

--- a/src/h3lib/include/bbox.h
+++ b/src/h3lib/include/bbox.h
@@ -38,8 +38,8 @@ bool bboxIsTransmeridian(const BBox *bbox);
 void bboxCenter(const BBox *bbox, LatLng *center);
 bool bboxContains(const BBox *bbox, const LatLng *point);
 bool bboxEquals(const BBox *b1, const BBox *b2);
-int64_t bboxHexEstimate(const BBox *bbox, int res);
-int64_t lineHexEstimate(const LatLng *origin, const LatLng *destination,
-                        int res);
+H3Error bboxHexEstimate(const BBox *bbox, int res, int64_t *out);
+H3Error lineHexEstimate(const LatLng *origin, const LatLng *destination,
+                        int res, int64_t *out);
 
 #endif

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -101,8 +101,10 @@ double _hexRadiusKm(H3Index h3Index) {
 H3Error bboxHexEstimate(const BBox *bbox, int res, int64_t *out) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
-    // TODO: Return error here
-    H3_EXPORT(getPentagons)(res, pentagons);
+    H3Error pentagonsErr = H3_EXPORT(getPentagons)(res, pentagons);
+    if (pentagonsErr) {
+        return pentagonsErr;
+    }
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
     // Area of a regular hexagon is 3/2*sqrt(3) * r * r
     // The pentagon has the most distortion (smallest edges) and shares its
@@ -149,8 +151,10 @@ H3Error lineHexEstimate(const LatLng *origin, const LatLng *destination,
                         int res, int64_t *out) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
-    // TODO: Return error here
-    H3_EXPORT(getPentagons)(res, pentagons);
+    H3Error pentagonsErr = H3_EXPORT(getPentagons)(res, pentagons);
+    if (pentagonsErr) {
+        return pentagonsErr;
+    }
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
 
     double dist = H3_EXPORT(greatCircleDistanceKm)(origin, destination);

--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -95,9 +95,10 @@ double _hexRadiusKm(H3Index h3Index) {
  *
  * @param bbox the bounding box to estimate the hexagon fill level
  * @param res the resolution of the H3 hexagons to fill the bounding box
- * @return the estimated number of hexagons to fill the bounding box
+ * @param out the estimated number of hexagons to fill the bounding box
+ * @return E_SUCCESS (0) on success, or another value otherwise.
  */
-int64_t bboxHexEstimate(const BBox *bbox, int res) {
+H3Error bboxHexEstimate(const BBox *bbox, int res, int64_t *out) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     // TODO: Return error here
@@ -123,22 +124,29 @@ int64_t bboxHexEstimate(const BBox *bbox, int res) {
     double a = d * d / fmin(3.0, fabs((p1.lng - p2.lng) / (p1.lat - p2.lat)));
 
     // Divide the two to get an estimate of the number of hexagons needed
-    int64_t estimate = (int64_t)ceil(a / pentagonAreaKm2);
+    double estimateDouble = ceil(a / pentagonAreaKm2);
+    if (!isfinite(estimateDouble)) {
+        return E_FAILED;
+    }
+    int64_t estimate = (int64_t)estimateDouble;
     if (estimate == 0) estimate = 1;
-    return estimate;
+    *out = estimate;
+    return E_SUCCESS;
 }
 
 /**
  * lineHexEstimate returns an estimated number of hexagons that trace
  *                 the cartesian-projected line
  *
- *  @param origin the origin coordinates
- *  @param destination the destination coordinates
- *  @param res the resolution of the H3 hexagons to trace the line
- *  @return the estimated number of hexagons required to trace the line
+ * @param origin the origin coordinates
+ * @param destination the destination coordinates
+ * @param res the resolution of the H3 hexagons to trace the line
+ * @param out Out parameter for the estimated number of hexagons required to
+ * trace the line
+ * @return E_SUCCESS (0) on success or another value otherwise.
  */
-int64_t lineHexEstimate(const LatLng *origin, const LatLng *destination,
-                        int res) {
+H3Error lineHexEstimate(const LatLng *origin, const LatLng *destination,
+                        int res, int64_t *out) {
     // Get the area of the pentagon as the maximally-distorted area possible
     H3Index pentagons[12] = {0};
     // TODO: Return error here
@@ -146,7 +154,12 @@ int64_t lineHexEstimate(const LatLng *origin, const LatLng *destination,
     double pentagonRadiusKm = _hexRadiusKm(pentagons[0]);
 
     double dist = H3_EXPORT(greatCircleDistanceKm)(origin, destination);
-    int64_t estimate = (int64_t)ceil(dist / (2 * pentagonRadiusKm));
+    double distCeil = ceil(dist / (2 * pentagonRadiusKm));
+    if (!isfinite(distCeil)) {
+        return E_FAILED;
+    }
+    int64_t estimate = (int64_t)distCeil;
     if (estimate == 0) estimate = 1;
-    return estimate;
+    *out = estimate;
+    return E_SUCCESS;
 }


### PR DESCRIPTION
* Fixes a test that had an invalid read. This was found by running the tests with `ENABLE_FUZZERS`, which enabled ASAN etc. We don't run this in CI but perhaps should.
* Added a couple tests that exercise what happens when non-finite values are passed into polygonToCells. We previously had some casts from double to int64_t that were unsafe if the value was not finite because that cast would be undefined behavior.

Edit: happy to break this out into two PRs if that's easier.

Edit 2: This does not block #633 