### PR TITLE
Code coverage improvement for vertex functions

### DIFF
--- a/src/apps/testapps/testVertex.c
+++ b/src/apps/testapps/testVertex.c
@@ -183,4 +183,11 @@ SUITE(Vertex) {
         t_assert(H3_EXPORT(vertexToLatLng)(invalid, &latLng) != E_SUCCESS,
                  "Invalid vertex returns error");
     }
+
+    TEST(cellToVertexes_invalid) {
+        H3Index invalid = 0xFFFFFFFFFFFFFFFF;
+        H3Index verts[6] = {0};
+        t_assert(H3_EXPORT(cellToVertexes)(invalid, verts) == E_FAILED,
+                 "cellToVertexes fails for invalid cell");
+    }
 }

--- a/src/h3lib/lib/vertex.c
+++ b/src/h3lib/lib/vertex.c
@@ -221,7 +221,6 @@ H3Error H3_EXPORT(cellToVertex)(H3Index cell, int vertexNum, H3Index *out) {
     if (res == 0 || H3_GET_INDEX_DIGIT(cell, res) != CENTER_DIGIT) {
         // Get the left neighbor of the vertex, with its rotations
         Direction left = directionForVertexNum(cell, vertexNum);
-        // This case should be unreachable; invalid verts fail earlier
         if (left == INVALID_DIGIT) return E_FAILED;
         int lRotations = 0;
         H3Index leftNeighbor;

--- a/src/h3lib/lib/vertex.c
+++ b/src/h3lib/lib/vertex.c
@@ -222,7 +222,7 @@ H3Error H3_EXPORT(cellToVertex)(H3Index cell, int vertexNum, H3Index *out) {
         // Get the left neighbor of the vertex, with its rotations
         Direction left = directionForVertexNum(cell, vertexNum);
         // This case should be unreachable; invalid verts fail earlier
-        if (left == INVALID_DIGIT) return E_FAILED;  // LCOV_EXCL_LINE
+        if (left == INVALID_DIGIT) return E_FAILED;
         int lRotations = 0;
         H3Index leftNeighbor;
         h3NeighborRotations(cell, left, &lRotations, &leftNeighbor);


### PR DESCRIPTION
Covers an a couple additional branches in vertex.c.

This is not required for #633. I didn't add a changelog entry as this is purely a test / coverage exclusion change.