### PR TITLE
exactEdgeLength -> edgeLength

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ set(OTHER_SOURCE_FILES
     src/apps/fuzzers/fuzzerCellsToLinkedMultiPolygon.c
     src/apps/fuzzers/fuzzerDistances.c
     src/apps/fuzzers/fuzzerCellArea.c
-    src/apps/fuzzers/fuzzerExactEdgeLength.c
+    src/apps/fuzzers/fuzzerEdgeLength.c
     src/apps/fuzzers/fuzzerCellProperties.c
     src/apps/fuzzers/fuzzerIndexIO.c
     src/apps/fuzzers/fuzzerResolutions.c
@@ -476,7 +476,7 @@ if(BUILD_FUZZERS)
     add_h3_fuzzer(fuzzerCellsToLinkedMultiPolygon src/apps/fuzzers/fuzzerCellsToLinkedMultiPolygon.c)
     add_h3_fuzzer(fuzzerDistances src/apps/fuzzers/fuzzerDistances.c)
     add_h3_fuzzer(fuzzerCellArea src/apps/fuzzers/fuzzerCellArea.c)
-    add_h3_fuzzer(fuzzerExactEdgeLength src/apps/fuzzers/fuzzerExactEdgeLength.c)
+    add_h3_fuzzer(fuzzerEdgeLength src/apps/fuzzers/fuzzerEdgeLength.c)
     add_h3_fuzzer(fuzzerCellProperties src/apps/fuzzers/fuzzerCellProperties.c)
     add_h3_fuzzer(fuzzerIndexIO src/apps/fuzzers/fuzzerIndexIO.c)
     add_h3_fuzzer(fuzzerResolutions src/apps/fuzzers/fuzzerResolutions.c)

--- a/src/apps/fuzzers/README.md
+++ b/src/apps/fuzzers/README.md
@@ -25,7 +25,7 @@ such as the H3 core library.
 | getHexagonAreaAvg | [fuzzerResolutions](./fuzzerResolutions.c)
 | cellArea | [fuzzerCellArea](./fuzzerCellArea.c)
 | getHexagonEdgeLengthAvg | [fuzzerResolutions](./fuzzerResolutions.c)
-| exactEdgeLength | [fuzzerExactEdgeLength](./fuzzerExactEdgeLength.c)
+| edgeLength | [fuzzerEdgeLength](./fuzzerEdgeLength.c)
 | getNumCells | [fuzzerResolutions](./fuzzerResolutions.c)
 | getRes0Cells | Trivial
 | getPentagons | [fuzzerResolutions](./fuzzerResolutions.c)

--- a/src/apps/fuzzers/fuzzerEdgeLength.c
+++ b/src/apps/fuzzers/fuzzerEdgeLength.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /** @file
- * @brief Fuzzer program for exactEdgeLengthRads
+ * @brief Fuzzer program for edgeLengthRads
  */
 
 #include "aflHarness.h"
@@ -32,9 +32,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     const inputArgs *args = (const inputArgs *)data;
 
     double distance;
-    H3_EXPORT(exactEdgeLengthRads)(args->index, &distance);
-    H3_EXPORT(exactEdgeLengthKm)(args->index, &distance);
-    H3_EXPORT(exactEdgeLengthM)(args->index, &distance);
+    H3_EXPORT(edgeLengthRads)(args->index, &distance);
+    H3_EXPORT(edgeLengthKm)(args->index, &distance);
+    H3_EXPORT(edgeLengthM)(args->index, &distance);
 
     return 0;
 }

--- a/src/apps/testapps/testDirectedEdge.c
+++ b/src/apps/testapps/testDirectedEdge.c
@@ -429,17 +429,15 @@ SUITE(directedEdge) {
             "directedEdgeToBoundary fails on invalid edge indexing digit");
     }
 
-    TEST(exactEdgeLength_invalid) {
+    TEST(edgeLength_invalid) {
         double length;
         // Test that invalid inputs do not cause crashes.
-        t_assert(
-            H3_EXPORT(exactEdgeLengthRads)(0, &length) == E_DIR_EDGE_INVALID,
-            "Invalid edge has zero length");
+        t_assert(H3_EXPORT(edgeLengthRads)(0, &length) == E_DIR_EDGE_INVALID,
+                 "Invalid edge has zero length");
         LatLng zero = {0, 0};
         H3Index h3;
         t_assertSuccess(H3_EXPORT(latLngToCell)(&zero, 0, &h3));
-        t_assert(
-            H3_EXPORT(exactEdgeLengthRads)(h3, &length) == E_DIR_EDGE_INVALID,
-            "Non-edge (cell) has zero edge length");
+        t_assert(H3_EXPORT(edgeLengthRads)(h3, &length) == E_DIR_EDGE_INVALID,
+                 "Non-edge (cell) has zero edge length");
     }
 }

--- a/src/apps/testapps/testH3CellAreaExhaustive.c
+++ b/src/apps/testapps/testH3CellAreaExhaustive.c
@@ -81,9 +81,9 @@ static void haversine_assert(H3Index edge) {
 /**
  * Tests positivity of edge length calculation for the functions:
  *
- *      exactEdgeLengthRads
- *      exactEdgeLengthKm
- *      exactEdgeLengthM
+ *      edgeLengthRads
+ *      edgeLengthKm
+ *      edgeLengthM
  *
  * @param  edge  edge to compute the length of
  */
@@ -91,11 +91,11 @@ static void edge_length_assert(H3Index edge) {
     char msg[] = "edge has positive length";
 
     double length;
-    t_assertSuccess(H3_EXPORT(exactEdgeLengthRads)(edge, &length));
+    t_assertSuccess(H3_EXPORT(edgeLengthRads)(edge, &length));
     t_assert(length > 0, msg);
-    t_assertSuccess(H3_EXPORT(exactEdgeLengthKm)(edge, &length));
+    t_assertSuccess(H3_EXPORT(edgeLengthKm)(edge, &length));
     t_assert(length > 0, msg);
-    t_assertSuccess(H3_EXPORT(exactEdgeLengthM)(edge, &length));
+    t_assertSuccess(H3_EXPORT(edgeLengthM)(edge, &length));
     t_assert(length > 0, msg);
 }
 

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -369,18 +369,18 @@ DECLSPEC H3Error H3_EXPORT(getHexagonEdgeLengthAvgKm)(int res, double *out);
 DECLSPEC H3Error H3_EXPORT(getHexagonEdgeLengthAvgM)(int res, double *out);
 /** @} */
 
-/** @defgroup exactEdgeLength exactEdgeLength
- * Functions for exactEdgeLength
+/** @defgroup edgeLength edgeLength
+ * Functions for edgeLength
  * @{
  */
 /** @brief exact length for a specific directed edge in radians*/
-DECLSPEC H3Error H3_EXPORT(exactEdgeLengthRads)(H3Index edge, double *length);
+DECLSPEC H3Error H3_EXPORT(edgeLengthRads)(H3Index edge, double *length);
 
 /** @brief exact length for a specific directed edge in kilometers*/
-DECLSPEC H3Error H3_EXPORT(exactEdgeLengthKm)(H3Index edge, double *length);
+DECLSPEC H3Error H3_EXPORT(edgeLengthKm)(H3Index edge, double *length);
 
 /** @brief exact length for a specific directed edge in meters*/
-DECLSPEC H3Error H3_EXPORT(exactEdgeLengthM)(H3Index edge, double *length);
+DECLSPEC H3Error H3_EXPORT(edgeLengthM)(H3Index edge, double *length);
 /** @} */
 
 /** @defgroup getNumCells getNumCells

--- a/src/h3lib/lib/latLng.c
+++ b/src/h3lib/lib/latLng.c
@@ -427,7 +427,7 @@ H3Error H3_EXPORT(cellAreaM2)(H3Index cell, double *out) {
  *
  * @return        length in radians
  */
-H3Error H3_EXPORT(exactEdgeLengthRads)(H3Index edge, double *length) {
+H3Error H3_EXPORT(edgeLengthRads)(H3Index edge, double *length) {
     CellBoundary cb;
 
     H3Error err = H3_EXPORT(directedEdgeToBoundary)(edge, &cb);
@@ -447,8 +447,8 @@ H3Error H3_EXPORT(exactEdgeLengthRads)(H3Index edge, double *length) {
 /**
  * Length of a directed edge in kilometers.
  */
-H3Error H3_EXPORT(exactEdgeLengthKm)(H3Index edge, double *length) {
-    H3Error err = H3_EXPORT(exactEdgeLengthRads)(edge, length);
+H3Error H3_EXPORT(edgeLengthKm)(H3Index edge, double *length) {
+    H3Error err = H3_EXPORT(edgeLengthRads)(edge, length);
     *length = *length * EARTH_RADIUS_KM;
     return err;
 }
@@ -456,8 +456,8 @@ H3Error H3_EXPORT(exactEdgeLengthKm)(H3Index edge, double *length) {
 /**
  * Length of a directed edge in meters.
  */
-H3Error H3_EXPORT(exactEdgeLengthM)(H3Index edge, double *length) {
-    H3Error err = H3_EXPORT(exactEdgeLengthKm)(edge, length);
+H3Error H3_EXPORT(edgeLengthM)(H3Index edge, double *length) {
+    H3Error err = H3_EXPORT(edgeLengthKm)(edge, length);
     *length = *length * 1000;
     return err;
 }

--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -483,7 +483,7 @@ function example() {
 Average hexagon edge length in meters at the given resolution. Excludes pentagons.
 
 
-## exactEdgeLengthKm
+## edgeLengthKm
 
 <Tabs
   groupId="language"
@@ -498,7 +498,7 @@ Average hexagon edge length in meters at the given resolution. Excludes pentagon
 <TabItem value="c">
 
 ```c
-H3Error exactEdgeLengthKm(H3Index edge, double *length);
+H3Error edgeLengthKm(H3Index edge, double *length);
 ```
 
 </TabItem>
@@ -512,21 +512,21 @@ h3.exact_edge_length(h, unit='km')
 <TabItem value="java">
 
 ```java
-double exactEdgeLength(long h3, LengthUnit unit);
-double exactEdgeLength(String h3Address, LengthUnit unit);
+double edgeLength(long h3, LengthUnit unit);
+double edgeLength(String h3Address, LengthUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.exactEdgeLength(h3, h3.UNITS.km)
+h3.edgeLength(h3, h3.UNITS.km)
 ```
 
 ```js live
 function example() {
   const h = '115283473fffffff';
-  return h3.exactEdgeLength(h, h3.UNITS.km);
+  return h3.edgeLength(h, h3.UNITS.km);
 }
 ```
 
@@ -535,7 +535,7 @@ function example() {
 
 Exact edge length of specific unidirectional edge in kilometers.
 
-## exactEdgeLengthM
+## edgeLengthM
 
 <Tabs
   groupId="language"
@@ -550,7 +550,7 @@ Exact edge length of specific unidirectional edge in kilometers.
 <TabItem value="c">
 
 ```c
-H3Error exactEdgeLengthM(H3Index edge, double *length);
+H3Error edgeLengthM(H3Index edge, double *length);
 ```
 
 </TabItem>
@@ -564,21 +564,21 @@ h3.exact_edge_length(h, unit='m')
 <TabItem value="java">
 
 ```java
-double exactEdgeLength(long h3, LengthUnit unit);
-double exactEdgeLength(String h3Address, LengthUnit unit);
+double edgeLength(long h3, LengthUnit unit);
+double edgeLength(String h3Address, LengthUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.exactEdgeLength(h3, h3.UNITS.m)
+h3.edgeLength(h3, h3.UNITS.m)
 ```
 
 ```js live
 function example() {
   const h = '115283473fffffff';
-  return h3.exactEdgeLength(h, h3.UNITS.m);
+  return h3.edgeLength(h, h3.UNITS.m);
 }
 ```
 
@@ -587,7 +587,7 @@ function example() {
 
 Exact edge length of specific unidirectional edge in meters.
 
-## exactEdgeLengthRads
+## edgeLengthRads
 
 <Tabs
   groupId="language"
@@ -602,7 +602,7 @@ Exact edge length of specific unidirectional edge in meters.
 <TabItem value="c">
 
 ```c
-H3Error exactEdgeLengthRads(H3Index edge, double *length);
+H3Error edgeLengthRads(H3Index edge, double *length);
 ```
 
 </TabItem>
@@ -616,21 +616,21 @@ h3.exact_edge_length(h, unit='rads')
 <TabItem value="java">
 
 ```java
-double exactEdgeLength(long h3, LengthUnit unit);
-double exactEdgeLength(String h3Address, LengthUnit unit);
+double edgeLength(long h3, LengthUnit unit);
+double edgeLength(String h3Address, LengthUnit unit);
 ```
 
 </TabItem>
 <TabItem value="javascript">
 
 ```js
-h3.exactEdgeLength(h3, h3.UNITS.rads)
+h3.edgeLength(h3, h3.UNITS.rads)
 ```
 
 ```js live
 function example() {
   const h = '115283473fffffff';
-  return h3.exactEdgeLength(h, h3.UNITS.rads);
+  return h3.edgeLength(h, h3.UNITS.rads);
 }
 ```
 


### PR DESCRIPTION
Fix a naming consistency issue. `edgeLength` now lines up with `cellArea`.