### PR TITLE
Cover getPentagons res argument being invalid

### DIFF
--- a/src/apps/testapps/testPentagonIndexes.c
+++ b/src/apps/testapps/testPentagonIndexes.c
@@ -56,6 +56,16 @@ SUITE(getPentagons) {
         }
     }
 
+    TEST(getPentagonsInvalid) {
+        H3Index h3Indexes[PADDED_COUNT] = {0};
+        t_assert(H3_EXPORT(getPentagons)(16, h3Indexes) == E_RES_DOMAIN,
+                 "getPentagons of invalid resolutions fails");
+        t_assert(H3_EXPORT(getPentagons)(100, h3Indexes) == E_RES_DOMAIN,
+                 "getPentagons of invalid resolutions fails");
+        t_assert(H3_EXPORT(getPentagons)(-1, h3Indexes) == E_RES_DOMAIN,
+                 "getPentagons of invalid resolutions fails");
+    }
+
     TEST(invalidPentagons) {
         t_assert(!H3_EXPORT(isPentagon)(0), "0 is not a pentagon");
         t_assert(!H3_EXPORT(isPentagon)(0x7fffffffffffffff),

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -104,7 +104,7 @@ int H3_EXPORT(isValidCell)(H3Index h) {
     int res = H3_GET_RESOLUTION(h);
     if (res < 0 || res > MAX_H3_RES) {  // LCOV_EXCL_BR_LINE
         // Resolutions less than zero can not be represented in an index
-        return 0;
+        return 0;  // LCOV_EXCL_LINE
     }
 
     bool foundFirstNonZeroDigit = false;


### PR DESCRIPTION
Mainly-test only change to cover an additional line. The core library change is adding a coverage exclusion comment on a line we already excluded the branch coverage for. I plan to merge after v4.0.0.