### PR TITLE
Remove GeoMultiPolygon since it is not used

### DIFF
--- a/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
+++ b/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md
@@ -276,13 +276,12 @@ discussion requiring benchmarking, so we will defer that to a
 
 - rename `GeoBoundary` to `CellBoundary` to indicate it is space-limited to describing the geometry of cells
 
-|    Current name   |   Proposed name   |              Notes              |
-|-------------------|-------------------|---------------------------------|
-| `GeoCoord`        | `LatLng`          |                                 |
-| `GeoBoundary`     | `CellBoundary`    | <= 10 stack-allocated `LatLng`s |
-| `Geofence`        | `GeoLoop`         | heap-allocated `LatLng`s        |
-| `GeoPolygon`      | `GeoPolygon`      |                                 |
-| `GeoMultiPolygon` | `GeoMultiPolygon` | currently not used              |
+|  Current name | Proposed name  |              Notes              |
+|---------------|----------------|---------------------------------|
+| `GeoCoord`    | `LatLng`       |                                 |
+| `GeoBoundary` | `CellBoundary` | <= 10 stack-allocated `LatLng`s |
+| `Geofence`    | `GeoLoop`      | heap-allocated `LatLng`s        |
+| `GeoPolygon`  | `GeoPolygon`   |                                 |
 
 
 ### Functions

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -149,14 +149,6 @@ typedef struct {
     GeoLoop *holes;   ///< interior boundaries (holes) in the polygon
 } GeoPolygon;
 
-/** @struct GeoMultiPolygon
- *  @brief Simplified core of GeoJSON MultiPolygon coordinates definition
- */
-typedef struct {
-    int numPolygons;
-    GeoPolygon *polygons;
-} GeoMultiPolygon;
-
 /** @struct LinkedLatLng
  *  @brief A coordinate node in a linked geo structure, part of a linked list
  */

--- a/website/docs/library/migration-3.x/functions.md
+++ b/website/docs/library/migration-3.x/functions.md
@@ -149,13 +149,12 @@ the passed-in cell.
 
 - rename `GeoBoundary` to `CellBoundary` to indicate it is space-limited to describing the geometry of cells
 
-|      3.x name     |    4.0.0 name     |               Notes               |
-|-------------------|-------------------|-----------------------------------|
-| `GeoBoundary`     | `CellBoundary`    | <= 10 stack-allocated `LatLng`s   |
-| `GeoCoord`        | `LatLng`          |                                   |
-| `Geofence`        | `GeoLoop`         | heap-allocated `LatLng`s          |
-| `GeoPolygon`      | `GeoPolygon`      |                                   |
-| `GeoMultiPolygon` | `GeoMultiPolygon` | currently not used                |
+|    3.x name   |   4.0.0 name   |              Notes              |
+|---------------|----------------|---------------------------------|
+| `GeoBoundary` | `CellBoundary` | <= 10 stack-allocated `LatLng`s |
+| `GeoCoord`    | `LatLng`       |                                 |
+| `Geofence`    | `GeoLoop`      | heap-allocated `LatLng`s        |
+| `GeoPolygon`  | `GeoPolygon`   |                                 |
 
 
 ### Functions


### PR DESCRIPTION
Or is there a reason to keep this in `h3api.h`?