### PR TITLE
Use h3-js v4.0.0 in the website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "global": "^4.4.0",
-    "h3-js": "^4.0.0-rc1",
+    "h3-js": "^4.0.0",
     "h3-jsv3": "npm:h3-js@^3.7.1",
     "hast-util-is-element": "1.1.0",
     "react": "^17.0.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -5083,10 +5083,10 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
-h3-js@^4.0.0-rc1:
-  version "4.0.0-rc1"
-  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-4.0.0-rc1.tgz#7a2fb11240e6bf1354bd45565fc328fadd727fc5"
-  integrity sha512-aI1SUJOzkekQgQT9TfieAn+BcXCS3lPvh8Ht22OKE8/XkoQY9u/D3fmjiv5hQGaOSPmnMowva/LA6Tk+L5g45w==
+h3-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-4.0.0.tgz#f55efb89f4608014146f3839d1d01d7a2767b3ba"
+  integrity sha512-zIx1NIflzkQ6Jw0tzVOba1wkJvZ/uwVHnuOrgK6VGFzsWdM/QUC3h2ALk2RizyxSNAi0UibmftniyfVK3BVf7A==
 
 "h3-jsv3@npm:h3-js@^3.7.1":
   version "3.7.2"


### PR DESCRIPTION
For the live code blocks, use the most recent version of H3-JS.