### PR TITLE
Add a combined fuzzer

### DIFF
--- a/.github/workflows/test-fuzzer.yml
+++ b/.github/workflows/test-fuzzer.yml
@@ -69,6 +69,5 @@ jobs:
           cd build
           for fuzzer in bin/fuzzer*; do
             echo $fuzzer
-            # TODO: Increase run count
-            $fuzzer -runs=1000
+            $fuzzer -runs=10000
           done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set(OTHER_SOURCE_FILES
     src/apps/miscapps/generatePentagonDirectionFaces.c
     src/apps/miscapps/generateFaceCenterPoint.c
     src/apps/miscapps/h3ToHier.c
+    src/apps/fuzzers/fuzzer.c
     src/apps/fuzzers/fuzzerLatLngToCell.c
     src/apps/fuzzers/fuzzerCellToLatLng.c
     src/apps/fuzzers/fuzzerGridDisk.c
@@ -462,8 +463,8 @@ endif()
 if(BUILD_FUZZERS)
     add_custom_target(fuzzers)
 
-    macro(add_h3_fuzzer name srcfile)
-        add_h3_executable(${name} ${srcfile} ${APP_SOURCE_FILES})
+    macro(add_h3_fuzzer name)
+        add_h3_executable(${ARGV} ${APP_SOURCE_FILES})
         if(ENABLE_LIBFUZZER)
             target_compile_definitions(${name} PRIVATE H3_USE_LIBFUZZER)
         endif()
@@ -487,6 +488,27 @@ if(BUILD_FUZZERS)
     add_h3_fuzzer(fuzzerLocalIj src/apps/fuzzers/fuzzerLocalIj.c)
     add_h3_fuzzer(fuzzerPolygonToCells src/apps/fuzzers/fuzzerPolygonToCells.c)
     add_h3_fuzzer(fuzzerPolygonToCellsNoHoles src/apps/fuzzers/fuzzerPolygonToCellsNoHoles.c)
+
+    # Add a combined all-function fuzzer
+    add_h3_fuzzer(fuzzerH3 src/apps/fuzzers/fuzzer.c
+        src/apps/fuzzers/fuzzerLatLngToCell.c
+        src/apps/fuzzers/fuzzerCellToLatLng.c
+        src/apps/fuzzers/fuzzerGridDisk.c
+        src/apps/fuzzers/fuzzerCellsToLinkedMultiPolygon.c
+        src/apps/fuzzers/fuzzerDistances.c
+        src/apps/fuzzers/fuzzerCellArea.c
+        src/apps/fuzzers/fuzzerEdgeLength.c
+        src/apps/fuzzers/fuzzerCellProperties.c
+        src/apps/fuzzers/fuzzerIndexIO.c
+        src/apps/fuzzers/fuzzerResolutions.c
+        src/apps/fuzzers/fuzzerHierarchy.c
+        src/apps/fuzzers/fuzzerVertexes.c
+        src/apps/fuzzers/fuzzerCompact.c
+        src/apps/fuzzers/fuzzerDirectedEdge.c
+        src/apps/fuzzers/fuzzerLocalIj.c
+        src/apps/fuzzers/fuzzerPolygonToCells.c
+        src/apps/fuzzers/fuzzerPolygonToCellsNoHoles.c)
+    target_compile_definitions(fuzzerH3 PRIVATE FUZZER_COMBINED)
 endif()
 
 if(BUILD_BENCHMARKS)

--- a/src/apps/applib/include/aflHarness.h
+++ b/src/apps/applib/include/aflHarness.h
@@ -25,7 +25,8 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
-#ifndef H3_USE_LIBFUZZER
+#if !defined(H3_USE_LIBFUZZER) && \
+    (!defined(FUZZER_COMBINED) || defined(FUZZER_COMBINED_INCLUDE_MAIN))
 
 /**
  * Generate a AFL++ test case file of the right size initialized to all zeroes.

--- a/src/apps/fuzzers/fuzzer.c
+++ b/src/apps/fuzzers/fuzzer.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @file
+ * @brief Fuzzer program for the entire H3 API
+ */
+
+#ifndef FUZZER_COMBINED
+#error \
+    "fuzzer.c (combined fuzzer program) must be compiled with FUZZER_COMBINED defined"
+#endif
+
+#define FUZZER_COMBINED_INCLUDE_MAIN
+#include "aflHarness.h"
+#include "h3api.h"
+#include "utility.h"
+
+int fuzzerCellArea(const uint8_t *data, size_t size);
+int fuzzerCellProperties(const uint8_t *data, size_t size);
+int fuzzerCellsToLinkedMultiPolygon(const uint8_t *data, size_t size);
+int fuzzerCellToLatLng(const uint8_t *data, size_t size);
+int fuzzerCompact(const uint8_t *data, size_t size);
+int fuzzerDirectedEdge(const uint8_t *data, size_t size);
+int fuzzerDistances(const uint8_t *data, size_t size);
+int fuzzerEdgeLength(const uint8_t *data, size_t size);
+int fuzzerGridDisk(const uint8_t *data, size_t size);
+int fuzzerHierarchy(const uint8_t *data, size_t size);
+int fuzzerIndexIO(const uint8_t *data, size_t size);
+int fuzzerLatLngToCell(const uint8_t *data, size_t size);
+int fuzzerLocalIj(const uint8_t *data, size_t size);
+int fuzzerPolygonToCells(const uint8_t *data, size_t size);
+int fuzzerPolygonToCellsNoHoles(const uint8_t *data, size_t size);
+int fuzzerResolutions(const uint8_t *data, size_t size);
+int fuzzerVertexes(const uint8_t *data, size_t size);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    // All return codes are ignored.
+    fuzzerCellArea(data, size);
+    fuzzerCellProperties(data, size);
+    fuzzerCellsToLinkedMultiPolygon(data, size);
+    fuzzerCellToLatLng(data, size);
+    fuzzerCompact(data, size);
+    fuzzerDirectedEdge(data, size);
+    fuzzerDistances(data, size);
+    fuzzerEdgeLength(data, size);
+    fuzzerGridDisk(data, size);
+    fuzzerHierarchy(data, size);
+    fuzzerIndexIO(data, size);
+    fuzzerLatLngToCell(data, size);
+    fuzzerLocalIj(data, size);
+    fuzzerPolygonToCells(data, size);
+    fuzzerPolygonToCellsNoHoles(data, size);
+    fuzzerResolutions(data, size);
+    fuzzerVertexes(data, size);
+    return 0;
+}
+
+AFL_HARNESS_MAIN(4096);

--- a/src/apps/fuzzers/fuzzerCellArea.c
+++ b/src/apps/fuzzers/fuzzerCellArea.c
@@ -25,7 +25,12 @@ typedef struct {
     H3Index index;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerCellArea
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerCellProperties.c
+++ b/src/apps/fuzzers/fuzzerCellProperties.c
@@ -25,7 +25,12 @@ typedef struct {
     H3Index index;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerCellProperties
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerCellToLatLng.c
+++ b/src/apps/fuzzers/fuzzerCellToLatLng.c
@@ -25,7 +25,12 @@ typedef struct {
     H3Index index;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerCellToLatLng
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerCellsToLinkedMultiPolygon.c
+++ b/src/apps/fuzzers/fuzzerCellsToLinkedMultiPolygon.c
@@ -21,7 +21,12 @@
 #include "h3api.h"
 #include "utility.h"
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerCellsToLinkedMultiPolygon
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     const H3Index *h3Set = (const H3Index *)data;
     int sz = size / sizeof(H3Index);
 

--- a/src/apps/fuzzers/fuzzerCompact.c
+++ b/src/apps/fuzzers/fuzzerCompact.c
@@ -24,7 +24,12 @@
 const int MAX_UNCOMPACT_RES = 9;
 const int64_t MAX_UNCOMPACT_SIZE = 4000000;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerCompact
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(H3Index) * 2) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerDirectedEdge.c
+++ b/src/apps/fuzzers/fuzzerDirectedEdge.c
@@ -26,7 +26,12 @@ typedef struct {
     H3Index index2;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerDirectedEdge
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerDistances.c
+++ b/src/apps/fuzzers/fuzzerDistances.c
@@ -26,7 +26,12 @@ typedef struct {
     LatLng b;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerDistances
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerEdgeLength.c
+++ b/src/apps/fuzzers/fuzzerEdgeLength.c
@@ -25,7 +25,12 @@ typedef struct {
     H3Index index;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerEdgeLength
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerGridDisk.c
+++ b/src/apps/fuzzers/fuzzerGridDisk.c
@@ -28,7 +28,12 @@ typedef struct {
 
 const int64_t MAX_GRID_DISK_SIZE = 0x10000000;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerGridDisk
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerHierarchy.c
+++ b/src/apps/fuzzers/fuzzerHierarchy.c
@@ -29,7 +29,12 @@ typedef struct {
     int childRes;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerHierarchy
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerIndexIO.c
+++ b/src/apps/fuzzers/fuzzerIndexIO.c
@@ -28,7 +28,12 @@ typedef struct {
     char str[STRING_LENGTH];
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerIndexIO
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerLatLngToCell.c
+++ b/src/apps/fuzzers/fuzzerLatLngToCell.c
@@ -26,7 +26,12 @@ typedef struct {
     int res;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerLatLngToCell
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerLocalIj.c
+++ b/src/apps/fuzzers/fuzzerLocalIj.c
@@ -30,7 +30,7 @@ typedef struct {
     uint32_t mode;
 } inputArgs;
 
-void testTwoIndexes(H3Index index, H3Index index2) {
+static void testTwoIndexes(H3Index index, H3Index index2) {
     int64_t distance;
     H3_EXPORT(gridDistance)(index, index2, &distance);
     int64_t size;
@@ -42,7 +42,12 @@ void testTwoIndexes(H3Index index, H3Index index2) {
     }
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerLocalIj
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerPolygonToCells.c
+++ b/src/apps/fuzzers/fuzzerPolygonToCells.c
@@ -30,12 +30,12 @@ typedef struct {
     uint8_t buffer[1024];
 } inputArgs;
 
-const int MAX_RES = 15;
-const int MAX_SZ = 4000000;
-const int MAX_HOLES = 100;
+static const int MAX_RES = 15;
+static const int MAX_SZ = 4000000;
+static const int MAX_HOLES = 100;
 
-int populateGeoLoop(GeoLoop *g, const uint8_t *data, size_t *offset,
-                    size_t size) {
+static int populateGeoLoop(GeoLoop *g, const uint8_t *data, size_t *offset,
+                           size_t size) {
     if (size < *offset + sizeof(int)) {
         return 1;
     }
@@ -50,7 +50,7 @@ int populateGeoLoop(GeoLoop *g, const uint8_t *data, size_t *offset,
     return 0;
 }
 
-void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
+static void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
     int64_t sz;
     H3Error err = H3_EXPORT(maxPolygonToCellsSize)(geoPolygon, res, flags, &sz);
     if (!err && sz < MAX_SZ) {
@@ -60,7 +60,12 @@ void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
     }
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerPolygonToCells
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     // TODO: It is difficult for the fuzzer to generate inputs that are
     // considered valid by this fuzzer. fuzzerPolygonToCellsNoHoles.c
     // is a workaround for that.

--- a/src/apps/fuzzers/fuzzerPolygonToCellsNoHoles.c
+++ b/src/apps/fuzzers/fuzzerPolygonToCellsNoHoles.c
@@ -21,10 +21,9 @@
 #include "h3api.h"
 #include "utility.h"
 
-const int MAX_RES = 15;
-const int MAX_SZ = 4000000;
+static const int MAX_SZ = 4000000;
 
-void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
+static void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
     int64_t sz;
     H3Error err = H3_EXPORT(maxPolygonToCellsSize)(geoPolygon, res, flags, &sz);
     if (!err && sz < MAX_SZ) {
@@ -34,7 +33,12 @@ void run(GeoPolygon *geoPolygon, uint32_t flags, int res) {
     }
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerPolygonToCellsNoHoles
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(int)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerResolutions.c
+++ b/src/apps/fuzzers/fuzzerResolutions.c
@@ -25,7 +25,12 @@ typedef struct {
     int res;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerResolutions
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }

--- a/src/apps/fuzzers/fuzzerVertexes.c
+++ b/src/apps/fuzzers/fuzzerVertexes.c
@@ -26,7 +26,12 @@ typedef struct {
     int vertexNum;
 } inputArgs;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+#ifdef FUZZER_COMBINED
+#define MAIN_NAME fuzzerVertexes
+#else
+#define MAIN_NAME LLVMFuzzerTestOneInput
+#endif
+int MAIN_NAME(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {
         return 0;
     }


### PR DESCRIPTION
Creates a fuzzer that runs against the entire H3 API surface; not sure how useful this will be as I would like to get all the fuzzers currently in the H3 repo run by oss-fuzz which would take care of ensuring these are all run at once.