### PR TITLE
Remove duplicated faceijk.h include

### DIFF
--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -19,7 +19,6 @@
  */
 #include "h3Index.h"
 
-#include <faceijk.h>
 #include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>


### PR DESCRIPTION
this is fine when building standalone, but when including this file in go, go cannot find the header file `<faceijk.h>`.  someone generously wrote a `sed` processor that removes this line when importing the source, but it would be nice to not have to process this in the bindings <3 