### PR TITLE
Fix memory leak in compactCells

### DIFF
--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -355,9 +355,7 @@ SUITE(compactCells) {
                          0x2100000000,
                          0x7,
                          0x400000000};
-        H3Index output[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        H3Index output[43] = {0};
         t_assert(H3_EXPORT(compactCells)(bad, output, numHex) == E_RES_DOMAIN,
                  "compactCells returns E_RES_DOMAIN on bad input (parent "
                  "error #2)");

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -355,7 +355,9 @@ SUITE(compactCells) {
                          0x2100000000,
                          0x7,
                          0x400000000};
-        H3Index output[numHex] = {0};
+        H3Index output[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         t_assert(H3_EXPORT(compactCells)(bad, output, numHex) == E_RES_DOMAIN,
                  "compactCells returns E_RES_DOMAIN on bad input (parent "
                  "error #2)");

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -307,6 +307,60 @@ SUITE(compactCells) {
             "compactCells returns E_RES_MISMATCH on bad input (parent error)");
     }
 
+    TEST(compactCells_parentError2) {
+        // This test primary ensures memory is not leaked upon invalid input,
+        // and ensures coverage of a very particular error branch in
+        // compactCells. The particular error code is not important.
+        const int numHex = 43;
+        H3Index bad[] = {0x2010202020202020,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x20000000,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x5000000000,
+                         0x100321,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x2100000000,
+                         0x7,
+                         0x400000000,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x20000000,
+                         0x5000000000,
+                         0x100321,
+                         0x2100000000,
+                         0x7,
+                         0x400000000};
+        H3Index output[numHex] = {0};
+        t_assert(H3_EXPORT(compactCells)(bad, output, numHex) == E_RES_DOMAIN,
+                 "compactCells returns E_RES_DOMAIN on bad input (parent "
+                 "error #2)");
+    }
+
     TEST(uncompactCells_wrongRes) {
         int numHex = 3;
         H3Index someHexagons[] = {0, 0, 0};

--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -308,7 +308,7 @@ SUITE(compactCells) {
     }
 
     TEST(compactCells_parentError2) {
-        // This test primary ensures memory is not leaked upon invalid input,
+        // This test primarily ensures memory is not leaked upon invalid input,
         // and ensures coverage of a very particular error branch in
         // compactCells. The particular error code is not important.
         const int numHex = 43;

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -446,16 +446,12 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
                 H3Index parent;
                 H3Error parentError =
                     H3_EXPORT(cellToParent)(currIndex, parentRes, &parent);
-                // LCOV_EXCL_START
-                // Should never be reachable as a result of the compact
-                // algorithm.
                 if (parentError) {
-                    // TODO: Determine if this is somehow reachable.
+                    H3_MEMORY(free)(compactableHexes);
                     H3_MEMORY(free)(remainingHexes);
                     H3_MEMORY(free)(hashSetArray);
                     return parentError;
                 }
-                // LCOV_EXCL_STOP
                 // Modulus hash the parent into the temp array
                 // to determine if this index was included in
                 // the compactableHexes array


### PR DESCRIPTION
This branch was previously thought unreachable, but evidently is. It resulted in a memory leak which allowed us to detect it. I added a test based on a specific bad input and assert that it returns failure, plus rely on Valgrind to detect if a leak happens; it may be possible to minify the test case even further.

We should convert these "unreachable" branches to assertions, at least for debug builds so we can be sure to find other such cases in e.g. fuzzing.