### PR TITLE
Prevent signed integer overflow in maxGridDiskSize

### DIFF
--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -83,7 +83,9 @@ SUITE(compactCells) {
         H3Index *compressed = calloc(arrSize, sizeof(H3Index));
         t_assertSuccess(H3_EXPORT(compactCells(children, compressed, arrSize)));
         t_assert(compressed[0] == parent, "got expected parent");
-        t_assert(compressed[1] == 0, "expected only 1 cell");
+        for (int idx = 1; idx < arrSize; idx++) {
+            t_assert(compressed[idx] == 0, "expected only 1 cell");
+        }
 
         free(compressed);
         free(children);

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -418,4 +418,20 @@ SUITE(gridDisk) {
         t_assertSuccess(H3_EXPORT(maxGridDiskSize)(26755, &sz));
         t_assert(sz == 2147570341, "large (> 32 bit signed int) k works");
     }
+
+    TEST(maxGridDiskSize_numCells) {
+        int64_t sz;
+        int64_t prev = 0;
+        int64_t max;
+        t_assertSuccess(H3_EXPORT(getNumCells)(15, &max));
+        // 13780510 will produce values above max
+        for (int64_t k = 13780510 - 100; k < 13780510 + 100; k++) {
+            t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &sz));
+            t_assert(sz <= max,
+                     "maxGridDiskSize does not produce estimates above the "
+                     "number of grid cells");
+            t_assert(prev <= sz, "maxGridDiskSize is monotonically increasing");
+            prev = sz;
+        }
+    }
 }

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -425,7 +425,7 @@ SUITE(gridDisk) {
         int64_t max;
         t_assertSuccess(H3_EXPORT(getNumCells)(15, &max));
         // 13780510 will produce values above max
-        for (int64_t k = 13780510 - 100; k < 13780510 + 100; k++) {
+        for (int k = 13780510 - 100; k < 13780510 + 100; k++) {
             t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &sz));
             t_assert(sz <= max,
                      "maxGridDiskSize does not produce estimates above the "
@@ -433,5 +433,9 @@ SUITE(gridDisk) {
             t_assert(prev <= sz, "maxGridDiskSize is monotonically increasing");
             prev = sz;
         }
+
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(INT32_MAX, &sz));
+        t_assert(sz == max,
+                 "maxGridDiskSize of INT32_MAX produces valid result");
     }
 }

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -152,6 +152,12 @@ static const Direction NEW_ADJUSTMENT_III[7][7] = {
      CENTER_DIGIT, IJ_AXES_DIGIT}};
 
 /**
+ * k value which will encompass all cells at resolution 15.
+ * This is the largest possible k in the H3 grid system.
+ */
+static const int K_ALL_CELLS_AT_RES_15 = 13780510;
+
+/**
  * Maximum number of cells that result from the gridDisk algorithm with the
  * given k. Formula source and proof: https://oeis.org/A003215
  *
@@ -162,7 +168,7 @@ H3Error H3_EXPORT(maxGridDiskSize)(int k, int64_t *out) {
     if (k < 0) {
         return E_DOMAIN;
     }
-    if (k >= 13780510) {
+    if (k >= K_ALL_CELLS_AT_RES_15) {
         // If a k value of this value or above is provided, this function will
         // estimate more cells than exist in the H3 grid at the finest
         // resolution. This is a problem since the function does signed integer

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -162,6 +162,17 @@ H3Error H3_EXPORT(maxGridDiskSize)(int k, int64_t *out) {
     if (k < 0) {
         return E_DOMAIN;
     }
+    if (k >= 13780510) {
+        // If a k value of this value or above is provided, this function will
+        // estimate more cells than exist in the H3 grid at the finest
+        // resolution. This is a problem since the function does signed integer
+        // arithmetic on `k`, which could overflow. To prevent that, instead
+        // substitute the maximum number of cells in the grid, as it should not
+        // be possible for the gridDisk functions to exceed that. Note this is
+        // not resolution specific. So, when resolution < 15, this function may
+        // still estimate a size larger than the number of cells in the grid.
+        return getNumCells(MAX_H3_RES, out);
+    }
     *out = 3 * (int64_t)k * ((int64_t)k + 1) + 1;
     return E_SUCCESS;
 }

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -171,7 +171,7 @@ H3Error H3_EXPORT(maxGridDiskSize)(int k, int64_t *out) {
         // be possible for the gridDisk functions to exceed that. Note this is
         // not resolution specific. So, when resolution < 15, this function may
         // still estimate a size larger than the number of cells in the grid.
-        return getNumCells(MAX_H3_RES, out);
+        return H3_EXPORT(getNumCells)(MAX_H3_RES, out);
     }
     *out = 3 * (int64_t)k * ((int64_t)k + 1) + 1;
     return E_SUCCESS;

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -357,8 +357,8 @@ H3Error H3_EXPORT(compactCells)(const H3Index *h3Set, H3Index *compactedSet,
                     int loc = (int)(parent % numRemainingHexes);
                     int loopCount = 0;
                     while (hashSetArray[loc] != 0) {
-                        if (loopCount >           // LCOV_EXCL_BR_LINE
-                            numRemainingHexes) {  // LCOV_EXCL_BR_LINE
+                        if (loopCount >  // LCOV_EXCL_BR_LINE
+                            numRemainingHexes) {
                             // LCOV_EXCL_START
                             // This case should not be possible because at
                             // most one index is placed into hashSetArray


### PR DESCRIPTION
Signed integer overflow is undefined behavior in C, so we cannot add, multiply, etc. arbitrary integer inputs. This adds a hard cap on the maxGridDiskSize function based on knowledge of the grid system itself.