### PR TITLE
Further reduce MAX_GRID_DISK_SIZE in fuzzerGridDisk

### DIFF
--- a/src/apps/fuzzers/fuzzerGridDisk.c
+++ b/src/apps/fuzzers/fuzzerGridDisk.c
@@ -28,7 +28,7 @@ typedef struct {
 
 // This is limited to avoid timeouts due to the runtime of gridDisk growing with
 // k
-const int64_t MAX_GRID_DISK_SIZE = 100000;
+const int64_t MAX_GRID_DISK_SIZE = 10000;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size < sizeof(inputArgs)) {


### PR DESCRIPTION
Reduces the limit to try to avoid timeouts which spuriously block CI. This function is expected to have a runtime that scales with `k`, so this is expected for large values of `k`.