### PR TITLE
Fix second potential use of uninitialized value in cellToVertex

### DIFF
--- a/src/apps/testapps/testVertex.c
+++ b/src/apps/testapps/testVertex.c
@@ -114,6 +114,13 @@ SUITE(Vertex) {
                  "Invalid cell returns error");
     }
 
+    TEST(cellToVertex_invalid3) {
+        H3Index index = 0x20ff20202020ff35;
+        H3Index vert;
+        t_assert(H3_EXPORT(cellToVertex)(index, 0, &vert) == E_CELL_INVALID,
+                 "Invalid cell returns error");
+    }
+
     TEST(isValidVertex_hex) {
         H3Index origin = 0x823d6ffffffffff;
         H3Index vert = 0x2222597fffffffff;

--- a/src/h3lib/lib/vertex.c
+++ b/src/h3lib/lib/vertex.c
@@ -240,7 +240,9 @@ H3Error H3_EXPORT(cellToVertex)(H3Index cell, int vertexNum, H3Index *out) {
             if (right == INVALID_DIGIT) return E_FAILED;  // LCOV_EXCL_LINE
             int rRotations = 0;
             H3Index rightNeighbor;
-            h3NeighborRotations(cell, right, &rRotations, &rightNeighbor);
+            H3Error rightNeighborError =
+                h3NeighborRotations(cell, right, &rRotations, &rightNeighbor);
+            if (rightNeighborError) return rightNeighborError;
             // Set to owner if lowest index
             if (rightNeighbor < owner) {
                 owner = rightNeighbor;


### PR DESCRIPTION
Follow up to #683.