### PR TITLE
Fix a possible signed integer overflow in localIjToCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- Fixed possible signed integer overflow in `localIjToCell` (#706)
 
 ## [4.0.1] - 2022-09-15
 ### Fixed

--- a/src/apps/testapps/testCellToLocalIj.c
+++ b/src/apps/testapps/testCellToLocalIj.c
@@ -280,4 +280,22 @@ SUITE(h3ToLocalIj) {
         t_assert(H3_EXPORT(localIjToCell)(index, &ij, 0, &out) == E_FAILED,
                  "Negative I and J components fail");
     }
+
+    TEST(localIjToCell_overflow_i) {
+        H3Index origin;
+        setH3Index(&origin, 2, 2, CENTER_DIGIT);
+        CoordIJ ij = {.i = INT32_MIN, .j = INT32_MAX};
+        H3Index out;
+        t_assert(H3_EXPORT(localIjToCell)(origin, &ij, 0, &out) == E_FAILED,
+                 "High magnitude I and J components fail");
+    }
+
+    TEST(localIjToCell_overflow_j) {
+        H3Index origin;
+        setH3Index(&origin, 2, 2, CENTER_DIGIT);
+        CoordIJ ij = {.i = INT32_MAX, .j = INT32_MIN};
+        H3Index out;
+        t_assert(H3_EXPORT(localIjToCell)(origin, &ij, 0, &out) == E_FAILED,
+                 "High magnitude J and I components fail");
+    }
 }

--- a/src/apps/testapps/testCellToLocalIj.c
+++ b/src/apps/testapps/testCellToLocalIj.c
@@ -298,4 +298,13 @@ SUITE(h3ToLocalIj) {
         t_assert(H3_EXPORT(localIjToCell)(origin, &ij, 0, &out) == E_FAILED,
                  "High magnitude J and I components fail");
     }
+
+    TEST(localIjToCell_overflow_ij) {
+        H3Index origin;
+        setH3Index(&origin, 2, 2, CENTER_DIGIT);
+        CoordIJ ij = {.i = INT32_MIN, .j = INT32_MIN};
+        H3Index out;
+        t_assert(H3_EXPORT(localIjToCell)(origin, &ij, 0, &out) == E_FAILED,
+                 "High magnitude J and I components fail");
+    }
 }

--- a/src/apps/testapps/testCellToLocalIjExhaustive.c
+++ b/src/apps/testapps/testCellToLocalIjExhaustive.c
@@ -69,7 +69,7 @@ void h3ToLocalIj_coordinates_assertions(H3Index h3) {
     t_assert(H3_EXPORT(cellToLocalIj)(h3, h3, 0, &ij) == 0,
              "get ij for origin");
     CoordIJK ijk;
-    ijToIjk(&ij, &ijk);
+    t_assertSuccess(ijToIjk(&ij, &ijk));
     if (r == 0) {
         t_assert(_ijkMatches(&ijk, &UNIT_VECS[0]) == 1, "res 0 cell at 0,0,0");
     } else if (r == 1) {
@@ -95,7 +95,7 @@ void h3ToLocalIj_neighbors_assertions(H3Index h3) {
     t_assert(H3_EXPORT(cellToLocalIj)(h3, h3, 0, &origin) == 0,
              "got ij for origin");
     CoordIJK originIjk;
-    ijToIjk(&origin, &originIjk);
+    t_assertSuccess(ijToIjk(&origin, &originIjk));
 
     for (Direction d = K_AXES_DIGIT; d < INVALID_DIGIT; d++) {
         if (d == K_AXES_DIGIT && H3_EXPORT(isPentagon)(h3)) {
@@ -110,7 +110,7 @@ void h3ToLocalIj_neighbors_assertions(H3Index h3) {
         t_assert(H3_EXPORT(cellToLocalIj)(h3, offset, 0, &ij) == 0,
                  "got ij for destination");
         CoordIJK ijk;
-        ijToIjk(&ij, &ijk);
+        t_assertSuccess(ijToIjk(&ij, &ijk));
         CoordIJK invertedIjk = {0};
         _neighbor(&invertedIjk, d);
         for (int i = 0; i < 3; i++) {

--- a/src/apps/testapps/testCoordIj.c
+++ b/src/apps/testapps/testCoordIj.c
@@ -41,7 +41,7 @@ SUITE(coordIj) {
         t_assert(ij.i == 0, "ij.i zero");
         t_assert(ij.j == 0, "ij.j zero");
 
-        ijToIjk(&ij, &ijk);
+        t_assertSuccess(ijToIjk(&ij, &ijk));
         t_assert(ijk.i == 0, "ijk.i zero");
         t_assert(ijk.j == 0, "ijk.j zero");
         t_assert(ijk.k == 0, "ijk.k zero");
@@ -56,7 +56,7 @@ SUITE(coordIj) {
             ijkToIj(&ijk, &ij);
 
             CoordIJK recovered = {0};
-            ijToIjk(&ij, &recovered);
+            t_assertSuccess(ijToIjk(&ij, &recovered));
 
             t_assert(_ijkMatches(&ijk, &recovered),
                      "got same ijk coordinates back");

--- a/src/h3lib/include/coordijk.h
+++ b/src/h3lib/include/coordijk.h
@@ -108,7 +108,7 @@ Direction _rotate60ccw(Direction digit);
 Direction _rotate60cw(Direction digit);
 int ijkDistance(const CoordIJK *a, const CoordIJK *b);
 void ijkToIj(const CoordIJK *ijk, CoordIJ *ij);
-void ijToIjk(const CoordIJ *ij, CoordIJK *ijk);
+H3Error ijToIjk(const CoordIJ *ij, CoordIJK *ijk);
 void ijkToCube(CoordIJK *ijk);
 void cubeToIjk(CoordIJK *ijk);
 

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -527,13 +527,36 @@ void ijkToIj(const CoordIJK *ijk, CoordIJ *ij) {
  *
  * @param ij The input IJ coordinates
  * @param ijk The output IJK+ coordinates
+ * @returns E_SUCCESS on success, E_FAILED if signed integer overflow would have
+ * occurred.
  */
-void ijToIjk(const CoordIJ *ij, CoordIJK *ijk) {
+H3Error ijToIjk(const CoordIJ *ij, CoordIJK *ijk) {
     ijk->i = ij->i;
     ijk->j = ij->j;
     ijk->k = 0;
 
+    // Check for the possibility of overflow
+    int max, min;
+    if (ijk->i > ijk->j) {
+        max = ijk->i;
+        min = ijk->j;
+    } else {
+        max = ijk->j;
+        min = ijk->i;
+    }
+    if (min < 0) {
+        if (max > INT32_MAX + min) {
+            return E_FAILED;
+        }
+    } else {
+        // min >= 0
+        if (max < INT32_MIN + min) {
+            return E_FAILED;
+        }
+    }
+
     _ijkNormalize(ijk);
+    return E_SUCCESS;
 }
 
 /**

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -210,11 +210,11 @@ void _ijkScale(CoordIJK *c, int factor) {
 /**
  * Normalizes ijk coordinates by setting the components to the smallest possible
  * values. Works in place.
- * 
- * This function does not protect against signed integer overflow. The caller must
- * ensure that none of (i - j), (i - k), (j - i), (j - k), (k - i), (k - j) will
- * overflow. This function may be changed in the future to make that check itself
- * and return an error code.
+ *
+ * This function does not protect against signed integer overflow. The caller
+ * must ensure that none of (i - j), (i - k), (j - i), (j - k), (k - i), (k - j)
+ * will overflow. This function may be changed in the future to make that check
+ * itself and return an error code.
  *
  * @param c The ijk coordinates to normalize.
  */
@@ -550,12 +550,16 @@ H3Error ijToIjk(const CoordIJ *ij, CoordIJK *ijk) {
         min = ijk->i;
     }
     if (min < 0) {
-        if (max > INT32_MAX + min) {
+        // Only if the min is less than 0 will the resulting number be larger
+        // than max. If min is positive, then max is also positive, and a
+        // positive signed integer minus another positive signed integer will
+        // not overflow.
+        if (max < INT32_MIN - min) {
+            // max - min would overflow
             return E_FAILED;
         }
-    } else {
-        // min >= 0
-        if (max < INT32_MIN + min) {
+        if (min == INT32_MIN) {
+            // 0 - INT32_MIN would overflow
             return E_FAILED;
         }
     }

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -210,6 +210,11 @@ void _ijkScale(CoordIJK *c, int factor) {
 /**
  * Normalizes ijk coordinates by setting the components to the smallest possible
  * values. Works in place.
+ * 
+ * This function does not protect against signed integer overflow. The caller must
+ * ensure that none of (i - j), (i - k), (j - i), (j - k), (k - i), (k - j) will
+ * overflow. This function may be changed in the future to make that check itself
+ * and return an error code.
  *
  * @param c The ijk coordinates to normalize.
  */

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -563,7 +563,10 @@ H3Error H3_EXPORT(localIjToCell)(H3Index origin, const CoordIJ *ij,
         return E_OPTION_INVALID;
     }
     CoordIJK ijk;
-    ijToIjk(ij, &ijk);
+    H3Error ijToIjkError = ijToIjk(ij, &ijk);
+    if (ijToIjkError) {
+        return ijToIjkError;
+    }
 
     return localIjkToCell(origin, &ijk, out);
 }


### PR DESCRIPTION
This protects against a particular instance of signed integer overflow that would have occurred in `ijkNormalize`.