### PR TITLE
Fix possible signed integer overflow in h3NeighborRotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Fixed
+- Fixed possible signed integer overflow in `h3NeighborRotations` (#707)
 
 ## [4.0.1] - 2022-09-15
 ### Fixed

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -344,9 +344,7 @@ SUITE(gridDisk) {
         // Determined by looking at the base cell table
         setH3Index(&expected, 0, 1, CENTER_DIGIT);
         t_assert(out == expected, "Expected neighbor");
-        // 1 (original value) + 4 (newRotations for IK direction) + 1 (applied
-        // when adjusting to the IK direction) = 6, 6 modulo 6 = 0
-        t_assert(rotations == 0, "Expected rotations value");
+        t_assert(rotations == 5, "Expected rotations value");
     }
 
     TEST(h3NeighborRotations_rotationsOverflow2) {
@@ -364,8 +362,9 @@ SUITE(gridDisk) {
         // Determined by looking at the base cell table
         setH3Index(&expected, 0, 0, CENTER_DIGIT);
         t_assert(out == expected, "Expected neighbor");
-        printf("\n\n*** %d ***\n\n", rotations);
-        t_assert(rotations == 2, "Expected rotations value");
+        // 1 (original value) + 4 (newRotations for IK direction) + 1 (applied
+        // when adjusting to the IK direction) = 6, 6 modulo 6 = 0
+        t_assert(rotations == 0, "Expected rotations value");
     }
 
     TEST(h3NeighborRotations_invalid) {

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -355,6 +355,9 @@ H3Error h3NeighborRotations(H3Index origin, Direction dir, int *rotations,
     if (dir < CENTER_DIGIT || dir >= INVALID_DIGIT) {
         return E_FAILED;
     }
+    // Ensure that rotations is modulo'd by 6 before any possible addition,
+    // to protect against signed integer overflow.
+    *rotations = *rotations % 6;
     for (int i = 0; i < *rotations; i++) {
         dir = _rotate60ccw(dir);
     }


### PR DESCRIPTION
`h3NeighborRotations` adds to the value pointed to by `rotations` before checking. This isn't part of the public API but we test `h3NeighborRotations` to a strict standard anyways.