### PR TITLE
Include instructions for building Release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ From the repository root, you can compile H3 with:
 ```
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 ```
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -168,7 +168,7 @@ Next, build the library:
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 ```
 


### PR DESCRIPTION
We should recommend explicitly choosing Release or Debug when building the library; it seems like for many users a Release build with optimizations would be a reasonable default.