### PR TITLE
ratio for calculation of bbox area should always be > 1 (#708)

### DIFF
--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -247,17 +247,25 @@ SUITE(BBox) {
     }
 
     TEST(bboxHexEstimate_ratio) {
-        BBox bbox1 = {100.0, 1.0, 3.0, 2.0};
-        BBox bbox2 = {3.0, 2.0, 100.0, 1.0};
+        BBox bbox1 = {0.82294, 0.82273, 0.131671, 0.131668};
+        BBox bbox2 = {0.131671, 0.131668, 0.82294, 0.82273};
         int64_t numHexagons1;
         int64_t numHexagons2;
 
-        bboxHexEstimate(&bbox1, -1, &numHexagons1);
-        bboxHexEstimate(&bbox2, -1, &numHexagons2);
+        t_assert(bboxHexEstimate(&bbox1, 15, &numHexagons1) == 0,
+                 "should not fail");
+        t_assert(bboxHexEstimate(&bbox2, 15, &numHexagons2) == 0,
+                 "should not fail");
 
-        t_assert(numHexagons1 == numHexagons2,
-                 "Should be equal for bounding boxes with the same diameter "
-                 "and side ratio");
+        double diffPercentage = fabs(1.0 - numHexagons1 / (double)numHexagons2);
+
+        // numHexagons1 and numHexagons2 cannot be exactly equals because the
+        // diameter of the two bboxes is not exaxtly the same. (It's calculated
+        // using greatCircleDistanceKm)
+        t_assert(
+            diffPercentage < 0.03,
+            "Should be true for bounding boxes with (almost) the same diameter "
+            "and side ratio");
     }
 
     TEST(lineHexEstimate_invalidRes) {

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -246,6 +246,20 @@ SUITE(BBox) {
                  "bboxHexEstimate of invalid resolution fails");
     }
 
+    TEST(bboxHexEstimate_ratio) {
+        BBox bbox1 = {100.0, 1.0, 3.0, 2.0};
+        BBox bbox2 = {3.0, 2.0, 100.0, 1.0};
+        int64_t numHexagons1;
+        int64_t numHexagons2;
+
+        bboxHexEstimate(&bbox1, -1, &numHexagons1);
+        bboxHexEstimate(&bbox2, -1, &numHexagons2);
+
+        t_assert(numHexagons1 == numHexagons2,
+                 "Should be equal for bounding boxes with the same diameter "
+                 "and side ratio");
+    }
+
     TEST(lineHexEstimate_invalidRes) {
         int64_t numHexagons;
         LatLng origin = {0.0, 0.0};

--- a/src/apps/testapps/testBBox.c
+++ b/src/apps/testapps/testBBox.c
@@ -252,15 +252,13 @@ SUITE(BBox) {
         int64_t numHexagons1;
         int64_t numHexagons2;
 
-        t_assert(bboxHexEstimate(&bbox1, 15, &numHexagons1) == 0,
-                 "should not fail");
-        t_assert(bboxHexEstimate(&bbox2, 15, &numHexagons2) == 0,
-                 "should not fail");
+        t_assertSuccess(bboxHexEstimate(&bbox1, 15, &numHexagons1));
+        t_assertSuccess(bboxHexEstimate(&bbox2, 15, &numHexagons2));
 
         double diffPercentage = fabs(1.0 - numHexagons1 / (double)numHexagons2);
 
-        // numHexagons1 and numHexagons2 cannot be exactly equals because the
-        // diameter of the two bboxes is not exaxtly the same. (It's calculated
+        // numHexagons1 and numHexagons2 cannot be exactly equal because the
+        // diameter of the two bboxes is not exactly the same (it's calculated
         // using greatCircleDistanceKm)
         t_assert(
             diffPercentage < 0.03,


### PR DESCRIPTION
Description and discussion is here: https://github.com/uber/h3/issues/708