### PR TITLE
Add temporary edge length documentation to the website

### DIFF
--- a/website/docs/library/restable.md
+++ b/website/docs/library/restable.md
@@ -133,8 +133,30 @@ given by
 [WGS84](https://en.wikipedia.org/wiki/WGS84)/[EPSG:4326](https://epsg.io/4326).
 :::
 
-TODO
+:::danger
+These values are hard coded into the `getHexagonEdgeLengthAvgKm` function and
+related functions in the H3 library. There are [known issues](https://github.com/uber/h3/issues/666)
+with these numbers and they are expected to be updated later.
+:::
 
+| Res | Average edge length (Km) |
+|----:|-------------------------:|
+|   0 | 1107.712591              |
+|   1 | 418.6760055              |
+|   2 | 158.2446558              |
+|   3 | 59.81085794              |
+|   4 | 22.6063794               |
+|   5 | 8.544408276              |
+|   6 | 3.229482772              |
+|   7 | 1.220629759              |
+|   8 | 0.461354684              |
+|   9 | 0.174375668              |
+|  10 | 0.065907807              |
+|  11 | 0.024910561              |
+|  12 | 0.009415526              |
+|  13 | 0.003559893              |
+|  14 | 0.001348575              |
+|  15 | 0.000509713              |
 
 ## Appendix: Methodology
 


### PR DESCRIPTION
This does not fix #666 or #526 but at least makes it easier to find what the library is already returning.

