### PR TITLE
[Docs] Fix cellsToMultiPolygon signature from polygons to hexagons

### DIFF
--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -166,7 +166,7 @@ List<List<List<LatLng>>> cellAddressesToMultiPolygon(Collection<String> h3Addres
 <TabItem value="javascript">
 
 ```js
-h3.cellsToMultiPolygon(polygon, geoJson)
+h3.cellsToMultiPolygon(hexagons, geoJson)
 ```
 
 ```js live


### PR DESCRIPTION
It looks like there is a typo in the website documentations.
I think that the function cellsToMultiPolygon in API Reference -> Regions receives hexagons as the first parameter instead of polygons.