### PR TITLE
Docs: fix incorrect plurals for Java binding

### DIFF
--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -252,7 +252,7 @@ h3.compact_cells(cells)
 
 ```java
 List<Long> compactCells(Collection<Long> cells);
-List<String> compactCellsAddress(Collection<String> cells);
+List<String> compactCellAddress(Collection<String> cells);
 ```
 
 </TabItem>
@@ -307,7 +307,7 @@ h3.uncompact_cells(cells, res)
 
 ```java
 List<Long> uncompactCells(Collection<Long> cells, int res);
-List<String> uncompactCellsAddress(Collection<String> cells, int res);
+List<String> uncompactCellAddress(Collection<String> cells, int res);
 ```
 
 </TabItem>

--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -720,7 +720,7 @@ h3.get_res0_cells(res)
 
 ```java
 Collection<Long> getRes0Cells(int res);
-Collection<String> getRes0CellsAddresses(int res);
+Collection<String> getRes0CellAddresses(int res);
 ```
 
 </TabItem>

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -40,7 +40,7 @@ h3.polygon_to_cells(polygons, res, geo_json_conformant=False)
 
 ```java
 List<Long> polygonToCells(List<LatLng> points, List<List<LatLng>> holes, int res);
-List<String> polygonToCellsAddresses(List<LatLng> points, List<List<LatLng>> holes, int res);
+List<String> polygonToCellAddresses(List<LatLng> points, List<List<LatLng>> holes, int res);
 ```
 
 </TabItem>


### PR DESCRIPTION
It was pointed out on the H3 Slack the plurals for the "Address" form of the Java API was incorrect.