### PR TITLE
Upgrade formatter to clang-format-11

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt update
-          sudo apt-get install doxygen graphviz clang-format-9
+          sudo apt-get install doxygen graphviz clang-format-11
 
       - name: Configure build
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNINGS_AS_ERRORS=ON .
@@ -31,7 +31,7 @@ jobs:
       - name: Formatting check
         working-directory: build
         run: |
-          clang-format-9 --version
+          clang-format-11 --version
           make format
           git diff --exit-code
 
@@ -83,7 +83,7 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt update
-          sudo apt-get install doxygen graphviz clang-format-9
+          sudo apt-get install doxygen graphviz clang-format-11
 
       - name: Configure build
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNINGS_AS_ERRORS=ON -DCMAKE_C_FLAGS="${{ matrix.compile_opt }}" .
@@ -91,7 +91,7 @@ jobs:
       - name: Formatting check
         working-directory: build
         run: |
-          clang-format-9 --version
+          clang-format-11 --version
           make format
           git diff --exit-code
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,8 +330,8 @@ endfunction()
 add_h3_library(h3 "")
 
 # Automatic code formatting
-# Give preference to clang-format-9
-find_program(CLANG_FORMAT_PATH NAMES clang-format-9 clang-format)
+# Give preference to clang-format-11
+find_program(CLANG_FORMAT_PATH NAMES clang-format-11 clang-format)
 cmake_dependent_option(
     ENABLE_FORMAT "Enable running clang-format before compiling" ON
     "CLANG_FORMAT_PATH" OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,10 @@ Planned improvements and changes are listed on the [H3 Roadmap](https://github.c
 ## Pull requests
 
 * Please include tests that show the bug is fixed or feature works as intended.
+* Please include fuzzer tests for public API functions.
 * Please add a description of your change to the Unreleased section of the [changelog](./CHANGELOG.md).
 * Please open issues to discuss large features or changes which would break compatibility, before submitting pull requests.
-* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC. We use clang-format-9 for source code formatting, if you have another version the CI job may error on formatting differences.
+* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC. We use clang-format-11 for source code formatting, if you have another version the CI job may error on formatting differences.
 * Please keep code coverage of the core H3 library at 100%.
 
 Before we can merge your changes, you must agree to the [Uber Contributor License Agreement](https://cla-assistant.io/uber/h3).

--- a/website/docs/core-library/compilation-options.md
+++ b/website/docs/core-library/compilation-options.md
@@ -65,7 +65,7 @@ but is rather the documentation for the internal C library functions.
 
 ## ENABLE_FORMAT
 
-Whether to enable using clang-format-9 to format source files before building. This should be enabled
+Whether to enable using clang-format-11 to format source files before building. This should be enabled
 before submitting patches for H3 as continuous integration will fail if the formatting does not match.
 
 Only this version of clang-format should be used to format the sources as new releases of clang-format

--- a/website/docs/core-library/testing.md
+++ b/website/docs/core-library/testing.md
@@ -18,7 +18,7 @@ Coverage information is collected in Coveralls. Because of the self-contained na
 
 | Operating system | Compiler    | Build type     | Processor architecture | Special notes
 | ---------------- | ----------- | -------------- | ---------------------- | -------------
-| Linux (Ubuntu)   | Clang       | Debug, Release | x64                    | clang-format-9 is used to ensure all code is consistently formatted
+| Linux (Ubuntu)   | Clang       | Debug, Release | x64                    | clang-format-11 is used to ensure all code is consistently formatted
 | Linux            | Clang       | Debug          | x64                    | An additional copy of the job runs with [Valgrind](https://valgrind.org/)
 | Linux            | Clang       | Debug          | x64                    | An additional copy of the job runs with coverage reporting, and excerising the `H3_PREFIX` mechanism.
 | Linux            | gcc         | Debug, Release | x64                    |


### PR DESCRIPTION
CI in #733 is failing due to an upgrade of Github Actions CI from Ubuntu Focal to Ubuntu Jammy. clang-format-9 is no longer available in Jammy. (https://packages.ubuntu.com/focal/clang-format-9 vs https://packages.ubuntu.com/jammy/clang-format-9) It seems the lowest version of clang-format in Jammy is clang-format-11, which was released about a year after clang-format-9, in October 2022. I propose we upgrade our standard formatter from 9 to 11.

It turns out I have already been formatting code with clang-format-14 so I don't think there will be any formatting change.