### PR TITLE
aarch64 performance fix: replace long double with double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The public API of this library consists of the functions declared in file
 ## [Unreleased]
 ### Changed
 - Reorganize tests into public / internal. (#762)
+- Performance enhancement for aarch64, should not affect other platforms
 
 ## [4.1.0] - 2023-01-18
 ### Added

--- a/src/h3lib/lib/coordijk.c
+++ b/src/h3lib/lib/coordijk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, 2020-2022 Uber Technologies, Inc.
+ * Copyright 2016-2018, 2020-2023 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
 
     // first do a reverse conversion
     x2 = a2 / M_SIN60;
-    x1 = a1 + x2 / 2.0L;
+    x1 = a1 + x2 / 2.0;
 
     // check if we have the center of a hex
     m1 = x1;
@@ -77,9 +77,9 @@ void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
     r1 = x1 - m1;
     r2 = x2 - m2;
 
-    if (r1 < 0.5L) {
-        if (r1 < 1.0L / 3.0L) {
-            if (r2 < (1.0L + r1) / 2.0L) {
+    if (r1 < 0.5) {
+        if (r1 < 1.0 / 3.0) {
+            if (r2 < (1.0 + r1) / 2.0) {
                 h->i = m1;
                 h->j = m2;
             } else {
@@ -87,33 +87,33 @@ void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
                 h->j = m2 + 1;
             }
         } else {
-            if (r2 < (1.0L - r1)) {
+            if (r2 < (1.0 - r1)) {
                 h->j = m2;
             } else {
                 h->j = m2 + 1;
             }
 
-            if ((1.0L - r1) <= r2 && r2 < (2.0 * r1)) {
+            if ((1.0 - r1) <= r2 && r2 < (2.0 * r1)) {
                 h->i = m1 + 1;
             } else {
                 h->i = m1;
             }
         }
     } else {
-        if (r1 < 2.0L / 3.0L) {
-            if (r2 < (1.0L - r1)) {
+        if (r1 < 2.0 / 3.0) {
+            if (r2 < (1.0 - r1)) {
                 h->j = m2;
             } else {
                 h->j = m2 + 1;
             }
 
-            if ((2.0L * r1 - 1.0L) < r2 && r2 < (1.0L - r1)) {
+            if ((2.0 * r1 - 1.0) < r2 && r2 < (1.0 - r1)) {
                 h->i = m1;
             } else {
                 h->i = m1 + 1;
             }
         } else {
-            if (r2 < (r1 / 2.0L)) {
+            if (r2 < (r1 / 2.0)) {
                 h->i = m1 + 1;
                 h->j = m2;
             } else {
@@ -125,7 +125,7 @@ void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
 
     // now fold across the axes if necessary
 
-    if (v->x < 0.0L) {
+    if (v->x < 0.0) {
         if ((h->j % 2) == 0)  // even
         {
             long long int axisi = h->j / 2;
@@ -138,7 +138,7 @@ void _hex2dToCoordIJK(const Vec2d *v, CoordIJK *h) {
         }
     }
 
-    if (v->y < 0.0L) {
+    if (v->y < 0.0) {
         h->i = h->i - (2 * h->j + 1) / 2;
         h->j = -1 * h->j;
     }
@@ -156,7 +156,7 @@ void _ijkToHex2d(const CoordIJK *h, Vec2d *v) {
     int i = h->i - h->k;
     int j = h->j - h->k;
 
-    v->x = i - 0.5L * j;
+    v->x = i - 0.5 * j;
     v->y = j * M_SQRT3_2;
 }
 
@@ -346,8 +346,8 @@ H3Error _upAp7Checked(CoordIJK *ijk) {
     }
 
     // TODO: Do the int math parts here in long double?
-    ijk->i = (int)lroundl(((i * 3) - j) / 7.0L);
-    ijk->j = (int)lroundl((i + (j * 2)) / 7.0L);
+    ijk->i = (int)lround(((i * 3) - j) / 7.0);
+    ijk->j = (int)lround((i + (j * 2)) / 7.0);
     ijk->k = 0;
 
     // Expected not to be reachable, because max + min or max - min would need
@@ -395,8 +395,8 @@ H3Error _upAp7rChecked(CoordIJK *ijk) {
     }
 
     // TODO: Do the int math parts here in long double?
-    ijk->i = (int)lroundl(((i * 2) + j) / 7.0L);
-    ijk->j = (int)lroundl(((j * 3) - i) / 7.0L);
+    ijk->i = (int)lround(((i * 2) + j) / 7.0);
+    ijk->j = (int)lround(((j * 3) - i) / 7.0);
     ijk->k = 0;
 
     // Expected not to be reachable, because max + min or max - min would need
@@ -419,8 +419,8 @@ void _upAp7(CoordIJK *ijk) {
     int i = ijk->i - ijk->k;
     int j = ijk->j - ijk->k;
 
-    ijk->i = (int)lroundl((3 * i - j) / 7.0L);
-    ijk->j = (int)lroundl((i + 2 * j) / 7.0L);
+    ijk->i = (int)lround((3 * i - j) / 7.0);
+    ijk->j = (int)lround((i + 2 * j) / 7.0);
     ijk->k = 0;
     _ijkNormalize(ijk);
 }
@@ -436,8 +436,8 @@ void _upAp7r(CoordIJK *ijk) {
     int i = ijk->i - ijk->k;
     int j = ijk->j - ijk->k;
 
-    ijk->i = (int)lroundl((2 * i + j) / 7.0L);
-    ijk->j = (int)lroundl((3 * j - i) / 7.0L);
+    ijk->i = (int)lround((2 * i + j) / 7.0);
+    ijk->j = (int)lround((3 * j - i) / 7.0);
     ijk->k = 0;
     _ijkNormalize(ijk);
 }

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -33,7 +33,7 @@
 #include "vec3d.h"
 
 /** square root of 7 */
-#define M_SQRT7 2.6457513110645905905016157536392604257102L
+#define M_SQRT7 2.6457513110645905905016157536392604257102
 
 /** @brief icosahedron face centers in lat/lng radians */
 const LatLng faceCenterGeo[NUM_ICOSA_FACES] = {
@@ -395,7 +395,7 @@ void _geoToHex2d(const LatLng *g, int res, int *face, Vec2d *v) {
     double r = acos(1 - sqd / 2);
 
     if (r < EPSILON) {
-        v->x = v->y = 0.0L;
+        v->x = v->y = 0.0;
         return;
     }
 

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Uber Technologies, Inc.
+ * Copyright 2016-2023 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/h3lib/lib/latLng.c
+++ b/src/h3lib/lib/latLng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Uber Technologies, Inc.
+ * Copyright 2016-2023 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
  * @return The normalized radians value.
  */
 double _posAngleRads(double rads) {
-    double tmp = ((rads < 0.0L) ? rads + M_2PI : rads);
+    double tmp = ((rads < 0.0) ? rads + M_2PI : rads);
     if (rads >= M_2PI) tmp -= M_2PI;
     return tmp;
 }


### PR DESCRIPTION
On aarch64 systems, we are seeing a significant overhead in libgcc - __multf3.
```
26.28%  h3geo  libgcc_s.so.1      [.] __multf3
```
This overhead is due to the usage of lroundl in coordijk.c. To prevent this overhead, we are proposing to replace long double type with double type and use lround instead of lroundl. This should have no impact on other systems than aarch64. We have verified the behavior matches on some test cases. For coherency sake, we also changed long double constants to double type.

This was found by the SPEC CPU committee, where h3 is being considered as a candidate benchmark for [SPEC CPU v8](https://spec.org/cpuv8/) and undergoing testing across a wide variety of systems and compilers.

Feel free to squash these commits.