### PR TITLE
`hierarchy.mdx`: Fix call to nonexistent `compact` in `js` example for `uncompactCells`

### DIFF
--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -432,7 +432,7 @@ h3.uncompactCells(cells, res)
 function example() {
   const cell = '85283473fffffff';
   const nearby = h3.gridDisk(cell, 4);
-  const compacted = h3.compact(nearby);
+  const compacted = h3.compactCells(nearby);
   return h3.uncompactCells(compacted, 5);
 }
 ```


### PR DESCRIPTION
The `uncompactCells` example for `js` makes a call to `compact`, which no longer exists. It should use `compactCells`.