### PR TITLE
Fix for edge cases with bbox overlap and out-of-bounds polygons

### DIFF
--- a/src/apps/testapps/testPolyfillInternal.c
+++ b/src/apps/testapps/testPolyfillInternal.c
@@ -36,14 +36,6 @@ static GeoPolygon sfGeoPolygon = {
                                     {0.6599990002976, -2.1376771158464}}},
     .numHoles = 0};
 
-static GeoPolygon invalidGeoPolygon = {
-    .geoloop = {.numVerts = 4,
-                .verts = (LatLng[]){{NAN, -2.1364398519396},
-                                    {0.6595011102219, NAN},
-                                    {NAN, -2.1354884206045},
-                                    {0.6581220034068, NAN}}},
-    .numHoles = 0};
-
 SUITE(polyfillInternal) {
     TEST(iterInitPolygonCompact_errors) {
         IterCellsPolygonCompact iter;
@@ -139,24 +131,6 @@ SUITE(polyfillInternal) {
         iterStepPolygonCompact(&iter);
         t_assert(iter.error == E_RES_DOMAIN,
                  "Got expected error for too-fine cell");
-        t_assert(iter.cell == H3_NULL, "Got null output for invalid cell");
-    }
-
-    TEST(iterStepPolygonCompact_invalidPolygonErrors) {
-        IterCellsPolygonCompact iter;
-
-        // Start with a good polygon, otherwise we error out early
-        iter =
-            iterInitPolygonCompact(&sfGeoPolygon, 5, CONTAINMENT_OVERLAPPING);
-        t_assertSuccess(iter.error);
-
-        // Give the iterator a bad polygon and a cell at target res
-        iter._polygon = &invalidGeoPolygon;
-        iter.cell = 0x85283473fffffff;
-
-        iterStepPolygonCompact(&iter);
-        t_assert(iter.error == E_LATLNG_DOMAIN,
-                 "Got expected error for invalid polygon");
         t_assert(iter.cell == H3_NULL, "Got null output for invalid cell");
     }
 

--- a/src/apps/testapps/testPolygonToCellsExperimental.c
+++ b/src/apps/testapps/testPolygonToCellsExperimental.c
@@ -50,6 +50,11 @@ static LatLng invalidVerts[] = {{INFINITY, INFINITY}, {-INFINITY, -INFINITY}};
 static GeoLoop invalidGeoLoop = {.numVerts = 2, .verts = invalidVerts};
 static GeoPolygon invalidGeoPolygon;
 
+static LatLng outOfBoundsVert[] = {{-2000, -2000}};
+static GeoLoop outOfBoundsVertGeoLoop = {.numVerts = 1,
+                                         .verts = outOfBoundsVert};
+static GeoPolygon outOfBoundsVertGeoPolygon;
+
 static LatLng invalid2Verts[] = {{NAN, NAN}, {-NAN, -NAN}};
 static GeoLoop invalid2GeoLoop = {.numVerts = 2, .verts = invalid2Verts};
 static GeoPolygon invalid2GeoPolygon;
@@ -173,6 +178,9 @@ SUITE(polygonToCells) {
     invalid2GeoPolygon.geoloop = invalid2GeoLoop;
     invalid2GeoPolygon.numHoles = 0;
 
+    outOfBoundsVertGeoPolygon.geoloop = outOfBoundsVertGeoLoop;
+    outOfBoundsVertGeoPolygon.numHoles = 0;
+
     nullGeoPolygon.geoloop = nullGeoLoop;
     nullGeoPolygon.numHoles = 0;
 
@@ -226,6 +234,21 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
+    TEST(polygonToCells_OverlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &sfGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &sfGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        t_assert(actualNumIndexes == 1416,
+                 "got expected polygonToCells size (overlapping bbox mode)");
+        free(hexagons);
+    }
+
     TEST(polygonToCellsHole) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -269,6 +292,22 @@ SUITE(polygonToCells) {
 
         t_assert(actualNumIndexes == 1311,
                  "got expected polygonToCells size (hole, overlapping mode)");
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsHoleOverlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &holeGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &holeGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        t_assert(
+            actualNumIndexes == 1403,
+            "got expected polygonToCells size (hole, overlapping bbox mode)");
         free(hexagons);
     }
 
@@ -398,6 +437,22 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
+    TEST(polygonToCellsContainsPolygon_OverlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &sfGeoPolygon, 4, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &sfGeoPolygon, 4, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        t_assert(actualNumIndexes == 5,
+                 "got expected polygonToCells size (overlapping bbox mode)");
+        t_assert(hexagons[0] == 0x8428309ffffffff, "got expected hexagon");
+        free(hexagons);
+    }
+
     TEST(polygonToCellsExact) {
         LatLng somewhere = {1, 2};
         H3Index origin;
@@ -439,6 +494,15 @@ SUITE(polygonToCells) {
 
         // TODO: CONTAINMENT_OVERLAPPING yields 7 cells, presumably due to FPE
         // in the various cell boundaries
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &someHexagon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+        // Overlapping BBox is very rough, so we get a couple of overlaps from
+        // non-neighboring cells
+        t_assert(actualNumIndexes == 9,
+                 "got expected polygonToCells size for overlapping bbox "
+                 "containment");
 
         free(hexagons);
         free(verts);
@@ -643,48 +707,105 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsPointPolygon) {
-        int64_t numHexagons;
-        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
-        t_assert(numHexagons == 1, "got expected estimated size");
-        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+        for (int res = 0; res < MAX_H3_RES; res++) {
+            int64_t numHexagons;
+            t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_CENTER, &numHexagons));
+            t_assert(numHexagons >= 1 && numHexagons <= 5,
+                     "got expected estimated size");
+            H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
-        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_CENTER, hexagons));
-        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+            t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_CENTER, hexagons));
+            int64_t actualNumIndexes =
+                countNonNullIndexes(hexagons, numHexagons);
 
-        t_assert(actualNumIndexes == 0, "got expected polygonToCells size");
-        free(hexagons);
+            t_assert(actualNumIndexes == 0, "got expected polygonToCells size");
+            free(hexagons);
+        }
     }
 
     TEST(polygonToCellsPointPolygon_full) {
-        int64_t numHexagons;
-        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
-        t_assert(numHexagons == 1, "got expected estimated size");
-        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+        for (int res = 0; res < MAX_H3_RES; res++) {
+            int64_t numHexagons;
+            t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_FULL, &numHexagons));
+            t_assert(numHexagons >= 1 && numHexagons <= 5,
+                     "got expected estimated size");
+            H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
-        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_FULL, hexagons));
-        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+            t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_FULL, hexagons));
+            int64_t actualNumIndexes =
+                countNonNullIndexes(hexagons, numHexagons);
 
-        t_assert(actualNumIndexes == 0, "got expected polygonToCells size");
-        free(hexagons);
+            t_assert(actualNumIndexes == 0, "got expected polygonToCells size");
+            free(hexagons);
+        }
     }
 
     TEST(polygonToCellsPointPolygon_overlapping) {
-        int64_t numHexagons;
-        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
-        t_assert(numHexagons == 1, "got expected estimated size");
-        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+        for (int res = 0; res < MAX_H3_RES; res++) {
+            int64_t numHexagons;
+            t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING, &numHexagons));
+            t_assert(numHexagons >= 1 && numHexagons <= 5,
+                     "got expected estimated size");
+            H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
 
-        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
-            &pointGeoPolygon, 9, CONTAINMENT_OVERLAPPING, hexagons));
-        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+            t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING, hexagons));
+            int64_t actualNumIndexes =
+                countNonNullIndexes(hexagons, numHexagons);
 
-        t_assert(actualNumIndexes == 1, "got expected polygonToCells size");
-        free(hexagons);
+            t_assert(actualNumIndexes == 1, "got expected polygonToCells size");
+            free(hexagons);
+        }
+    }
+
+    TEST(polygonToCellsPointPolygon_overlappingBBox) {
+        for (int res = 0; res < MAX_H3_RES; res++) {
+            int64_t numHexagons;
+            t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING_BBOX,
+                &numHexagons));
+            t_assert(numHexagons >= 1 && numHexagons <= 5,
+                     "got expected estimated size");
+            H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+            t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+                &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+            int64_t actualNumIndexes =
+                countNonNullIndexes(hexagons, numHexagons);
+
+            t_assert(actualNumIndexes >= 1 && actualNumIndexes <= 5,
+                     "got expected polygonToCells size");
+            free(hexagons);
+        }
+    }
+
+    TEST(polygonToCellsOutOfBoundsPolygon) {
+        for (int res = 0; res < MAX_H3_RES; res++) {
+            for (uint32_t flags = 0; flags < CONTAINMENT_INVALID; flags++) {
+                int64_t numHexagons;
+                t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+                    &outOfBoundsVertGeoPolygon, res, flags, &numHexagons));
+                t_assert(numHexagons == 0, "got expected estimated size");
+                // Note: We're allocating more memory than the estimate to test
+                // for out-of-bounds writes here
+                H3Index *hexagons = calloc(10, sizeof(H3Index));
+
+                t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+                    &outOfBoundsVertGeoPolygon, res, flags, hexagons));
+                int64_t actualNumIndexes =
+                    countNonNullIndexes(hexagons, numHexagons);
+
+                h3Println(hexagons[0]);
+                t_assert(actualNumIndexes == 0,
+                         "got expected polygonToCells size");
+                free(hexagons);
+            }
+        }
     }
 
     TEST(polygonToCellsLinePolygon) {
@@ -726,6 +847,20 @@ SUITE(polygonToCells) {
         int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
 
         t_assert(actualNumIndexes == 9, "got expected polygonToCells size");
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsLinePolygon_overlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &lineGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &lineGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        t_assert(actualNumIndexes == 21, "got expected polygonToCells size");
         free(hexagons);
     }
 
@@ -773,6 +908,23 @@ SUITE(polygonToCells) {
 
         // Same as without the hole
         t_assert(actualNumIndexes == 1334,
+                 "got expected polygonToCells size (null hole)");
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsNullHole_overlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &nullHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,
+            &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &nullHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        // Same as without the hole
+        t_assert(actualNumIndexes == 1416,
                  "got expected polygonToCells size (null hole)");
         free(hexagons);
     }
@@ -825,6 +977,23 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
+    TEST(polygonToCellsPointHole_overlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &pointHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,
+            &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &pointHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        // Same as without the hole
+        t_assert(actualNumIndexes == 1416,
+                 "got expected polygonToCells size (point hole)");
+        free(hexagons);
+    }
+
     TEST(polygonToCellsLineHole) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -869,6 +1038,23 @@ SUITE(polygonToCells) {
 
         // Same as without the hole
         t_assert(actualNumIndexes == 1334,
+                 "got expected polygonToCells size (line hole)");
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsLineHole_overlappingBBox) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
+            &lineHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,
+            &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(polygonToCellsExperimental)(
+            &lineHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, hexagons));
+        int64_t actualNumIndexes = countNonNullIndexes(hexagons, numHexagons);
+
+        // Same as without the hole
+        t_assert(actualNumIndexes == 1416,
                  "got expected polygonToCells size (line hole)");
         free(hexagons);
     }

--- a/src/apps/testapps/testPolygonToCellsExperimental.c
+++ b/src/apps/testapps/testPolygonToCellsExperimental.c
@@ -800,7 +800,6 @@ SUITE(polygonToCells) {
                 int64_t actualNumIndexes =
                     countNonNullIndexes(hexagons, numHexagons);
 
-                h3Println(hexagons[0]);
                 t_assert(actualNumIndexes == 0,
                          "got expected polygonToCells size");
                 free(hexagons);

--- a/src/apps/testapps/testPolygonToCellsExperimental.c
+++ b/src/apps/testapps/testPolygonToCellsExperimental.c
@@ -190,7 +190,7 @@ SUITE(polygonToCells) {
     lineGeoPolygon.geoloop = lineGeoLoop;
     lineGeoPolygon.numHoles = 0;
 
-    TEST(polygonToCells) {
+    TEST(polygonToCells_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &sfGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -249,7 +249,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsHole) {
+    TEST(polygonToCellsHole_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &holeGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -264,7 +264,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsHoleFullContainment) {
+    TEST(polygonToCellsHole_FullContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &holeGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
@@ -280,7 +280,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsHoleOverlapping) {
+    TEST(polygonToCellsHole_Overlapping) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &holeGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -295,7 +295,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsHoleOverlappingBBox) {
+    TEST(polygonToCellsHole_OverlappingBBox) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &holeGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
@@ -380,7 +380,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsContainsPolygon_CenterContained) {
+    TEST(polygonToCellsContainsPolygon_CenterContainment) {
         // Contains the center point of a res 4 cell
         LatLng centerVerts[] = {{0.6595645, -2.1353315},
                                 {0.6595645, -2.1353314},
@@ -706,7 +706,7 @@ SUITE(polygonToCells) {
         }
     }
 
-    TEST(polygonToCellsPointPolygon) {
+    TEST(polygonToCellsPointPolygon_CenterContainment) {
         for (int res = 0; res < MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -725,7 +725,7 @@ SUITE(polygonToCells) {
         }
     }
 
-    TEST(polygonToCellsPointPolygon_full) {
+    TEST(polygonToCellsPointPolygon_FullContainment) {
         for (int res = 0; res < MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -744,7 +744,7 @@ SUITE(polygonToCells) {
         }
     }
 
-    TEST(polygonToCellsPointPolygon_overlapping) {
+    TEST(polygonToCellsPointPolygon_Overlapping) {
         for (int res = 0; res < MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -763,7 +763,7 @@ SUITE(polygonToCells) {
         }
     }
 
-    TEST(polygonToCellsPointPolygon_overlappingBBox) {
+    TEST(polygonToCellsPointPolygon_OverlappingBBox) {
         for (int res = 0; res < MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -807,7 +807,7 @@ SUITE(polygonToCells) {
         }
     }
 
-    TEST(polygonToCellsLinePolygon) {
+    TEST(polygonToCellsLinePolygon_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -821,7 +821,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLinePolygon_full) {
+    TEST(polygonToCellsLinePolygon_FullContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
@@ -835,7 +835,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLinePolygon_overlapping) {
+    TEST(polygonToCellsLinePolygon_Overlapping) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -849,7 +849,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLinePolygon_overlappingBBox) {
+    TEST(polygonToCellsLinePolygon_OverlappingBBox) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX, &numHexagons));
@@ -863,7 +863,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsNullHole) {
+    TEST(polygonToCellsNullHole_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &nullHoleGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -879,7 +879,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsNullHole_full) {
+    TEST(polygonToCellsNullHole_FullContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &nullHoleGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
@@ -895,7 +895,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsNullHole_overlapping) {
+    TEST(polygonToCellsNullHole_Overlapping) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &nullHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -911,7 +911,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsNullHole_overlappingBBox) {
+    TEST(polygonToCellsNullHole_OverlappingBBox) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &nullHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,
@@ -928,7 +928,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsPointHole) {
+    TEST(polygonToCellsPointHole_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &pointHoleGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -944,7 +944,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsPointHole_full) {
+    TEST(polygonToCellsPointHole_FullContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &pointHoleGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
@@ -960,7 +960,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsPointHole_overlapping) {
+    TEST(polygonToCellsPointHole_Overlapping) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &pointHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -976,7 +976,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsPointHole_overlappingBBox) {
+    TEST(polygonToCellsPointHole_OverlappingBBox) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &pointHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,
@@ -993,7 +993,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLineHole) {
+    TEST(polygonToCellsLineHole_CenterContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineHoleGeoPolygon, 9, CONTAINMENT_CENTER, &numHexagons));
@@ -1009,7 +1009,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLineHole_full) {
+    TEST(polygonToCellsLineHole_FullContainment) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineHoleGeoPolygon, 9, CONTAINMENT_FULL, &numHexagons));
@@ -1025,7 +1025,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLineHole_overlapping) {
+    TEST(polygonToCellsLineHole_Overlapping) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -1041,7 +1041,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsLineHole_overlappingBBox) {
+    TEST(polygonToCellsLineHole_OverlappingBBox) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
             &lineHoleGeoPolygon, 9, CONTAINMENT_OVERLAPPING_BBOX,

--- a/src/h3lib/lib/polyfill.c
+++ b/src/h3lib/lib/polyfill.c
@@ -466,8 +466,7 @@ void iterStepPolygonCompact(IterCellsPolygonCompact *iter) {
                         &(iter->_polygon->geoloop.verts[0]), cellRes,
                         &polygonCell);
                     if (NEVER(polygonCellErr != E_SUCCESS)) {
-                        // This should be unreachable with the bboxContains
-                        // check
+                        // This should be unreachable with the bbox check
                         iterErrorPolygonCompact(iter, polygonCellErr);
                         return;
                     }
@@ -488,7 +487,7 @@ void iterStepPolygonCompact(IterCellsPolygonCompact *iter) {
                 }
                 BBox bbox;
                 H3Error bboxErr = cellToBBox(cell, &bbox, false);
-                if ((bboxErr != E_SUCCESS)) {
+                if (NEVER(bboxErr != E_SUCCESS)) {
                     // Should be unreachable - invalid cells would be caught in
                     // the previous boundaryErr
                     iterErrorPolygonCompact(iter, bboxErr);


### PR DESCRIPTION
More follow-up for #800:
- Adds tests for `CONTAINMENT_OVERLAPPING_BBOX` and fixes the out-of-bounds write when using bbox overlap on a one-vertex polygon
- Adds a simpler version of [this test case](https://github.com/uber/h3/pull/800/commits/673046900ad0eabaa65bcd66c508047ce24af806) and fixes `CONTAINMENT_OVERLAPPING` results for polygons outside of the normal lat/lng range. The issue here was the test for cell-contains-polygon, which used `latLngToCell` - this function will return results for out-of-bounds input, presumably wrapping around the sphere, but because the rest of the logic (including the estimator) in `polygonToCells` is using cartesian coords, these false positives were unexpected. I updated this to include a bbox check first, which will exclude polygons with all points outside of the normal range.