### PR TITLE
MAX_H3_RES should be tested inclusive

### DIFF
--- a/src/apps/testapps/testDirectedEdge.c
+++ b/src/apps/testapps/testDirectedEdge.c
@@ -213,7 +213,7 @@ SUITE(directedEdge) {
         H3Index pentagon;
         H3Index edge;
 
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             t_assertSuccess(H3_EXPORT(getPentagons)(res, pentagons));
             for (int p = 0; p < NUM_PENTAGONS; p++) {
                 pentagon = pentagons[p];
@@ -342,7 +342,7 @@ SUITE(directedEdge) {
         const int expectedVertices[][2] = {{3, 4}, {1, 2}, {2, 3},
                                            {5, 0}, {4, 5}, {0, 1}};
 
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             t_assertSuccess(H3_EXPORT(latLngToCell)(&sfGeo, res, &sf));
             t_assertSuccess(H3_EXPORT(cellToBoundary)(sf, &boundary));
             t_assertSuccess(H3_EXPORT(originToDirectedEdges)(sf, edges));
@@ -371,7 +371,7 @@ SUITE(directedEdge) {
         const int expectedVertices[][3] = {{-1, -1, -1}, {2, 3, 4}, {4, 5, 6},
                                            {8, 9, 0},    {6, 7, 8}, {0, 1, 2}};
 
-        for (int res = 1; res < MAX_H3_RES; res += 2) {
+        for (int res = 1; res <= MAX_H3_RES; res += 2) {
             setH3Index(&pentagon, res, 24, 0);
             t_assertSuccess(H3_EXPORT(cellToBoundary)(pentagon, &boundary));
             t_assertSuccess(H3_EXPORT(originToDirectedEdges)(pentagon, edges));
@@ -409,7 +409,7 @@ SUITE(directedEdge) {
         const int expectedVertices[][3] = {{-1, -1}, {1, 2}, {2, 3},
                                            {4, 0},   {3, 4}, {0, 1}};
 
-        for (int res = 0; res < MAX_H3_RES; res += 2) {
+        for (int res = 0; res <= MAX_H3_RES; res += 2) {
             setH3Index(&pentagon, res, 24, 0);
             t_assertSuccess(H3_EXPORT(cellToBoundary)(pentagon, &boundary));
             t_assertSuccess(H3_EXPORT(originToDirectedEdges)(pentagon, edges));

--- a/src/apps/testapps/testPolygonToCellsExperimental.c
+++ b/src/apps/testapps/testPolygonToCellsExperimental.c
@@ -686,7 +686,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsNullPolygon) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             for (uint32_t flags = 0; flags < CONTAINMENT_INVALID; flags++) {
                 int64_t numHexagons;
                 t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
@@ -707,7 +707,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsPointPolygon_CenterContainment) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
                 &pointGeoPolygon, res, CONTAINMENT_CENTER, &numHexagons));
@@ -726,7 +726,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsPointPolygon_FullContainment) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
                 &pointGeoPolygon, res, CONTAINMENT_FULL, &numHexagons));
@@ -745,7 +745,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsPointPolygon_Overlapping) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
                 &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING, &numHexagons));
@@ -764,7 +764,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsPointPolygon_OverlappingBBox) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             int64_t numHexagons;
             t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(
                 &pointGeoPolygon, res, CONTAINMENT_OVERLAPPING_BBOX,
@@ -785,7 +785,7 @@ SUITE(polygonToCells) {
     }
 
     TEST(polygonToCellsOutOfBoundsPolygon) {
-        for (int res = 0; res < MAX_H3_RES; res++) {
+        for (int res = 0; res <= MAX_H3_RES; res++) {
             for (uint32_t flags = 0; flags < CONTAINMENT_INVALID; flags++) {
                 int64_t numHexagons;
                 t_assertSuccess(H3_EXPORT(maxPolygonToCellsSizeExperimental)(


### PR DESCRIPTION
I think this is an oversight in these tests, MAX_H3_RES is the last valid resolution, so we should include it.