### PR TITLE
Add tbbuck/H3.net.SqlClr to bindings list for SQL Server

### DIFF
--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -111,6 +111,10 @@ As a C library, bindings can be made to call H3 functions from different program
 - [crazycapivara/h3-r](https://github.com/crazycapivara/h3-r)
 - [obrl-soil/h3jsr](https://github.com/obrl-soil/h3jsr)
 
+## SQL Server
+
+- [tbbuck/H3.net.SqlClr](https://github.com/tbbuck/H3.net.SqlClr)
+
 ## Ruby
 
 - [seanhandley/h3_ruby](https://github.com/seanhandley/h3_ruby)


### PR DESCRIPTION
Adding SQL CLR implementation of H3 for SQL Server using the https://github.com/pocketken/H3.net C# port as a base.