### PR TITLE
upgrade to clang-format-14

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt update
-          sudo apt-get install doxygen graphviz clang-format-11
+          sudo apt-get install doxygen graphviz clang-format-14
 
       - name: Configure build
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNINGS_AS_ERRORS=ON .
@@ -41,7 +41,7 @@ jobs:
       - name: Formatting check
         working-directory: build
         run: |
-          clang-format-11 --version
+          clang-format-14 --version
           make format
           git diff --exit-code
 
@@ -93,7 +93,7 @@ jobs:
       - name: Install Doxygen
         run: |
           sudo apt update
-          sudo apt-get install doxygen graphviz clang-format-11
+          sudo apt-get install doxygen graphviz clang-format-14
 
       - name: Configure build
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DWARNINGS_AS_ERRORS=ON -DCMAKE_C_FLAGS="${{ matrix.compile_opt }}" .
@@ -101,7 +101,7 @@ jobs:
       - name: Formatting check
         working-directory: build
         run: |
-          clang-format-11 --version
+          clang-format-14 --version
           make format
           git diff --exit-code
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,8 +381,8 @@ endfunction()
 add_h3_library(h3 "")
 
 # Automatic code formatting
-# Give preference to clang-format-11
-find_program(CLANG_FORMAT_PATH NAMES clang-format-11 clang-format)
+# Give preference to clang-format-14
+find_program(CLANG_FORMAT_PATH NAMES clang-format-14 clang-format)
 cmake_dependent_option(
     ENABLE_FORMAT "Enable running clang-format before compiling" ON
     "CLANG_FORMAT_PATH" OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Planned improvements and changes are discussed in Github issues. Feel free to op
 * Please include fuzzer tests for public API functions.
 * Please add a description of your change to the Unreleased section of the [changelog](./CHANGELOG.md).
 * Please open issues to discuss large features or changes which would break compatibility, before submitting pull requests.
-* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC. We use clang-format-11 for source code formatting, if you have another version the CI job may error on formatting differences.
+* Please keep H3 compatible with major C compilers, such as GCC, Clang, and MSVC. We use clang-format-14 for source code formatting, if you have another version the CI job may error on formatting differences.
 * Please keep code coverage of the core H3 library at 100%.
 
 Before we can merge your changes, you must agree to the [Uber Contributor License Agreement](https://cla-assistant.io/uber/h3).

--- a/website/docs/core-library/compilation-options.md
+++ b/website/docs/core-library/compilation-options.md
@@ -77,7 +77,7 @@ but is rather the documentation for the internal C library functions.
 
 ## ENABLE_FORMAT
 
-Whether to enable using clang-format-11 to format source files before building. This should be enabled
+Whether to enable using clang-format-14 to format source files before building. This should be enabled
 before submitting patches for H3 as continuous integration will fail if the formatting does not match.
 
 Only this version of clang-format should be used to format the sources as new releases of clang-format

--- a/website/docs/core-library/testing.md
+++ b/website/docs/core-library/testing.md
@@ -18,7 +18,7 @@ Coverage information is collected in Coveralls. Because of the self-contained na
 
 | Operating system | Compiler    | Build type     | Processor architecture | Special notes
 | ---------------- | ----------- | -------------- | ---------------------- | -------------
-| Linux (Ubuntu)   | Clang       | Debug, Release | x64                    | clang-format-11 is used to ensure all code is consistently formatted
+| Linux (Ubuntu)   | Clang       | Debug, Release | x64                    | clang-format-14 is used to ensure all code is consistently formatted
 | Linux            | Clang       | Debug          | x64                    | An additional copy of the job runs with [Valgrind](https://valgrind.org/)
 | Linux            | Clang       | Debug          | x64                    | An additional copy of the job runs with coverage reporting, and excerising the `H3_PREFIX` mechanism.
 | Linux            | gcc         | Debug, Release | x64                    |


### PR DESCRIPTION
clang-format-11 is no longer available in the latest Ubuntu and Fedora repositories, so upgrading the version here to the minimum supported by Ubuntu. This version is also found in Debian stable.