### PR TITLE
Fix cellToChildPos and childPosToCell docs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/theme-live-codeblock": "^2.0.1",
     "@mdx-js/react": "^1.6.22",
     "global": "^4.4.0",
-    "h3-js": "^4.0.0",
+    "h3-js": "4.1.0",
     "h3-jsv3": "npm:h3-js@^3.7.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1546,7 +1546,7 @@
     "@docusaurus/theme-search-algolia" "2.0.1"
     "@docusaurus/types" "2.0.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -4271,10 +4271,10 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
-h3-js@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-4.0.0.tgz#f55efb89f4608014146f3839d1d01d7a2767b3ba"
-  integrity sha512-zIx1NIflzkQ6Jw0tzVOba1wkJvZ/uwVHnuOrgK6VGFzsWdM/QUC3h2ALk2RizyxSNAi0UibmftniyfVK3BVf7A==
+h3-js@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-4.1.0.tgz#f8c4a8ad36612489a954f1a0bb3f4b7657d364e5"
+  integrity sha512-LQhmMl1dRQQjMXPzJc7MpZ/CqPOWWuAvVEoVJM9n/s7vHypj+c3Pd5rLQCkAsOgAoAYKbNCsYFE++LF7MvSfCQ==
 
 "h3-jsv3@npm:h3-js@^3.7.1":
   version "3.7.2"
@@ -6262,6 +6262,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
I noticed while going through the H3 documentation working on the cli that the live examples for the `cellToChildPos` and `childPosToCell` don't work because the website is using an out of date version of h3-js. This small PR fixes that (confirmed locally).
