### PR TITLE
Remove "Edge lengths" docs todo

### DIFF
--- a/website/docs/library/restable.md
+++ b/website/docs/library/restable.md
@@ -251,7 +251,3 @@ has notebooks for producing the
 [average cell area table](https://github.com/uber/h3-py-notebooks/blob/master/notebooks/stats_tables/avg_area_table.ipynb)
 and the
 [min/max area table](https://github.com/uber/h3-py-notebooks/blob/master/notebooks/stats_tables/extreme_hex_area.ipynb).
-
-### Edge lengths
-
-todo


### PR DESCRIPTION
The "Edge lengths" section of cell statistics _seems_ done, so I propose removing this "todo".