### PR TITLE
Optimization in getEdgeHexagons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The public API of this library consists of the functions declared in file
 ### Changed
 - Replace internal algorithm for `polygonToCells` with a new version that is more memory-efficient (#785)
 - Reorganize tests into public / internal. (#762)
-- Performance enhancement for aarch64, may improve other platforms (#790, #792, #852, #905)
+- Performance enhancement for aarch64, may improve other platforms (#790, #792, #852, #905, #913)
 - `clang-format` upgraded to version 14. (#834)
 - Fixed tests that incorrectly did not test resolution 15. (#820)
 - Use `CMAKE_INSTALL_LIBDIR` when choosing where to install library files. (#819)

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -837,12 +837,13 @@ H3Error _getEdgeHexagons(const GeoLoop *geoloop, int64_t numHexagons, int res,
         }
         for (int64_t j = 0; j < numHexesEstimate; j++) {
             LatLng interpolate;
+            double invNumHexesEst = 1.0 / numHexesEstimate;
             interpolate.lat =
-                (origin.lat * (numHexesEstimate - j) / numHexesEstimate) +
-                (destination.lat * j / numHexesEstimate);
+                (origin.lat * (numHexesEstimate - j) * invNumHexesEst) +
+                (destination.lat * j * invNumHexesEst);
             interpolate.lng =
-                (origin.lng * (numHexesEstimate - j) / numHexesEstimate) +
-                (destination.lng * j / numHexesEstimate);
+                (origin.lng * (numHexesEstimate - j) * invNumHexesEst) +
+                (destination.lng * j * invNumHexesEst);
             H3Index pointHex;
             H3Error e = H3_EXPORT(latLngToCell)(&interpolate, res, &pointHex);
             if (e) {


### PR DESCRIPTION
Replace 4 fpdiv's with 1 fpdiv and 4 fpmul's. 

I ran `benchmarkPolygonToCellsExperimental` and `benchmarkPolygonToCells` on my Ampere Altra, and here are the results. The Alameda geoloop is doing well at +5.5%.

benchmark | old | new | ratio
-- | -- | -- | --
polygonToCellsSF_Center | 1651.815 | 1644.885 | 1.0042
polygonToCellsSF_Full | 4763.64 | 4729.577 | 1.0072
polygonToCellsSF_Overlapping | 5672.139 | 5646.54 | 1.0045
polygonToCellsAlameda_Center | 3889.226 | 3686.52 | 1.0550
polygonToCellsAlameda_Full | 9900.065 | 9650.448 | 1.0259
polygonToCellsAlameda_Overlapping | 12840.43 | 12585.24 | 1.0203
polygonToCellsSouthernExpansion_Center | 76209.64 | 76028.62 | 1.0024
polygonToCellsSouthernExpansion_Full | 228112.8 | 226663.6 | 1.0064
polygonToCellsSouthernExpansion_Overlapping | 370727.4 | 367403.3 | 1.0090
polygonToCellsSF | 2804.544 | 2803.674 | 1.0003
polygonToCellsAlameda | 4218.331 | 4215.235 | 1.0007
polygonToCellsSouthernExpansion | 125736.6 | 125077.6 | 1.0053


