### PR TITLE
Test on x86 and apple silicon

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   tests:
-    name: Test Compile ${{ matrix.build_type }}
-    runs-on: macos-latest
+    name: ${{ matrix.build_type }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [macos-12, macos-13, macos-latest]
         build_type: ["Debug", "Release"]
 
     steps:


### PR DESCRIPTION
We've seen a bug (https://github.com/uber/h3/issues/917) that appears on Apple Silicon but not x86, so adding to the build matrix to test across both.

Also, I shorten the job name so we can see the OS version in the github actions web UI.

Note, I don't think there's a way to guarantee architecture, but it seems like it is usually correlated with macos version:
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories