### PR TITLE
Update docs to match h3-py v4.x

### DIFF
--- a/website/docs/api/directededge.mdx
+++ b/website/docs/api/directededge.mdx
@@ -13,6 +13,8 @@ edge from one cell to a neighboring cell.
 
 ## areNeighborCells
 
+Determines whether or not the provided H3 cells are neighbors.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -29,6 +31,8 @@ edge from one cell to a neighboring cell.
 ```c
 H3Error areNeighborCells(H3Index origin, H3Index destination, int *out);
 ```
+
+`out` will be 1 if the indexes are neighbors, 0 otherwise.
 
 </TabItem>
 <TabItem value="java">
@@ -83,11 +87,11 @@ true
 </TabItem>
 </Tabs>
 
-Returns whether or not the provided H3 cell indexes are neighbors.
-
-`out` will be 1 if the indexes are neighbors, 0 otherwise.
 
 ## cellsToDirectedEdge
+
+Returns a directed edge H3 index based on the provided origin and
+destination.
 
 <Tabs
   groupId="language"
@@ -105,6 +109,8 @@ Returns whether or not the provided H3 cell indexes are neighbors.
 ```c
 H3Error cellsToDirectedEdge(H3Index origin, H3Index destination, H3Index *out);
 ```
+
+Returns 0 on success.
 
 </TabItem>
 <TabItem value="java">
@@ -159,12 +165,9 @@ $ h3 cellsToDirectedEdge -o 85283473fffffff -d 85283477fffffff
 </TabItem>
 </Tabs>
 
-Returns a unidirectional edge H3 index based on the provided origin and
-destination.
-
-Returns 0 on success.
-
 ## isValidDirectedEdge
+
+Determines if the provided H3Index is a valid unidirectional edge index.
 
 <Tabs
   groupId="language"
@@ -182,6 +185,8 @@ Returns 0 on success.
 ```c
 int isValidDirectedEdge(H3Index edge);
 ```
+
+Returns 1 if it is a unidirectional edge H3Index, otherwise 0.
 
 </TabItem>
 <TabItem value="java">
@@ -234,11 +239,9 @@ true
 </TabItem>
 </Tabs>
 
-Determines if the provided H3Index is a valid unidirectional edge index.
-
-Returns 1 if it is a unidirectional edge H3Index, otherwise 0.
-
 ## getDirectedEdgeOrigin
+
+Returns the origin hexagon from the directed edge H3Index.
 
 <Tabs
   groupId="language"
@@ -308,9 +311,9 @@ $ h3 getDirectedEdgeOrigin -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the origin hexagon from the unidirectional edge H3Index.
-
 ## getDirectedEdgeDestination
+
+Returns the destination hexagon from the directed edge H3Index.
 
 <Tabs
   groupId="language"
@@ -380,9 +383,11 @@ $ h3 getDirectedEdgeDestination -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the destination hexagon from the unidirectional edge H3Index.
+
 
 ## directedEdgeToCells
+
+Returns the origin-destination pair of cells for the given directed edge.
 
 <Tabs
   groupId="language"
@@ -400,6 +405,10 @@ Returns the destination hexagon from the unidirectional edge H3Index.
 ```c
 H3Error directedEdgeToCells(H3Index edge, H3Index* originDestination);
 ```
+
+The origin and destination are placed at
+`originDestination[0]` and `originDestination[1]`, respectively.
+
 
 </TabItem>
 <TabItem value="java">
@@ -452,10 +461,9 @@ $ h3 directedEdgeToCells -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the origin, destination pair of hexagon IDs for the given edge ID, which are placed at `originDestination[0]` and
-`originDestination[1]` respectively.
-
 ## originToDirectedEdges
+
+Provides all of the directed edges from the current cell.
 
 <Tabs
   groupId="language"
@@ -473,6 +481,10 @@ Returns the origin, destination pair of hexagon IDs for the given edge ID, which
 ```c
 H3Error originToDirectedEdges(H3Index origin, H3Index* edges);
 ```
+
+`edges` must be of length 6,
+and the number of directed edges placed in the array may be less than 6.
+If this is the case, one of the members of the array will be `0`.
 
 </TabItem>
 <TabItem value="java">
@@ -525,11 +537,11 @@ $ h3 originToDirectedEdges -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Provides all of the directed edges from the current H3Index. `edges` must be of length 6,
-and the number of directed edges placed in the array may be less than 6. If this is the case,
-one of the members of the array will be `0`.
 
 ## directedEdgeToBoundary
+
+Provides the geographic lat/lng coordinates defining the directed edge.
+Note that this may be more than two points for complex edges.
 
 <Tabs
   groupId="language"
@@ -574,7 +586,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.directed_edge_to_boundary(edge, geo_json=False)
+h3.directed_edge_to_boundary(edge)
 ```
 
 </TabItem>
@@ -598,5 +610,3 @@ $ h3 directedEdgeToBoundary -c 115283473fffffff
 
 </TabItem>
 </Tabs>
-
-Provides the coordinates defining the unidirectional edge.

--- a/website/docs/api/directededge.mdx
+++ b/website/docs/api/directededge.mdx
@@ -416,7 +416,6 @@ The origin and destination are placed at
 
 Returns 0 (`E_SUCCESS`) on success.
 
-
 </TabItem>
 <TabItem value="java">
 

--- a/website/docs/api/directededge.mdx
+++ b/website/docs/api/directededge.mdx
@@ -34,6 +34,8 @@ H3Error areNeighborCells(H3Index origin, H3Index destination, int *out);
 
 `out` will be 1 if the indexes are neighbors, 0 otherwise.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -90,7 +92,7 @@ true
 
 ## cellsToDirectedEdge
 
-Returns a directed edge H3 index based on the provided origin and
+Provides a directed edge H3 index based on the provided origin and
 destination.
 
 <Tabs
@@ -110,7 +112,7 @@ destination.
 H3Error cellsToDirectedEdge(H3Index origin, H3Index destination, H3Index *out);
 ```
 
-Returns 0 on success.
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -186,7 +188,7 @@ Determines if the provided H3Index is a valid unidirectional edge index.
 int isValidDirectedEdge(H3Index edge);
 ```
 
-Returns 1 if it is a unidirectional edge H3Index, otherwise 0.
+Returns `1` if it is a unidirectional edge H3Index, otherwise `0`.
 
 </TabItem>
 <TabItem value="java">
@@ -241,7 +243,7 @@ true
 
 ## getDirectedEdgeOrigin
 
-Returns the origin hexagon from the directed edge H3Index.
+Provides the origin hexagon from the directed edge H3Index.
 
 <Tabs
   groupId="language"
@@ -259,6 +261,8 @@ Returns the origin hexagon from the directed edge H3Index.
 ```c
 H3Error getDirectedEdgeOrigin(H3Index edge, H3Index *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -313,7 +317,7 @@ $ h3 getDirectedEdgeOrigin -c 115283473fffffff
 
 ## getDirectedEdgeDestination
 
-Returns the destination hexagon from the directed edge H3Index.
+Provides the destination hexagon from the directed edge H3Index.
 
 <Tabs
   groupId="language"
@@ -331,6 +335,8 @@ Returns the destination hexagon from the directed edge H3Index.
 ```c
 H3Error getDirectedEdgeDestination(H3Index edge, H3Index *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -384,10 +390,9 @@ $ h3 getDirectedEdgeDestination -c 115283473fffffff
 </Tabs>
 
 
-
 ## directedEdgeToCells
 
-Returns the origin-destination pair of cells for the given directed edge.
+Provides the origin-destination pair of cells for the given directed edge.
 
 <Tabs
   groupId="language"
@@ -408,6 +413,8 @@ H3Error directedEdgeToCells(H3Index edge, H3Index* originDestination);
 
 The origin and destination are placed at
 `originDestination[0]` and `originDestination[1]`, respectively.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 
 </TabItem>
@@ -486,6 +493,8 @@ H3Error originToDirectedEdges(H3Index origin, H3Index* edges);
 and the number of directed edges placed in the array may be less than 6.
 If this is the case, one of the members of the array will be `0`.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -559,6 +568,8 @@ Note that this may be more than two points for complex edges.
 ```c
 H3Error directedEdgeToBoundary(H3Index edge, CellBoundary* gb);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -493,9 +493,9 @@ $ h3 childPosToCell -p 42 -c 85283473fffffff -r 7
 
 ## compactCells
 
-Compacts the set `cellSet` of indexes as best as possible, into the array `compactedSet`.
-`compactedSet` must be at least the size of `cellSet` in case the set cannot be compacted.
-Cells in `cellSet` must all share the same resolution.
+Compacts a collection of H3 cells by recursively replacing children cells
+with their parents if all children are present.
+Input cells must all share the same resolution.
 
 <Tabs
   groupId="language"
@@ -513,6 +513,9 @@ Cells in `cellSet` must all share the same resolution.
 ```c
 H3Error compactCells(const H3Index *cellSet, H3Index *compactedSet, const int64_t numCells);
 ```
+
+Compacts `cellSet` into the array `compactedSet`.
+`compactedSet` must be at least the size of `cellSet` (in case the set cannot be compacted).
 
 Returns 0 (`E_SUCCESS`) on success.
 

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -335,7 +335,7 @@ $ h3 cellToCenterChild -c 85283473fffffff -r 7
 
 ## cellToChildPos
 
-Returns the position of the child cell within an ordered list of all children of the cell's parent at the specified resolution `parentRes`.
+Provides the position of the child cell within an ordered list of all children of the cell's parent at the specified resolution `parentRes`.
 The order of the ordered list is the same as that returned by `cellToChildren`.
 This is the complement of `childPosToCell`.
 
@@ -353,7 +353,7 @@ This is the complement of `childPosToCell`.
 <TabItem value="c">
 
 ```c
-H3Index cellToChildPos(H3Index child, int parentRes, int64_t *out);
+H3Error cellToChildPos(H3Index child, int parentRes, int64_t *out);
 ```
 
 Returns 0 (`E_SUCCESS`) on success.
@@ -412,7 +412,7 @@ $ h3 cellToChildPos -c 85283473fffffff -r 3
 
 ## childPosToCell
 
-Returns the child cell at a given position within an ordered list of all children of `parent` at the specified resolution `childRes`.
+Provides the child cell at a given position within an ordered list of all children of `parent` at the specified resolution `childRes`.
 The order of the ordered list is the same as that returned by `cellToChildren`.
 This is the complement of `cellToChildPos`.
 
@@ -430,7 +430,7 @@ This is the complement of `cellToChildPos`.
 <TabItem value="c">
 
 ```c
-H3Index childPosToCell(int64_t childPos, H3Index parent, int childRes, H3Index *child);
+H3Error childPosToCell(int64_t childPos, H3Index parent, int childRes, H3Index *child);
 ```
 
 Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -670,6 +670,7 @@ H3Error uncompactCellsSize(const H3Index *compactedSet, const int64_t numCompact
 ```
 
 Provides the size of the array needed by `uncompactCells` into `out`.
+
 Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -12,6 +12,11 @@ These functions permit moving between resolutions in the H3 grid system. The fun
 
 ## cellToParent
 
+Provides the unique ancestor (coarser) cell of the given `cell` for
+the provided resolution. If the input cell has resolution `r`, then
+`parentRes = r - 1` would give the immediate parent,
+`parentRes = r - 2` would give the grandparent, and so on.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -28,6 +33,8 @@ These functions permit moving between resolutions in the H3 grid system. The fun
 ```c
 H3Error cellToParent(H3Index cell, int parentRes, H3Index *parent);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -55,8 +62,11 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cell_to_parent(cell, parent_res)
+h3.cell_to_parent(h, res=None)
 ```
+
+If `res = None`, we set `res = resolution(h) - 1`.
+See the [h3-py docs](https://uber.github.io/h3-py/api_verbose.html#h3.cell_to_parent).
 
 </TabItem>
 <TabItem value="shell">
@@ -81,11 +91,12 @@ $ h3 cellToParent -c 85283473fffffff -r 4
 </TabItem>
 </Tabs>
 
-Provides the parent (coarser) index containing `cell`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToChildren
+
+Provides the children (descendant) cells of `cell` at
+resolution `childRes`.
+
 
 <Tabs
   groupId="language"
@@ -103,6 +114,9 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error cellToChildren(H3Index cell, int childRes, H3Index *children);
 ```
+
+`children` must be an array of at least size `cellToChildrenSize(cell, childRes)`.
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -130,8 +144,11 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cell_to_children(cell, child_res)
+h3.cell_to_children(h, res=None)
 ```
+
+If `res = None`, we set `res = resolution(h) + 1`.
+See the [h3-py docs](https://uber.github.io/h3-py/api_verbose.html#h3.cell_to_children).
 
 </TabItem>
 <TabItem value="shell">
@@ -156,11 +173,10 @@ $ h3 cellToChildren -c 85283473fffffff -r 6
 </TabItem>
 </Tabs>
 
-Populates `children` with the indexes contained by `cell` at resolution `childRes`. `children` must be an array of at least size `cellToChildrenSize(cell, childRes)`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToChildrenSize
+
+Provides the number of children at a given resolution of the given cell.
 
 <Tabs
   groupId="language"
@@ -178,6 +194,9 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error cellToChildrenSize(H3Index cell, int childRes, int64_t *out);
 ```
+
+Provides the size of the `children` array needed for the given inputs to `cellToChildren`.
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -200,11 +219,14 @@ This function exists for memory management and is not exposed.
 </TabItem>
 <TabItem value="python">
 
-:::note
 
-This function exists for memory management and is not exposed.
+```py
+h3.cell_to_children_size(h, res=None)
+```
 
-:::
+If `res = None`, we set `res = resolution(h) + 1`.
+See the [h3-py docs](https://uber.github.io/h3-py/api_verbose.html#h3.cell_to_children_size).
+
 
 </TabItem>
 <TabItem value="shell">
@@ -228,11 +250,10 @@ $ h3 cellToChildrenSize -c 85283473fffffff -r 6
 </TabItem>
 </Tabs>
 
-Provides the size of the `children` array needed for the given inputs to `cellToChildren`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToCenterChild
+
+Provides the center child (finer) cell contained by `cell` at resolution `childRes`.
 
 <Tabs
   groupId="language"
@@ -250,6 +271,9 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error cellToCenterChild(H3Index cell, int childRes, H3Index *child);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
+
 
 </TabItem>
 <TabItem value="java">
@@ -277,8 +301,11 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cell_to_center_child(cell, child_res)
+h3.cell_to_center_child(h, res=None)
 ```
+
+If `res = None`, we set `res = resolution(h) + 1`.
+See the [h3-py docs](https://uber.github.io/h3-py/api_verbose.html#h3.cell_to_center_child).
 
 </TabItem>
 <TabItem value="shell">
@@ -303,11 +330,12 @@ $ h3 cellToCenterChild -c 85283473fffffff -r 7
 </TabItem>
 </Tabs>
 
-Provides the center child (finer) index contained by `cell` at resolution `childRes`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToChildPos
+
+Returns the position of the child cell within an ordered list of all children of the cell's parent at the specified resolution `parentRes`.
+The order of the ordered list is the same as that returned by `cellToChildren`.
+This is the complement of `childPosToCell`.
 
 <Tabs
   groupId="language"
@@ -325,6 +353,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Index cellToChildPos(H3Index child, int parentRes, int64_t *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -352,7 +382,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cell_to_child_pos(child, parent_res)
+h3.cell_to_child_pos(child, res_parent)
 ```
 
 </TabItem>
@@ -377,11 +407,12 @@ $ h3 cellToChildPos -c 85283473fffffff -r 3
 </TabItem>
 </Tabs>
 
-Returns the position of the child cell within an ordered list of all children of the cell's parent at the specified resolution `parentRes`. The order of the ordered list is the same as that returned by `cellToChildren`. This is the complement of `childPosToCell`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## childPosToCell
+
+Returns the child cell at a given position within an ordered list of all children of `parent` at the specified resolution `childRes`.
+The order of the ordered list is the same as that returned by `cellToChildren`.
+This is the complement of `cellToChildPos`.
 
 <Tabs
   groupId="language"
@@ -399,6 +430,9 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Index childPosToCell(int64_t childPos, H3Index parent, int childRes, H3Index *child);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
+
 
 </TabItem>
 <TabItem value="java">
@@ -427,7 +461,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.child_pos_to_cell(child_pos, parent, child_res)
+h3.child_pos_to_cell(parent, res_child, child_pos)
 ```
 
 </TabItem>
@@ -454,11 +488,12 @@ $ h3 childPosToCell -p 42 -c 85283473fffffff -r 7
 </TabItem>
 </Tabs>
 
-Returns the child cell at a given position within an ordered list of all children of `parent` at the specified resolution `childRes`. The order of the ordered list is the same as that returned by `cellToChildren`. This is the complement of `cellToChildPos`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## compactCells
+
+Compacts the set `cellSet` of indexes as best as possible, into the array `compactedSet`.
+`compactedSet` must be at least the size of `cellSet` in case the set cannot be compacted.
+Cells in `cellSet` must all share the same resolution.
 
 <Tabs
   groupId="language"
@@ -476,6 +511,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error compactCells(const H3Index *cellSet, H3Index *compactedSet, const int64_t numCells);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -530,11 +567,10 @@ $ h3 compactCells -c 85283473fffffff,85283447fffffff,8528347bfffffff,85283463fff
 </TabItem>
 </Tabs>
 
-Compacts the set `cellSet` of indexes as best as possible, into the array `compactedSet`. `compactedSet` must be at least the size of `cellSet` in case the set cannot be compacted. Cells in `cellSet` must all share the same resolution.
-
-Returns 0 (`E_SUCCESS`) on success.
-
 ## uncompactCells
+
+Uncompacts the set `compactedSet` of indexes to the resolution `res`.
+`h3Set` must be at least of size `uncompactCellsSize(compactedSet, numHexes, res)`.
 
 <Tabs
   groupId="language"
@@ -552,6 +588,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error uncompactCells(const H3Index *compactedSet, const int64_t numCells, H3Index *cellSet, const int64_t maxCells, const int res);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -608,11 +646,11 @@ $ h3 uncompactCells -r 5 -c 85283447fffffff,8528340ffffffff,8528340bfffffff,8528
 </TabItem>
 </Tabs>
 
-Uncompacts the set `compactedSet` of indexes to the resolution `res`. `h3Set` must be at least of size `uncompactCellsSize(compactedSet, numHexes, res)`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## uncompactCellsSize
+
+Provides the total resulting number of cells if uncompacting a cell set to
+a given resolution.
 
 <Tabs
   groupId="language"
@@ -630,6 +668,9 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error uncompactCellsSize(const H3Index *compactedSet, const int64_t numCompacted, const int res, int64_t *out);
 ```
+
+Provides the size of the array needed by `uncompactCells` into `out`.
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -669,7 +710,3 @@ This function exists for memory management and is not exposed.
 
 </TabItem>
 </Tabs>
-
-Places the size of the array needed by `uncompactCells` into `out`.
-
-Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -8,7 +8,8 @@ slug: /api/hierarchy
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-These functions permit moving between resolutions in the H3 grid system. The functions produce parent cells (coarser), or child cells (finer).
+These functions permit moving between resolutions in the H3 grid system.
+The functions produce parent cells (coarser), or child cells (finer).
 
 ## cellToParent
 

--- a/website/docs/api/hierarchy.mdx
+++ b/website/docs/api/hierarchy.mdx
@@ -97,7 +97,6 @@ $ h3 cellToParent -c 85283473fffffff -r 4
 Provides the children (descendant) cells of `cell` at
 resolution `childRes`.
 
-
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -116,6 +115,7 @@ H3Error cellToChildren(H3Index cell, int childRes, H3Index *children);
 ```
 
 `children` must be an array of at least size `cellToChildrenSize(cell, childRes)`.
+
 Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
@@ -196,6 +196,7 @@ H3Error cellToChildrenSize(H3Index cell, int childRes, int64_t *out);
 ```
 
 Provides the size of the `children` array needed for the given inputs to `cellToChildren`.
+
 Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -16,8 +16,8 @@ and for finding the center and boundary of H3 cells.
 Indexes the location at the specified resolution,
 providing the index of the cell containing the location.
 This buckets the geographic point into the H3 grid.
-See the [algorithm description](../core-library/latLngToCellDesc)
-for more information.
+For more information, see the
+[algorithm description](../core-library/latLngToCellDesc).
 
 <Tabs
   groupId="language"
@@ -177,10 +177,9 @@ $ h3 cellToLatLng -c 85283473fffffff
 
 ## cellToBoundary
 
-Finds the boundary of the cell. See the
-[algorithm description](../core-library/cellToBoundaryDesc)
-for more information.
-
+Finds the boundary of the cell.
+For more information, see the
+[algorithm description](../core-library/cellToBoundaryDesc).
 
 <Tabs
   groupId="language"

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -8,12 +8,16 @@ slug: /api/indexing
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-These functions are used for finding the H3 cell index containing coordinates, and for finding the center and boundary of H3 indexes.
+These functions are used for finding the H3 cell index containing coordinates,
+and for finding the center and boundary of H3 cells.
 
 ## latLngToCell
 
-Indexes the location at the specified resolution, providing the index of the cell containing the location. This buckets
-the geographic point into the H3 grid. See the [algorithm description](../core-library/latLngToCellDesc) for more information.
+Indexes the location at the specified resolution,
+providing the index of the cell containing the location.
+This buckets the geographic point into the H3 grid.
+See the [algorithm description](../core-library/latLngToCellDesc)
+for more information.
 
 <Tabs
   groupId="language"
@@ -227,7 +231,8 @@ h3.cell_to_boundary(cell)
 ```
 
 Returns tuple of lat/lng tuples.
-For GeoJSON compatibility (lng/lat order), see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
+For GeoJSON compatibility (lng/lat order), see the
+[`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
 
 </TabItem>
 <TabItem value="shell">

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -173,6 +173,11 @@ $ h3 cellToLatLng -c 85283473fffffff
 
 ## cellToBoundary
 
+Finds the boundary of the cell. See the
+[algorithm description](../core-library/cellToBoundaryDesc)
+for more information.
+
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -189,6 +194,8 @@ $ h3 cellToLatLng -c 85283473fffffff
 ```c
 H3Error cellToBoundary(H3Index cell, CellBoundary *bndry);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -216,8 +223,10 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cell_to_boundary(cell, geo_json=False)
+h3.cell_to_boundary(cell)
 ```
+
+Returns tuple of lat/lng tuples.
 
 </TabItem>
 <TabItem value="shell">
@@ -240,10 +249,3 @@ $ h3 cellToBoundary -c 85283473fffffff
 
 </TabItem>
 </Tabs>
-
-Finds the boundary of the cell. See the
-[algorithm description](../core-library/cellToBoundaryDesc)
-for more information.
-
-
-Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -227,7 +227,7 @@ h3.cell_to_boundary(cell)
 ```
 
 Returns tuple of lat/lng tuples.
-For GeoJSON compatibility, see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
+For GeoJSON compatibility (lng/lat order), see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
 
 </TabItem>
 <TabItem value="shell">

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -227,6 +227,7 @@ h3.cell_to_boundary(cell)
 ```
 
 Returns tuple of lat/lng tuples.
+For GeoJSON compatibility, see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
 
 </TabItem>
 <TabItem value="shell">

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -12,6 +12,9 @@ These functions are used for finding the H3 cell index containing coordinates, a
 
 ## latLngToCell
 
+Indexes the location at the specified resolution, providing the index of the cell containing the location. This buckets
+the geographic point into the H3 grid. See the [algorithm description](../core-library/latLngToCellDesc) for more information.
+
 <Tabs
   groupId="language"
   defaultValue="c"

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -32,6 +32,8 @@ the geographic point into the H3 grid. See the [algorithm description](../core-l
 H3Error latLngToCell(const LatLng *g, int res, H3Index *out);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -87,12 +89,21 @@ $ h3 latLngToCell --lat 45 --lng 40 -r 2
 </TabItem>
 </Tabs>
 
-Indexes the location at the specified resolution, returning the index of the cell containing the location. This buckets
-the geographic point into the H3 grid. See the [algorithm description](../core-library/latLngToCellDesc) for more information.
-
-Returns 0 (`E_SUCCESS`) on success.
-
 ## cellToLatLng
+
+Finds the center of the cell in grid space. See the
+[algorithm description](../core-library/cellToLatLngDesc) for
+more information.
+
+
+Note that H3 makes a distinction between the **center**
+and **centroid** of a cell.
+The two will differ on the surface of
+the Earth based on:
+
+- the distortion from the gnomonic projection
+within the icosahedron face it resides on, and
+- its distance from the center of the icosahedron face.
 
 <Tabs
   groupId="language"
@@ -110,6 +121,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error cellToLatLng(H3Index cell, LatLng *g);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -162,16 +175,6 @@ $ h3 cellToLatLng -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Finds the center of the cell in grid space. See the
-[algorithm description](../core-library/cellToLatLngDesc) for
-more information.
-
-The center will drift versus the centroid
-of the cell on Earth due to distortion from the gnomonic
-projection within the icosahedron face it resides on and its
-distance from the center of the icosahedron face.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellToBoundary
 

--- a/website/docs/api/indexing.mdx
+++ b/website/docs/api/indexing.mdx
@@ -95,15 +95,10 @@ Finds the center of the cell in grid space. See the
 [algorithm description](../core-library/cellToLatLngDesc) for
 more information.
 
-
-Note that H3 makes a distinction between the **center**
-and **centroid** of a cell.
-The two will differ on the surface of
-the Earth based on:
-
-- the distortion from the gnomonic projection
-within the icosahedron face it resides on, and
-- its distance from the center of the icosahedron face.
+The center will drift versus the centroid
+of the cell on Earth due to distortion from the gnomonic
+projection within the icosahedron face it resides on and its
+distance from the center of the icosahedron face.
 
 <Tabs
   groupId="language"

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -12,6 +12,9 @@ These functions provide metadata about an H3 index, such as its resolution or ba
 
 ## getResolution
 
+Returns the resolution of the index.
+(Works for cells, edges, and vertexes.)
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -79,9 +82,11 @@ $ h3 getResolution -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the resolution of the index.
 
 ## getBaseCellNumber
+
+Returns the base cell number of the index.
+(Works for cells, edges, and vertexes.)
 
 <Tabs
   groupId="language"
@@ -150,9 +155,9 @@ $ h3 getBaseCellNumber -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the base cell number of the index.
-
 ## stringToH3
+
+Converts the string representation to `H3Index` (`uint64_t`) representation.
 
 <Tabs
   groupId="language"
@@ -171,6 +176,8 @@ Returns the base cell number of the index.
 H3Error stringToH3(const char *str, H3Index *out);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -181,7 +188,11 @@ long stringToH3(String h3Address);
 </TabItem>
 <TabItem value="javascript">
 
+:::note
+
 The H3 JavaScript binding supports only the string representation of an H3 index.
+
+:::
 
 </TabItem>
 <TabItem value="python">
@@ -193,16 +204,20 @@ h3.string_to_h3(h)
 </TabItem>
 <TabItem value="shell">
 
+:::note
+
 The H3 CLI supports only the string representation of an H3 index.
+
+:::
+
 
 </TabItem>
 </Tabs>
 
-Converts the string representation to `H3Index` (`uint64_t`) representation.
-
-Returns 0 (`E_SUCCESS`) on success.
-
 ## h3ToString
+
+Converts the `H3Index` representation of the index to the string representation. `str` must be at least of length 17.
+
 
 <Tabs
   groupId="language"
@@ -221,12 +236,23 @@ Returns 0 (`E_SUCCESS`) on success.
 H3Error h3ToString(H3Index h, char *str, size_t sz);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
 ```java
 String h3ToString(long h3);
 ```
+
+</TabItem>
+<TabItem value="javascript">
+
+:::note
+
+The H3 JavaScript binding supports only the string representation of an H3 index.
+
+:::
 
 </TabItem>
 <TabItem value="python">
@@ -238,16 +264,20 @@ h3.h3_to_string(h)
 </TabItem>
 <TabItem value="shell">
 
+:::note
+
 The H3 CLI supports only the string representation of an H3 index.
+
+:::
 
 </TabItem>
 </Tabs>
 
-Converts the `H3Index` representation of the index to the string representation. `str` must be at least of length 17.
 
-Returns 0 (`E_SUCCESS`) on success.
 
 ## isValidCell
+
+Returns non-zero if this is a valid H3 cell index.
 
 <Tabs
   groupId="language"
@@ -317,9 +347,10 @@ true
 </TabItem>
 </Tabs>
 
-Returns non-zero if this is a valid H3 cell index.
 
 ## isResClassIII
+
+Returns non-zero if this index has a resolution with Class III orientation.
 
 <Tabs
   groupId="language"
@@ -389,9 +420,10 @@ true
 </TabItem>
 </Tabs>
 
-Returns non-zero if this index has a resolution with Class III orientation.
 
 ## isPentagon
+
+Returns non-zero if this index represents a pentagonal cell.
 
 <Tabs
   groupId="language"
@@ -461,9 +493,11 @@ false
 </TabItem>
 </Tabs>
 
-Returns non-zero if this index represents a pentagonal cell.
 
 ## getIcosahedronFaces
+
+Find all icosahedron faces intersected by a given H3 cell.
+Faces are represented as integers from 0-19, inclusive.
 
 <Tabs
   groupId="language"
@@ -481,6 +515,11 @@ Returns non-zero if this index represents a pentagonal cell.
 ```c
 H3Error getIcosahedronFaces(H3Index h, int* out);
 ```
+
+Face values and places them in the array `out`. `out` must be at least length of `maxFaceCount(h)`.
+The array is sparse, and empty (no intersection) array values are represented by -1.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -532,13 +571,9 @@ $ h3 getIcosahedronFaces -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Find all icosahedron faces intersected by a given H3 index and places them in the array `out`. `out` must be at least length of `maxFaceCount(h)`.
-
-Faces are represented as integers from 0-19, inclusive. The array is sparse, and empty (no intersection) array values are represented by -1.
-
-Returns 0 (`E_SUCCESS`) on success.
-
 ## maxFaceCount
+
+Returns the maximum number of icosahedron faces the given H3 index may intersect.
 
 <Tabs
   groupId="language"
@@ -556,6 +591,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error maxFaceCount(H3Index h3, int *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -595,5 +632,3 @@ This function exists for memory management and is not exposed.
 
 </TabItem>
 </Tabs>
-
-Returns the maximum number of icosahedron faces the given H3 index may intersect.

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -216,7 +216,8 @@ The H3 CLI supports only the string representation of an H3 index.
 
 ## h3ToString
 
-Converts the `H3Index` representation of the index to the string representation. `str` must be at least of length 17.
+Converts the `H3Index` representation of the index to the string representation.
+`str` must be at least of length 17.
 
 
 <Tabs
@@ -516,7 +517,8 @@ Faces are represented as integers from 0-19, inclusive.
 H3Error getIcosahedronFaces(H3Index h, int* out);
 ```
 
-Face values and places them in the array `out`. `out` must be at least length of `maxFaceCount(h)`.
+Face values and places them in the array `out`.
+`out` must be at least length of `maxFaceCount(h)`.
 The array is sparse, and empty (no intersection) array values are represented by -1.
 
 Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -516,7 +516,7 @@ Faces are represented as integers from 0-19, inclusive.
 H3Error getIcosahedronFaces(H3Index h, int* out);
 ```
 
-Face values and places them in the array `out`.
+Face values are placed in the array `out`.
 `out` must be at least length of `maxFaceCount(h)`.
 The array is sparse, and empty (no intersection) array values are represented by -1.
 

--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -217,8 +217,6 @@ The H3 CLI supports only the string representation of an H3 index.
 ## h3ToString
 
 Converts the `H3Index` representation of the index to the string representation.
-`str` must be at least of length 17.
-
 
 <Tabs
   groupId="language"
@@ -237,6 +235,7 @@ Converts the `H3Index` representation of the index to the string representation.
 H3Error h3ToString(H3Index h, char *str, size_t sz);
 ```
 
+`str` must be at least of length 17.
 Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>

--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -12,6 +12,8 @@ These functions include descriptions of the H3 grid system.
 
 ## degsToRads
 
+Converts degrees to radians.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -82,9 +84,9 @@ $ h3 degsToRads -d 180
 </TabItem>
 </Tabs>
 
-Converts degrees to radians.
-
 ## radsToDegs
+
+Converts radians to degrees.
 
 <Tabs
   groupId="language"
@@ -156,9 +158,10 @@ $ h3 radsToDegs -r 1
 </TabItem>
 </Tabs>
 
-Converts radians to degrees.
-
 ## getHexagonAreaAvgKm2
+
+Average hexagon area in square kilometers at the given resolution.
+Excludes pentagons.
 
 <Tabs
   groupId="language"
@@ -226,9 +229,10 @@ $ h3 getHexagonAreaAvgKm2 -r 1
 </TabItem>
 </Tabs>
 
-Average hexagon area in square kilometers at the given resolution. Excludes pentagons.
-
 ## getHexagonAreaAvgM2
+
+Average hexagon area in square meters at the given resolution.
+Excludes pentagons.
 
 <Tabs
   groupId="language"
@@ -296,11 +300,10 @@ $ h3 getHexagonAreaAvgM2 -r 5
 </TabItem>
 </Tabs>
 
-Average hexagon area in square meters at the given resolution. Excludes pentagons.
-
-
 
 ## cellAreaRads2
+
+Exact area of specific cell in square radians.
 
 <Tabs
   groupId="language"
@@ -369,9 +372,9 @@ $ h3 cellAreaRads2 -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Exact area of specific cell in square radians.
-
 ## cellAreaKm2
+
+Exact area of specific cell in square kilometers.
 
 <Tabs
   groupId="language"
@@ -440,9 +443,9 @@ $ h3 cellAreaKm2 -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Exact area of specific cell in square kilometers.
-
 ## cellAreaM2
+
+Exact area of specific cell in square meters.
 
 <Tabs
   groupId="language"
@@ -511,9 +514,10 @@ $ h3 cellAreaM2 -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Exact area of specific cell in square meters.
-
 ## getHexagonEdgeLengthAvgKm
+
+Average hexagon edge length in kilometers at the given resolution.
+Excludes pentagons.
 
 <Tabs
   groupId="language"
@@ -581,9 +585,11 @@ $ h3 getHexagonEdgeLengthAvgKm -r 5
 </TabItem>
 </Tabs>
 
-Average hexagon edge length in kilometers at the given resolution. Excludes pentagons.
 
 ## getHexagonEdgeLengthAvgM
+
+Average hexagon edge length in meters at the given resolution.
+Excludes pentagons.
 
 <Tabs
   groupId="language"
@@ -651,10 +657,10 @@ $ h3 getHexagonEdgeLengthAvgM -r 5
 </TabItem>
 </Tabs>
 
-Average hexagon edge length in meters at the given resolution. Excludes pentagons.
-
 
 ## edgeLengthKm
+
+Exact edge length of specific unidirectional edge in kilometers.
 
 <Tabs
   groupId="language"
@@ -723,9 +729,10 @@ $ h3 edgeLengthKm -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Exact edge length of specific unidirectional edge in kilometers.
 
 ## edgeLengthM
+
+Exact edge length of specific unidirectional edge in meters.
 
 <Tabs
   groupId="language"
@@ -794,9 +801,10 @@ $ h3 edgeLengthM -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Exact edge length of specific unidirectional edge in meters.
 
 ## edgeLengthRads
+
+Exact edge length of specific unidirectional edge in radians.
 
 <Tabs
   groupId="language"
@@ -865,9 +873,10 @@ $ h3 edgeLengthRads -c 115283473fffffff
 </TabItem>
 </Tabs>
 
-Exact edge length of specific unidirectional edge in radians.
 
 ## getNumCells
+
+Number of unique H3 indexes at the given resolution.
 
 <Tabs
   groupId="language"
@@ -935,9 +944,13 @@ $ h3 getNumCells -r 5
 </TabItem>
 </Tabs>
 
-Number of unique H3 indexes at the given resolution.
 
 ## getRes0Cells
+
+Provide all the resolution `0` H3 cells.
+These are the coarsest cells that can be represented in the H3 system and are
+the parents/ancestors of all other cells in the H3 grid system.
+The returned cells correspond to the 122 base cells.
 
 <Tabs
   groupId="language"
@@ -955,6 +968,8 @@ Number of unique H3 indexes at the given resolution.
 ```c
 H3Error getRes0Cells(H3Index *out);
 ```
+
+`out` must be an array of at least size `res0CellCount()`.
 
 </TabItem>
 <TabItem value="java">
@@ -1004,12 +1019,10 @@ $ h3 getRes0Cells
 </TabItem>
 </Tabs>
 
-All the resolution `0` H3 cell indexes. These are the coarsest cells that can be represented in the H3 system and are the 
-parents of all other cell indexes in the H3 grid system. The returned indexes correspond with the 122 base cells.
-
-`out` must be an array of at least size `res0CellCount()`.
 
 ## res0CellCount
+
+Number of resolution `0` H3 indexes, which is defined as 122.
 
 <Tabs
   groupId="language"
@@ -1067,9 +1080,11 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Number of resolution `0` H3 indexes, which is defined as 122.
 
 ## getPentagons
+
+All the pentagon H3 cells at the specified resolution.
+There are 12 pentagons at each resolution.
 
 <Tabs
   groupId="language"
@@ -1087,6 +1102,10 @@ Number of resolution `0` H3 indexes, which is defined as 122.
 ```c
 H3Error getPentagons(int res, H3Index *out);
 ```
+
+`out` must be an array of at least size `pentagonIndexCount()`.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -1139,12 +1158,10 @@ $ h3 getPentagons -r 5
 </TabItem>
 </Tabs>
 
-All the pentagon H3 indexes at the specified resolution.
-`out` must be an array of at least size `pentagonIndexCount()`.
-
-Returns 0 (`E_SUCCESS`) on success.
-
 ## pentagonCount
+
+Number of pentagon H3 cells per resolution.
+This is always 12, but provided as a convenience.
 
 <Tabs
   groupId="language"
@@ -1210,9 +1227,11 @@ $ h3 pentagonCount
 </TabItem>
 </Tabs>
 
-Number of pentagon H3 indexes per resolution. This is always 12, but provided as a convenience.
 
 ## greatCircleDistanceKm
+
+Gives the "great circle" or "haversine" distance between pairs of
+LatLng points (lat/lng pairs) in kilometers.
 
 <Tabs
   groupId="language"
@@ -1282,10 +1301,10 @@ $ h3 greatCircleDistanceKm -c "[[-10, 0], [10, 0]]"
 </TabItem>
 </Tabs>
 
-Gives the "great circle" or "haversine" distance between pairs of
-LatLng points (lat/lng pairs) in kilometers.
-
 ## greatCircleDistanceM
+
+Gives the "great circle" or "haversine" distance between pairs of
+LatLng points (lat/lng pairs) in meters.
 
 <Tabs
   groupId="language"
@@ -1355,10 +1374,11 @@ $ h3 greatCircleDistanceM -c "[[-10, 0], [10, 0]]"
 </TabItem>
 </Tabs>
 
-Gives the "great circle" or "haversine" distance between pairs of
-LatLng points (lat/lng pairs) in meters.
 
 ## greatCircleDistanceRads
+
+Gives the "great circle" or "haversine" distance between pairs of
+LatLng points (lat/lng pairs) in radians.
 
 <Tabs
   groupId="language"
@@ -1428,10 +1448,10 @@ $ h3 greatCircleDistanceRads -c "[[-10, 0], [10, 0]]"
 </TabItem>
 </Tabs>
 
-Gives the "great circle" or "haversine" distance between pairs of
-LatLng points (lat/lng pairs) in radians.
 
-## describeH3Error 
+## describeH3Error
+
+Provides a human-readable description of an H3Error error code.
 
 <Tabs
   groupId="language"
@@ -1447,6 +1467,10 @@ LatLng points (lat/lng pairs) in radians.
 ```c
 char *describeH3Error(H3Error err);
 ```
+
+This function cannot fail, as it just returns a string stating that the
+H3Error value is itself invalid and does not allocate memory to do so.
+Do not call `free` on the result of this function.
 
 </TabItem>
 <TabItem value="javascript">
@@ -1489,5 +1513,3 @@ Cell argument was not valid
 
 </TabItem>
 </Tabs>
-
-Provides a human-readable description of an H3Error error code. This function cannot fail, as it just returns a string stating that the H3Error value is itself invalid and does not allocate memory to do so. Do not call `free` on the result of this function.

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -108,7 +108,10 @@ $ h3 polygonToCells -r 7 -p "[[37.813318999983238, -122.4089866999972145], [37.7
 </Tabs>
 
 
-### maxPolygonToCellsSize
+## maxPolygonToCellsSize
+
+Provides an upper bound on the number of cells needed for memory allocation
+purposes when computing `polygonToCells` on the given GeoJSON-like data structure.
 
 <Tabs
   groupId="language"
@@ -127,12 +130,14 @@ $ h3 polygonToCells -r 7 -p "[[37.813318999983238, -122.4089866999972145], [37.7
 H3Error maxPolygonToCellsSize(const GeoPolygon *geoPolygon, int res, uint32_t flags, int64_t *out);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in Java.
 
 :::
 
@@ -141,7 +146,7 @@ This function exists for memory management and is not exposed.
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in JavaScript.
 
 :::
 
@@ -150,7 +155,7 @@ This function exists for memory management and is not exposed.
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in Python.
 
 :::
 
@@ -177,12 +182,17 @@ $ h3 maxPolygonToCellsSize -r 7 -p "[[37.813318999983238, -122.4089866999972145]
 </TabItem>
 </Tabs>
 
-maxPolygonToCellsSize returns the number of hexagons to allocate space for when
-computing `polygonToCells` on the given GeoJSON-like data structure.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## cellsToLinkedMultiPolygon / cellsToMultiPolygon
+
+Create a GeoJSON-like multi-polygon describing the outline(s) of a set of cells.
+Polygon outlines will follow GeoJSON MultiPolygon order: Each polygon will
+have one outer loop, which is first in the list, followed by any holes.
+
+It is expected that all cells in the set have the same resolution and
+that the set contains no duplicates. Behavior is undefined if duplicates
+or multiple resolutions are present, and the algorithm may produce
+unexpected or invalid output.
 
 <Tabs
   groupId="language"
@@ -201,6 +211,12 @@ Returns 0 (`E_SUCCESS`) on success.
 H3Error cellsToLinkedMultiPolygon(const H3Index *h3Set, const int numHexes, LinkedGeoPolygon *out);
 ```
 
+It is the responsibility of the caller to call `destroyLinkedPolygon` on the
+populated linked geo structure, or the memory for that structure will
+not be freed.
+
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -218,8 +234,8 @@ h3.cellsToMultiPolygon(cells, geoJson)
 
 ```js live
 function example() {
-    const hexagons = ['872830828ffffff', '87283082effffff'];
-    return h3.cellsToMultiPolygon(hexagons, true);
+    const cells = ['872830828ffffff', '87283082effffff'];
+    return h3.cellsToMultiPolygon(cells, true);
 }
 ```
 
@@ -229,6 +245,12 @@ function example() {
 ```py
 h3.cells_to_h3shape(cells, *, tight=True)
 ```
+
+Returns an `H3Shape` object:
+- If `tight=True`, returns `LatLngPoly` if possible, otherwise `LatLngMultiPoly`.
+- If `tight=False`, always returns a `LatLngMultiPoly`.
+
+For more info, see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
 
 </TabItem>
 <TabItem value="shell">
@@ -253,22 +275,12 @@ $ h3 cellsToMultiPolygon -c 872830828ffffff,87283082effffff
 </TabItem>
 </Tabs>
 
-Create a LinkedGeoPolygon describing the outline(s) of a set of  hexagons.
-Polygon outlines will follow GeoJSON MultiPolygon order: Each polygon will
-have one outer loop, which is first in the list, followed by any holes.
 
-It is the responsibility of the caller to call destroyLinkedPolygon on the
-populated linked geo structure, or the memory for that structure will
-not be freed.
-
-It is expected that all hexagons in the set have the same resolution and
-that the set contains no duplicates. Behavior is undefined if duplicates
-or multiple resolutions are present, and the algorithm may produce
-unexpected or invalid output.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## destroyLinkedMultiPolygon
+
+Free all allocated memory for a linked geo structure. The caller is
+responsible for freeing memory allocated to the input polygon struct.
 
 <Tabs
   groupId="language"
@@ -292,7 +304,7 @@ void destroyLinkedMultiPolygon(LinkedGeoPolygon *polygon);
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in Java.
 
 :::
 
@@ -301,7 +313,7 @@ This function exists for memory management and is not exposed.
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in JavaScript.
 
 :::
 
@@ -310,7 +322,7 @@ This function exists for memory management and is not exposed.
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in Python.
 
 :::
 
@@ -319,12 +331,11 @@ This function exists for memory management and is not exposed.
 
 :::note
 
-This function exists for memory management and is not exposed.
+This function exists for memory management and is not exposed in shell.
 
 :::
 
 </TabItem>
 </Tabs>
 
-Free all allocated memory for a linked geo structure. The caller is
-responsible for freeing memory allocated to the input polygon struct.
+

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -38,7 +38,7 @@ a partitioning of H3 cells.
 H3Error polygonToCells(const GeoPolygon *geoPolygon, int res, uint32_t flags, H3Index *out);
 ```
 
-`polygonToCells` takes a `GeoPolygon` struct and preallocated,
+In C, `polygonToCells` takes a `GeoPolygon` struct and preallocated,
 zeroed memory, and fills it with the covering cells.
 
 Returns 0 (`E_SUCCESS`) on success.

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -12,6 +12,15 @@ These functions convert H3 indexes to and from polygonal areas.
 
 ## polygonToCells
 
+Each binding's version of `polygonToCells` takes as input a GeoJSON-like data
+structure describing a polygon (i.e., an outer ring and optional holes) and
+a target cell resolution.
+It produces a collection of cells that are contained within the polygon.
+
+Containment is determined by centroids of the cells, so that a partitioning
+of polygons (covering an area without overlaps) will result in
+a partitioning of H3 cells.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -28,6 +37,11 @@ These functions convert H3 indexes to and from polygonal areas.
 ```c
 H3Error polygonToCells(const GeoPolygon *geoPolygon, int res, uint32_t flags, H3Index *out);
 ```
+
+`polygonToCells` takes a `GeoPolygon` struct and preallocated,
+zeroed memory, and fills it with the covering cells.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -60,8 +74,14 @@ function example() {
 <TabItem value="python">
 
 ```py
+h3.polygon_to_cells(h3shape, res)
 h3.h3shape_to_cells(h3shape, res)
 ```
+
+In Python, `h3shape_to_cells` takes an `H3Shape` object
+(`LatLngPoly` or `LatLngMultiPoly`).
+Note that `polygon_to_cells` is an alias for `h3shape_to_cells`.
+For more info, see the [`h3-py` docs](https://uber.github.io/h3-py/api_quick.html#polygon-interface).
 
 </TabItem>
 <TabItem value="shell">
@@ -87,16 +107,6 @@ $ h3 polygonToCells -r 7 -p "[[37.813318999983238, -122.4089866999972145], [37.7
 </TabItem>
 </Tabs>
 
-polygonToCells takes a given GeoJSON-like data structure and preallocated,
-zeroed memory, and fills it with the hexagons that are contained by
-the GeoJSON-like data structure.
-
-Containment is determined by the cells' centroids. A partitioning
-using the GeoJSON-like data structure, where polygons cover an area
-without overlap, will result in a partitioning in the H3 grid, where
-cells cover the same area without overlap.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ### maxPolygonToCellsSize
 

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -137,7 +137,7 @@ Returns 0 (`E_SUCCESS`) on success.
 
 :::note
 
-This function exists for memory management and is not exposed in Java.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -146,7 +146,7 @@ This function exists for memory management and is not exposed in Java.
 
 :::note
 
-This function exists for memory management and is not exposed in JavaScript.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -155,7 +155,7 @@ This function exists for memory management and is not exposed in JavaScript.
 
 :::note
 
-This function exists for memory management and is not exposed in Python.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -304,7 +304,7 @@ void destroyLinkedMultiPolygon(LinkedGeoPolygon *polygon);
 
 :::note
 
-This function exists for memory management and is not exposed in Java.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -313,7 +313,7 @@ This function exists for memory management and is not exposed in Java.
 
 :::note
 
-This function exists for memory management and is not exposed in JavaScript.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -322,7 +322,7 @@ This function exists for memory management and is not exposed in JavaScript.
 
 :::note
 
-This function exists for memory management and is not exposed in Python.
+This function exists for memory management and is not exposed.
 
 :::
 
@@ -331,7 +331,7 @@ This function exists for memory management and is not exposed in Python.
 
 :::note
 
-This function exists for memory management and is not exposed in shell.
+This function exists for memory management and is not exposed.
 
 :::
 

--- a/website/docs/api/regions.mdx
+++ b/website/docs/api/regions.mdx
@@ -60,7 +60,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.polygon_to_cells(polygons, res, geo_json_conformant=False)
+h3.h3shape_to_cells(h3shape, res)
 ```
 
 </TabItem>
@@ -217,7 +217,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.cells_to_multi_polygon(hexes, geo_json=False)
+h3.cells_to_h3shape(cells, *, tight=True)
 ```
 
 </TabItem>

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -421,6 +421,12 @@ $ h3 gridDiskDistances -k 5 -c 85283473fffffff
 
 ## gridDiskUnsafe
 
+Produces cells within grid distance `k` of the origin cell, just like `gridDisk`.
+However, the function may return an error code if pentagonal distorition is
+encountered. In this case, the output in the `out` array is undefined.
+
+Users can fall back to calling the slower but more robust `gridDiskDistances`.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -437,6 +443,12 @@ $ h3 gridDiskDistances -k 5 -c 85283473fffffff
 ```c
 H3Error gridDiskUnsafe(H3Index origin, int k, H3Index* out);
 ```
+
+Output is placed in the provided array in order of increasing distance from
+the origin. 
+The provided array must be of size `maxGridDiskSize(k)`.
+
+Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 
 </TabItem>
 <TabItem value="java">
@@ -458,9 +470,11 @@ This function is not exposed.
 </TabItem>
 <TabItem value="python">
 
-```py
-h3.grid_disk_unsafe(h, k)
-```
+:::note
+
+This function is not exposed.
+
+:::
 
 </TabItem>
 <TabItem value="shell">
@@ -474,20 +488,16 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-`gridDiskUnsafe` produces indexes within `k` distance of the origin index.
-The function returns an error code when one of the returned by this
-function is a pentagon or is in the pentagon distortion area. In this case,
-the output behavior of the `out` array is undefined.
-
-k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
-all neighboring indexes, and so on.
-
-Output is placed in the provided array in order of increasing distance from
-the origin. The provided array must be of size `maxGridDiskSize(k)`.
-
-Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 
 ## gridDiskDistancesUnsafe
+
+`gridDiskDistancesUnsafe` produces indexes within `k` distance of the origin index.
+Output behavior is undefined when one of the indexes returned by this
+function is a pentagon or is in the pentagon distortion area.
+
+Output is placed in the provided array in order of increasing distance from
+the origin. The distances in hexagons is placed in the distances array at
+the same offset. The provided array must be of size `maxGridDiskSize(k)`.
 
 <Tabs
   groupId="language"
@@ -505,6 +515,8 @@ Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 ```c
 H3Error gridDiskDistancesUnsafe(H3Index origin, int k, H3Index* out, int* distances);
 ```
+
+Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 
 </TabItem>
 <TabItem value="java">
@@ -527,9 +539,11 @@ This function is not exposed.
 </TabItem>
 <TabItem value="python">
 
-```py
-h3.grid_disk_distances_unsafe(h, k)
-```
+:::note
+
+This function is not exposed.
+
+:::
 
 </TabItem>
 <TabItem value="shell">
@@ -543,20 +557,14 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-`gridDiskDistancesUnsafe` produces indexes within `k` distance of the origin index.
-Output behavior is undefined when one of the indexes returned by this
-function is a pentagon or is in the pentagon distortion area.
 
-k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
-all neighboring indexes, and so on.
+## gridDiskDistancesSafe
+
+`gridDiskDistancesSafe` produces indexes within `k` distance of the origin index.
 
 Output is placed in the provided array in order of increasing distance from
 the origin. The distances in hexagons is placed in the distances array at
 the same offset. The provided array must be of size `maxGridDiskSize(k)`.
-
-Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
-
-## gridDiskDistancesSafe
 
 <Tabs
   groupId="language"
@@ -574,6 +582,8 @@ Returns 0 (`E_SUCCESS`) if no pentagonal distortion is encountered.
 ```c
 H3Error gridDiskDistancesSafe(H3Index origin, int k, H3Index* out, int* distances);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -596,9 +606,11 @@ This function is not exposed.
 </TabItem>
 <TabItem value="python">
 
-```py
-h3.grid_disk_distances_safe(h, k)
-```
+:::note
+
+This function is not exposed.
+
+:::
 
 </TabItem>
 <TabItem value="shell">
@@ -612,18 +624,12 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-`gridDiskDistancesSafe` produces indexes within `k` distance of the origin index.
-
-k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
-all neighboring indexes, and so on.
-
-Output is placed in the provided array in order of increasing distance from
-the origin. The distances in hexagons is placed in the distances array at
-the same offset. The provided array must be of size `maxGridDiskSize(k)`.
-
-Returns 0 (`E_SUCCESS`) on success.
 
 ## gridDisksUnsafe
+
+`gridDisksUnsafe` takes an array of input cells and a max `k` and returns an
+array of cells sorted first by the original cell indices and then by the
+grid ring (0 to max), with no guaranteed sorting within each grid ring group.
 
 <Tabs
   groupId="language"
@@ -641,6 +647,8 @@ Returns 0 (`E_SUCCESS`) on success.
 ```c
 H3Error gridDisksUnsafe(H3Index* h3Set, int length, int k, H3Index* out);
 ```
+
+Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered.
 
 </TabItem>
 <TabItem value="java">
@@ -663,9 +671,11 @@ This function is not exposed.
 </TabItem>
 <TabItem value="python">
 
-```py
-h3.grid_disks_unsafe(h, k)
-```
+:::note
+
+This function is not exposed.
+
+:::
 
 </TabItem>
 <TabItem value="shell">
@@ -679,16 +689,24 @@ This function is not exposed.
 </TabItem>
 </Tabs>
 
-`gridDisksUnsafe` takes an array of input hex IDs and a max k and returns an
-array of hexagon IDs sorted first by the original hex IDs and then by the
-grid k-ring (0 to max), with no guaranteed sorting within each grid k-ring group.
-
-Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered. Otherwise, output
-is undefined
-
-
 
 ## gridPathCells
+
+Given two H3 cells, return a minimal-length contiguous path of cells
+between them (inclusive of the endpoint cells).
+
+This function may fail if the cells are very far apart, or if
+the cells are on opposite sides of a pentagon.
+
+Notes:
+
+ * The output of this function should not be considered stable
+   across library versions. The only guarantees are
+   that the path length will be `gridDistance(start, end) + 1` and that
+   every cell in the path will be a neighbor of the preceding cell.
+
+ * Paths exist in the H3 grid of cells, and may not align closely with either
+   Cartesian lines or great arcs.
 
 <Tabs
   groupId="language"
@@ -706,6 +724,8 @@ is undefined
 ```c
 H3Error gridPathCells(H3Index start, H3Index end, H3Index* out);
 ```
+
+Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered.
 
 </TabItem>
 <TabItem value="java">
@@ -760,23 +780,10 @@ $ h3 gridPathCells -o 85283473fffffff -d 8528342bfffffff
 </TabItem>
 </Tabs>
 
-Given two H3 indexes, return the line of indexes between them (inclusive).
-
-This function may fail to find the line between two indexes, for
-example if they are very far apart. It may also fail when finding
-distances for indexes on opposite sides of a pentagon.
-
-*Notes:*
-
- * The specific output of this function should not be considered stable
-   across library versions. The only guarantees the library provides are
-   that the line length will be `h3Distance(start, end) + 1` and that
-   every index in the line will be a neighbor of the preceding index.
-
- * Lines are drawn in grid space, and may not correspond exactly to either
-   Cartesian lines or great arcs.
-
 ## gridPathCellsSize
+
+Number of cells in a grid path from the start cell to the end cell,
+to be used for allocating memory.
 
 <Tabs
   groupId="language"
@@ -794,6 +801,8 @@ distances for indexes on opposite sides of a pentagon.
 ```c
 H3Error gridPathCellsSize(H3Index start, H3Index end, int64_t* size);
 ```
+
+Returns 0 (`E_SUCCESS`) on success, or an error if the path cannot be computed.
 
 </TabItem>
 <TabItem value="java">
@@ -834,13 +843,15 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Number of indexes in a line from the start index to the end index,
-to be used for allocating memory.
-
-Returns 0 (`E_SUCCESS`) on success, or an error if the line cannot be computed.
-
 
 ## cellToLocalIj
+
+Produces local IJ coordinates for an H3 cell anchored by an origin.
+
+`mode` is reserved for future expansion and must be set to `0`.
+
+This function's output is not guaranteed to be compatible across different
+versions of H3.
 
 <Tabs
   groupId="language"
@@ -913,14 +924,14 @@ $ h3 cellToLocalIj -o 85283473fffffff -c 8528342bfffffff
 </TabItem>
 </Tabs>
 
-Produces local IJ coordinates for an H3 index anchored by an origin.
+## localIjToCell
+
+Produces an H3 cell from local IJ coordinates anchored by an origin.
 
 `mode` is reserved for future expansion and must be set to `0`.
 
 This function's output is not guaranteed to be compatible across different
 versions of H3.
-
-## localIjToCell
 
 <Tabs
   groupId="language"
@@ -992,12 +1003,5 @@ $ h3 localIjToCell -o 85283473fffffff -i 0 -j 0
 
 </TabItem>
 </Tabs>
-
-Produces an H3 index from local IJ coordinates anchored by an origin.
-
-`mode` is reserved for future expansion and must be set to `0`.
-
-This function's output is not guaranteed to be compatible across different
-versions of H3.
 
 

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -98,7 +98,7 @@ $ h3 gridDistance -o 85283473fffffff -d 8528342bfffffff
 
 ## gridRingUnsafe
 
-Produces the hollow ring of cells which are exactly grid distance `k`
+Produces the "hollow ring" of cells which are *exactly* grid distance `k`
 from the origin cell.
 
 This function may fail if pentagonal distortion is encountered.
@@ -195,17 +195,10 @@ The shell uses `gridRingUnsafe` internally to generate the results, but on failu
 
 ## gridDisk
 
-gridDisk produces all the cells within *grid distance* `k` of the origin cell.
-Grid distance is measured as the minimum number of "hops" between adjacent cells.
+Produces the "filled-in disk" of cells which are *at most* grid distance `k`
+from the origin cell.
 
-(There's a function for grid distance!)
-
-gridDisk was previously named *k-ring* after the concept of a ring with
-distance k. k-ring 0 is defined as the origin index, k-ring 1 is
-defined as k-ring 0 and all neighboring indices, and so on.
-
-Output is placed in the provided array in no particular order. Elements of
-the output array may be left as zero, which can happen when crossing a pentagon.
+The order of the output cells is not guaranteed.
 
 <Tabs
   groupId="language"
@@ -223,6 +216,11 @@ the output array may be left as zero, which can happen when crossing a pentagon.
 ```c
 H3Error gridDisk(H3Index origin, int k, H3Index* out);
 ```
+
+Elements of the output array may be left as zero,
+which can happen when crossing a pentagon.
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -364,6 +364,8 @@ H3Error gridDiskDistances(H3Index origin, int k, H3Index* out, int* distances);
 Elements of the output array may be left as zero,
 which can happen when crossing a pentagon.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -870,6 +872,8 @@ versions of H3.
 H3Error cellToLocalIj(H3Index origin, H3Index h3, uint32_t mode, CoordIJ *out);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -949,6 +953,8 @@ versions of H3.
 ```c
 H3Error localIjToCell(H3Index origin, const CoordIJ *ij, uint32_t mode, H3Index *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -8,7 +8,8 @@ slug: /api/traversal
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Grid traversal allows finding cells in the vicinity of an origin cell, and determining how to traverse the grid from one cell to another.
+Grid traversal allows finding cells in the vicinity of an origin cell,
+and determining how to traverse the grid from one cell to another.
 
 ## gridDistance
 
@@ -158,7 +159,10 @@ h3.grid_ring(h, k)
 
 :::note
 
-Python uses the C function `gridRingUnsafe` internally to generate the results, but on failure falls back to `gridDiskDistances` and returns the set of cells at the specified distance to produce an equivalent to the "safe" version, but this consumes a lot of memory to do so.
+Python uses the C function `gridRingUnsafe` internally to generate the results,
+but on failure falls back to `gridDiskDistances` and returns the set
+of cells at the specified distance to produce an equivalent to the "safe" version,
+but this consumes a lot of memory to do so.
 
 :::
 
@@ -184,7 +188,10 @@ $ h3 gridRing -k 1 -c 85283473fffffff
 
 :::note
 
-The shell uses `gridRingUnsafe` internally to generate the results, but on failure falls back to `gridDiskDistances` and returns the set of cells at the specified distance to produce an equivalent to the "safe" version, but this consumes a lot of memory to do so.
+The shell uses the C function `gridRingUnsafe` internally to generate the results,
+but on failure falls back to `gridDiskDistances` and returns the set
+of cells at the specified distance to produce an equivalent to the "safe" version,
+but this consumes a lot of memory to do so.
 
 :::
 

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -10,7 +10,202 @@ import TabItem from '@theme/TabItem';
 
 Grid traversal allows finding cells in the vicinity of an origin cell, and determining how to traverse the grid from one cell to another.
 
+## gridDistance
+
+Provides the *grid distance* between two cells, which is
+defined as the minimum number of "hops" needed across adjacent cells to get
+from one cell to the other.
+
+Note that finding the grid distance may fail for a few reasons:
+
+- the cells are not comparable (different resolutions),
+- the cells are too far apart, or
+- the cells are separated by pentagonal distortion.
+
+This is the same set of limitations as the local IJ coordinate space functions.
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+    {label: 'Python', value: 'python'},
+    {label: 'Shell', value: 'shell'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error gridDistance(H3Index origin, H3Index h3, int64_t *distance);
+```
+
+Returns 0 (`E_SUCCESS`) on success, or an error if finding the distance failed.
+
+</TabItem>
+<TabItem value="java">
+
+```java
+long gridDistance(long a, long b) throws DistanceUndefinedException;
+long gridDistance(String a, String b) throws DistanceUndefinedException;
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.gridDistance(a, b)
+```
+
+```js live
+function example() {
+  const start = '85283473fffffff';
+  const end = '8528342bfffffff';
+  return h3.gridDistance(start, end);
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.grid_distance(h1, h2)
+```
+
+</TabItem>
+<TabItem value="shell">
+
+```sh
+$ h3 gridDistance --help
+h3: Returns the number of steps along the grid to move from the origin cell to the destination cell
+H3 4.1.0
+
+  gridDistance  Returns the number of steps along the grid to move from the origin cell to the destination cell
+  -h, --help  Show this help message.
+  -o, --origin <cell> Required. The origin H3 cell
+  -d, --destination <cell>  Required. The destination H3 cell
+```
+
+```bash
+$ h3 gridDistance -o 85283473fffffff -d 8528342bfffffff
+2
+```
+
+</TabItem>
+</Tabs>
+
+
+## gridRingUnsafe
+
+Produces the hollow ring of cells which are exactly grid distance `k`
+from the origin cell.
+
+This function may fail if pentagonal distortion is encountered.
+
+<Tabs
+  groupId="language"
+  defaultValue="c"
+  values={[
+    {label: 'C', value: 'c'},
+    {label: 'Java', value: 'java'},
+    {label: 'JavaScript (Live)', value: 'javascript'},
+    {label: 'Python', value: 'python'},
+    {label: 'Shell', value: 'shell'},
+  ]
+}>
+<TabItem value="c">
+
+```c
+H3Error gridRingUnsafe(H3Index origin, int k, H3Index* out);
+```
+
+The caller should allocate memory for the maximum size of the ring, which is
+`6*k` if `k > 0` and `1` if `k == 0`.
+
+
+Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered.
+
+</TabItem>
+<TabItem value="java">
+
+```java
+List<Long> gridRingUnsafe(long h3, int k) throws PentagonEncounteredException;
+List<String> gridRingUnsafe(String h3Address, int k) throws PentagonEncounteredException;
+```
+
+</TabItem>
+<TabItem value="javascript">
+
+```js
+h3.gridRingUnsafe(h3Index, k)
+```
+
+```js live
+function example() {
+  const h = '85283473fffffff';
+  const k = 1;
+  return h3.gridRingUnsafe(h, k);
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+```py
+h3.grid_ring(h, k)
+```
+
+:::note
+
+Python uses the C function `gridRingUnsafe` internally to generate the results, but on failure falls back to `gridDiskDistances` and returns the set of cells at the specified distance to produce an equivalent to the "safe" version, but this consumes a lot of memory to do so.
+
+:::
+
+</TabItem>
+<TabItem value="shell">
+
+```sh
+$ h3 gridRing --help
+h3: Returns an array of H3 cells, each cell 'k' steps away from the origin cell
+H3 4.1.0
+
+  gridRing  Returns an array of H3 cells, each cell 'k' steps away from the origin cell
+  -h, --help  Show this help message.
+  -c, --cell <index>  Required. H3 Cell
+  -k <distance> Required. Maximum grid distance for the output set
+  -f, --format <FMT>  'json' for ["CELL", ...], 'newline' for CELL\n... (Default: json)
+```
+
+```bash
+$ h3 gridRing -k 1 -c 85283473fffffff
+[ "8528340bfffffff", "85283447fffffff", "8528347bfffffff", "85283463fffffff", "85283477fffffff", "8528340ffffffff" ]
+```
+
+:::note
+
+The shell uses `gridRingUnsafe` internally to generate the results, but on failure falls back to `gridDiskDistances` and returns the set of cells at the specified distance to produce an equivalent to the "safe" version, but this consumes a lot of memory to do so.
+
+:::
+
+</TabItem>
+</Tabs>
+
+
+
 ## gridDisk
+
+gridDisk produces all the cells within *grid distance* `k` of the origin cell.
+Grid distance is measured as the minimum number of "hops" between adjacent cells.
+
+(There's a function for grid distance!)
+
+gridDisk was previously named *k-ring* after the concept of a ring with
+distance k. k-ring 0 is defined as the origin index, k-ring 1 is
+defined as k-ring 0 and all neighboring indices, and so on.
+
+Output is placed in the provided array in no particular order. Elements of
+the output array may be left as zero, which can happen when crossing a pentagon.
 
 <Tabs
   groupId="language"
@@ -81,15 +276,6 @@ $ h3 gridDisk -k 5 -c 85283473fffffff
 
 </TabItem>
 </Tabs>
-
-gridDisk produces indices within k distance of the origin index.
-
-gridDisk was previously named *k-ring* after the concept of a ring with
-distance k. k-ring 0 is defined as the origin index, k-ring 1 is
-defined as k-ring 0 and all neighboring indices, and so on.
-
-Output is placed in the provided array in no particular order. Elements of
-the output array may be left as zero, which can happen when crossing a pentagon.
 
 ## maxGridDiskSize
 
@@ -498,87 +684,7 @@ grid k-ring (0 to max), with no guaranteed sorting within each grid k-ring group
 Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered. Otherwise, output
 is undefined
 
-## gridRingUnsafe
 
-<Tabs
-  groupId="language"
-  defaultValue="c"
-  values={[
-    {label: 'C', value: 'c'},
-    {label: 'Java', value: 'java'},
-    {label: 'JavaScript (Live)', value: 'javascript'},
-    {label: 'Python', value: 'python'},
-    {label: 'Shell', value: 'shell'},
-  ]
-}>
-<TabItem value="c">
-
-```c
-H3Error gridRingUnsafe(H3Index origin, int k, H3Index* out);
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-List<Long> gridRingUnsafe(long h3, int k) throws PentagonEncounteredException;
-List<String> gridRingUnsafe(String h3Address, int k) throws PentagonEncounteredException;
-```
-
-</TabItem>
-<TabItem value="javascript">
-
-```js
-h3.gridRingUnsafe(h3Index, k)
-```
-
-```js live
-function example() {
-  const h = '85283473fffffff';
-  const k = 1;
-  return h3.gridRingUnsafe(h, k);
-}
-```
-
-</TabItem>
-<TabItem value="python">
-
-```py
-h3.grid_ring_unsafe(h, k)
-```
-
-</TabItem>
-<TabItem value="shell">
-
-:::note
-
-The shell uses `gridRingUnsafe` internally to generate the results, but on failure falls back to `gridDiskDistances` and returns the set of cells at the specified distance to produce an equivalent to the "safe" version, but this consumes a lot of memory to do so.
-
-:::
-
-```sh
-$ h3 gridRing --help
-h3: Returns an array of H3 cells, each cell 'k' steps away from the origin cell
-H3 4.1.0
-
-	gridRing	Returns an array of H3 cells, each cell 'k' steps away from the origin cell
-	-h, --help	Show this help message.
-	-c, --cell <index>	Required. H3 Cell
-	-k <distance>	Required. Maximum grid distance for the output set
-	-f, --format <FMT>	'json' for ["CELL", ...], 'newline' for CELL\n... (Default: json)
-```
-
-```bash
-$ h3 gridRing -k 1 -c 85283473fffffff
-[ "8528340bfffffff", "85283447fffffff", "8528347bfffffff", "85283463fffffff", "85283477fffffff", "8528340ffffffff" ]
-```
-
-</TabItem>
-</Tabs>
-
-Produces the hollow hexagonal ring centered at origin with sides of length k.
-
-Returns 0 (`E_SUCCESS`) if no pentagonal distortion was encountered.
 
 ## gridPathCells
 
@@ -731,83 +837,6 @@ to be used for allocating memory.
 
 Returns 0 (`E_SUCCESS`) on success, or an error if the line cannot be computed.
 
-## gridDistance
-
-<Tabs
-  groupId="language"
-  defaultValue="c"
-  values={[
-    {label: 'C', value: 'c'},
-    {label: 'Java', value: 'java'},
-    {label: 'JavaScript (Live)', value: 'javascript'},
-    {label: 'Python', value: 'python'},
-    {label: 'Shell', value: 'shell'},
-  ]
-}>
-<TabItem value="c">
-
-```c
-H3Error gridDistance(H3Index origin, H3Index h3, int64_t *distance);
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-long gridDistance(long a, long b) throws DistanceUndefinedException;
-long gridDistance(String a, String b) throws DistanceUndefinedException;
-```
-
-</TabItem>
-<TabItem value="javascript">
-
-```js
-h3.gridDistance(a, b)
-```
-
-```js live
-function example() {
-  const start = '85283473fffffff';
-  const end = '8528342bfffffff';
-  return h3.gridDistance(start, end);
-}
-```
-
-</TabItem>
-<TabItem value="python">
-
-```py
-h3.grid_distance(h1, h2)
-```
-
-</TabItem>
-<TabItem value="shell">
-
-```sh
-$ h3 gridDistance --help
-h3: Returns the number of steps along the grid to move from the origin cell to the destination cell
-H3 4.1.0
-
-	gridDistance	Returns the number of steps along the grid to move from the origin cell to the destination cell
-	-h, --help	Show this help message.
-	-o, --origin <cell>	Required. The origin H3 cell
-	-d, --destination <cell>	Required. The destination H3 cell
-```
-
-```bash
-$ h3 gridDistance -o 85283473fffffff -d 8528342bfffffff
-2
-```
-
-</TabItem>
-</Tabs>
-
-Provides the distance in grid cells between the two indexes.
-
-Returns 0 (`E_SUCCESS`) on success, or an error if finding the distance failed. Finding the distance
-can fail because the two indexes are not comparable (different resolutions), too far apart, or are
-separated by pentagonal distortion. This is the same set of limitations as the local IJ coordinate
-space functions.
 
 ## cellToLocalIj
 

--- a/website/docs/api/traversal.mdx
+++ b/website/docs/api/traversal.mdx
@@ -192,13 +192,12 @@ The shell uses `gridRingUnsafe` internally to generate the results, but on failu
 </Tabs>
 
 
-
 ## gridDisk
 
 Produces the "filled-in disk" of cells which are *at most* grid distance `k`
 from the origin cell.
 
-The order of the output cells is not guaranteed.
+Output order is not guaranteed.
 
 <Tabs
   groupId="language"
@@ -277,6 +276,8 @@ $ h3 gridDisk -k 5 -c 85283473fffffff
 
 ## maxGridDiskSize
 
+Maximum number of cells that can result from the `gridDisk` function for a given `k`.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -293,6 +294,8 @@ $ h3 gridDisk -k 5 -c 85283473fffffff
 ```c
 H3Error maxGridDiskSize(int k, int64_t *out);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">
@@ -333,9 +336,13 @@ This function exists for memory management and is not exposed.
 </TabItem>
 </Tabs>
 
-Maximum number of indices that result from the `gridDisk` algorithm with the given `k`.
 
 ## gridDiskDistances
+
+Produces the same set of cells as `gridDisk`, but along with each cell's
+grid distance from the origin cell.
+
+Output order is not guaranteed.
 
 <Tabs
   groupId="language"
@@ -353,6 +360,9 @@ Maximum number of indices that result from the `gridDisk` algorithm with the giv
 ```c
 H3Error gridDiskDistances(H3Index origin, int k, H3Index* out, int* distances);
 ```
+
+Elements of the output array may be left as zero,
+which can happen when crossing a pentagon.
 
 </TabItem>
 <TabItem value="java">
@@ -380,9 +390,11 @@ function example() {
 </TabItem>
 <TabItem value="python">
 
-```py
-h3.grid_disk_distances(origin, k)
-```
+:::note
+
+This function is not exposed in Python.
+
+:::
 
 </TabItem>
 <TabItem value="shell">
@@ -406,14 +418,6 @@ $ h3 gridDiskDistances -k 5 -c 85283473fffffff
 
 </TabItem>
 </Tabs>
-
-gridDiskDistances produces indices within k distance of the origin index.
-
-k-ring 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
-all neighboring indices, and so on.
-
-Output is placed in the provided array in no particular order. Elements of
-the output array may be left as zero, which can happen when crossing a pentagon.
 
 ## gridDiskUnsafe
 

--- a/website/docs/api/vertex.mdx
+++ b/website/docs/api/vertex.mdx
@@ -12,7 +12,8 @@ Vertex mode allows encoding the topological vertexes of H3 cells.
 
 ## cellToVertex
 
-Returns the index for the specified cell vertex. Valid vertex numbers are between 0 and 5 (inclusive)
+Returns the index for the specified cell vertex.
+Valid vertex numbers are between 0 and 5 (inclusive)
 for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
 
 <Tabs

--- a/website/docs/api/vertex.mdx
+++ b/website/docs/api/vertex.mdx
@@ -12,6 +12,9 @@ Vertex mode allows encoding the topological vertexes of H3 cells.
 
 ## cellToVertex
 
+Returns the index for the specified cell vertex. Valid vertex numbers are between 0 and 5 (inclusive)
+for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
+
 <Tabs
   groupId="language"
   defaultValue="c"
@@ -82,10 +85,9 @@ $ h3 cellToVertex -v 2 -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the index for the specified cell vertex. Valid vertex numbers are between 0 and 5 (inclusive)
-for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
-
 ## cellToVertexes
+
+Returns the indexes for all vertexes of the given cell.
 
 <Tabs
   groupId="language"
@@ -103,6 +105,10 @@ for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
 ```c
 H3Error cellToVertexes(H3Index origin, H3Index *out);
 ```
+
+The length of the `out` array must be 6.
+If the given cell is a pentagon, one member of the
+array will be set to `0`.
 
 </TabItem>
 <TabItem value="java">
@@ -155,12 +161,9 @@ $ h3 cellToVertexes -c 85283473fffffff
 </TabItem>
 </Tabs>
 
-Returns the indexes for all vertexes of the given cell index.
-
-The length of the `out` array must be 6. If the given cell index represents a pentagon, one member of the
-array will be set to `0`.
-
 ## vertexToLatLng
+
+Returns the latitude and longitude coordinates of the given vertex.
 
 <Tabs
   groupId="language"
@@ -230,9 +233,9 @@ $ h3 vertexToLatLng -c 255283463fffffff
 </TabItem>
 </Tabs>
 
-Returns the latitude and longitude coordinates of the given vertex.
-
 ## isValidVertex
+
+Determines if the given H3 index represents a valid H3 vertex.
 
 <Tabs
   groupId="language"
@@ -250,6 +253,8 @@ Returns the latitude and longitude coordinates of the given vertex.
 ```c
 int isValidVertex(H3Index vertex);
 ```
+
+Returns 1 if the given index represents a valid H3 vertex.
 
 </TabItem>
 <TabItem value="java">
@@ -301,5 +306,3 @@ true
 
 </TabItem>
 </Tabs>
-
-Returns 1 if the given index represents a valid H3 vertex.

--- a/website/docs/api/vertex.mdx
+++ b/website/docs/api/vertex.mdx
@@ -32,6 +32,8 @@ for hexagonal cells, and 0 and 4 (inclusive) for pentagonal cells.
 H3Error cellToVertex(H3Index origin, int vertexNum, H3Index *out);
 ```
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -110,6 +112,8 @@ The length of the `out` array must be 6.
 If the given cell is a pentagon, one member of the
 array will be set to `0`.
 
+Returns 0 (`E_SUCCESS`) on success.
+
 </TabItem>
 <TabItem value="java">
 
@@ -181,6 +185,8 @@ Returns the latitude and longitude coordinates of the given vertex.
 ```c
 H3Error vertexToLatLng(H3Index vertex, LatLng *point);
 ```
+
+Returns 0 (`E_SUCCESS`) on success.
 
 </TabItem>
 <TabItem value="java">


### PR DESCRIPTION
Update the cells <> polygon functions in the h3geo.org docs to match h3-py v4.x.

Update: Also rework the h3geo.org docs so that language-agnostic function descriptions are given first, and language-specific details are given below the language tabs.

This also fixes some bugs in the docs that I found along the way.