### PR TITLE
fix integer/ string function names in docs for python

### DIFF
--- a/website/docs/api/inspection.mdx
+++ b/website/docs/api/inspection.mdx
@@ -198,7 +198,7 @@ The H3 JavaScript binding supports only the string representation of an H3 index
 <TabItem value="python">
 
 ```py
-h3.string_to_h3(h)
+h3.str_to_int(h)
 ```
 
 </TabItem>
@@ -258,7 +258,7 @@ The H3 JavaScript binding supports only the string representation of an H3 index
 <TabItem value="python">
 
 ```py
-h3.h3_to_string(h)
+h3.int_to_str(h)
 ```
 
 </TabItem>


### PR DESCRIPTION
These function names do not match the core library: https://uber.github.io/h3-py/api_verbose.html#h3.int_to_str