### PR TITLE
Fixing python docs for a few functions under "Miscellaneous"

### DIFF
--- a/website/docs/api/misc.mdx
+++ b/website/docs/api/misc.mdx
@@ -205,7 +205,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.get_hexagon_area_avg(res, unit='km^2')
+h3.average_hexagon_area(res, unit='km^2')
 ```
 
 </TabItem>
@@ -276,7 +276,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.get_hexagon_area_avg(res, unit='m^2')
+h3.average_hexagon_area(res, unit='m^2')
 ```
 
 </TabItem>
@@ -561,7 +561,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.get_hexagon_edge_length_avg(res, unit='km')
+h3.average_hexagon_edge_length(res, unit='km')
 ```
 
 </TabItem>
@@ -633,7 +633,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.get_hexagon_edge_length_avg(res, unit='m')
+h3.average_hexagon_edge_length(res, unit='m')
 ```
 
 </TabItem>
@@ -705,7 +705,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.exact_edge_length(h, unit='km')
+h3.edge_length(h, unit='km')
 ```
 
 </TabItem>
@@ -777,7 +777,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.exact_edge_length(h, unit='m')
+h3.edge_length(h, unit='m')
 ```
 
 </TabItem>
@@ -849,7 +849,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.exact_edge_length(h, unit='rads')
+h3.edge_length(h, unit='rads')
 ```
 
 </TabItem>
@@ -1349,7 +1349,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.latlng_distance(point1, point2, unit='m')
+h3.great_circle_distance(point1, point2, unit='m')
 ```
 
 </TabItem>
@@ -1423,7 +1423,7 @@ function example() {
 <TabItem value="python">
 
 ```py
-h3.latlng_distance(point1, point2, unit='rads')
+h3.great_circle_distance(point1, point2, unit='rads')
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixes the [h3geo.org documentation](https://h3geo.org/docs/api/misc/) for the three functions mentioned in #942 (`average_hexagon_edge_length`, `edge_length`, and `average_hexagon_area`) as well as `great_circle_distance`. 