### PR TITLE
CI: Update mac os runner versions

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-latest]
+        os: [macos-13, macos-15, macos-latest]
         build_type: ["Debug", "Release"]
 
     steps:


### PR DESCRIPTION
macos-latest is macos-14: https://github.com/actions/runner-images
macos-15 is ARM, and also in beta.