### PR TITLE
[Documentation] Add binding + debug tool

### DIFF
--- a/website/docs/community/applications.md
+++ b/website/docs/community/applications.md
@@ -11,3 +11,4 @@ The following applications use H3. Contributions to this list are welcome, pleas
 
 - [kepler.gl](http://kepler.gl/) - An open source geospatial analysis tool
 - [pydeck](https://deckgl.readthedocs.io/) - High-scale spatial rendering in Python, powered by deck.gl
+- [h3-viewer](https://h3.chotard.com/) - Debugging tool to visualise h3 on mercator projection, powered by deck.gl

--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -137,5 +137,6 @@ As a C library, bindings can be made to call H3 functions from different program
 
 ## Spark
 
-- [kevinschaich/h3-pyspark](https://github.com/kevinschaich/h3-pyspark) (3.x)
 - [jchotard/h3spark](https://github.com/JosephChotard/h3spark) (4.x)
+- [kevinschaich/h3-pyspark](https://github.com/kevinschaich/h3-pyspark) (3.x)
+

--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -137,4 +137,5 @@ As a C library, bindings can be made to call H3 functions from different program
 
 ## Spark
 
-- [kevinschaich/h3-pyspark](https://github.com/kevinschaich/h3-pyspark)
+- [kevinschaich/h3-pyspark](https://github.com/kevinschaich/h3-pyspark) (3.x)
+- [jchotard/h3spark](https://github.com/JosephChotard/h3spark) (4.x)


### PR DESCRIPTION
Added 2 links to documentation

1. A new h3 binding library for h3 in pyspark as the currently listed version hasn't been maintained in 3 years and does not work with h3 4.xx
2. A link to an h3 debugging tool for visualising the world split into h3 cells on mercator projection. (Code also shows how to split geometries when wrapping around the world)

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/c2421283-f22a-4272-83b4-7ba3462d5ed3" />
