### PR TITLE
Fix CI errors

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -72,11 +72,7 @@ jobs:
           cd build/examples
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../../examples
           make
-          make test
-      
-      - name: Display LastTest.log for debugging
-        if: failure()
-        run: cat /home/runner/work/h3/h3/build/examples/Testing/Temporary/LastTest.log
+          env CTEST_OUTPUT_ON_FAILURE=1 make test 
 
   clang-tests:
     name: Test Compile clang ${{ matrix.build_type }} ${{ matrix.compile_opt }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -132,7 +132,7 @@ jobs:
           cd build/examples
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_C_FLAGS="${{ matrix.compile_opt }}" ../../examples
           make
-          make test
+          env CTEST_OUTPUT_ON_FAILURE=1 make test 
 
   valgrind-tests:
     name: Test Valgrind

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -73,6 +73,10 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ../../examples
           make
           make test
+      
+      - name: Display LastTest.log for debugging
+        if: failure()
+        run: cat /home/runner/work/h3/h3/build/examples/Testing/Temporary/LastTest.log
 
   clang-tests:
     name: Test Compile clang ${{ matrix.build_type }} ${{ matrix.compile_opt }}

--- a/CMakeTests.cmake
+++ b/CMakeTests.cmake
@@ -49,7 +49,7 @@ if(ENABLE_COVERAGE)
     add_custom_target(
         clean-coverage
         # Before running coverage, clear all counters
-        COMMAND lcov --rc lcov_branch_coverage=1 --directory
+        COMMAND lcov --rc branch_coverage=1 --directory
                 '${CMAKE_CURRENT_BINARY_DIR}' --zerocounters
         COMMENT "Zeroing counters")
 endif()

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -66,7 +66,8 @@ int main(int argc, char *argv[]) {
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
-        "grid distance: %" PRId64 "\n"
+        "grid distance: %" PRId64
+        "\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
         radsToDegs(geoHQ2.lng), distance,

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -50,17 +50,18 @@ double haversineDistance(double th1, double ph1, double th2, double ph2) {
 
 int main(int argc, char *argv[]) {
     // 1455 Market St @ resolution 15
-    H3Index h3HQ1;
+    H3Index h3HQ1 = 0;
     stringToH3("8f2830828052d25", &h3HQ1);
     // 555 Market St @ resolution 15
-    H3Index h3HQ2;
+    H3Index h3HQ2 = 0;
     stringToH3("8f283082a30e623", &h3HQ2);
 
-    LatLng geoHQ1, geoHQ2;
+    LatLng geoHQ1 = {0};
+    LatLng geoHQ2 = {0};
     cellToLatLng(h3HQ1, &geoHQ1);
     cellToLatLng(h3HQ2, &geoHQ2);
 
-    int64_t distance;
+    int64_t distance = 0;
     assert(gridDistance(h3HQ1, h3HQ2, &distance) == E_SUCCESS);
 
     printf(

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -23,6 +23,7 @@
 
 #include <assert.h>
 #include <h3/h3api.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -65,7 +66,8 @@ int main(int argc, char *argv[]) {
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
-        "grid distance: %d\n"
+        "grid distance: %" PRId64
+        "\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
         radsToDegs(geoHQ2.lng), distance,

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -23,7 +23,6 @@
 
 #include <assert.h>
 #include <h3/h3api.h>
-#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -66,8 +65,7 @@ int main(int argc, char *argv[]) {
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
-        "grid distance: %" PRId64
-        "\n"
+        "grid distance: %d\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
         radsToDegs(geoHQ2.lng), distance,

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -23,9 +23,9 @@
 
 #include <assert.h>
 #include <h3/h3api.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
-#include <inttypes.h>
 
 /**
  * @brief haversineDistance finds the

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
-        "grid distance: %d\n"
+        "grid distance: %ld\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
         radsToDegs(geoHQ2.lng), distance,

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         "grid distance: %ld\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
-        radsToDegs(geoHQ2.lng), distance,
+        radsToDegs(geoHQ2.lng), (long)distance,
         haversineDistance(geoHQ1.lat, geoHQ1.lng, geoHQ2.lat, geoHQ2.lng));
     // Output:
     // origin: (37.775236, -122.419755)

--- a/examples/distance.c
+++ b/examples/distance.c
@@ -25,6 +25,7 @@
 #include <h3/h3api.h>
 #include <math.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /**
  * @brief haversineDistance finds the
@@ -65,10 +66,10 @@ int main(int argc, char *argv[]) {
     printf(
         "origin: (%lf, %lf)\n"
         "destination: (%lf, %lf)\n"
-        "grid distance: %ld\n"
+        "grid distance: %" PRId64 "\n"
         "distance in km: %lfkm\n",
         radsToDegs(geoHQ1.lat), radsToDegs(geoHQ1.lng), radsToDegs(geoHQ2.lat),
-        radsToDegs(geoHQ2.lng), (long)distance,
+        radsToDegs(geoHQ2.lng), distance,
         haversineDistance(geoHQ1.lat, geoHQ1.lng, geoHQ2.lat, geoHQ2.lng));
     // Output:
     // origin: (37.775236, -122.419755)

--- a/scripts/coverage.sh.in
+++ b/scripts/coverage.sh.in
@@ -49,6 +49,6 @@ binary_dir=${2:-"Missing binary directory"}
 br_exclusion='LCOV_EXCL_BR_LINE|assert\('
 
 cd "${binary_dir}"
-lcov --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --directory . --capture --output-file coverage.info
-lcov --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
+lcov --ignore-errors mismatch --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --directory . --capture --output-file coverage.info
+lcov --ignore-errors mismatch --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
 genhtml --branch-coverage -o coverage coverage.cleaned.info --title 'h3 coverage'

--- a/scripts/coverage.sh.in
+++ b/scripts/coverage.sh.in
@@ -49,6 +49,6 @@ binary_dir=${2:-"Missing binary directory"}
 br_exclusion='LCOV_EXCL_BR_LINE|assert\('
 
 cd "${binary_dir}"
-lcov --rc lcov_branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --directory . --capture --output-file coverage.info
-lcov --rc lcov_branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
+lcov --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --directory . --capture --output-file coverage.info
+lcov --rc branch_coverage=1 --rc "lcov_excl_br_line=$br_exclusion" --extract coverage.info "${src_dir}/src/h3lib/*" --output-file coverage.cleaned.info
 genhtml --branch-coverage -o coverage coverage.cleaned.info --title 'h3 coverage'


### PR DESCRIPTION
### LCOV

It seems that since lcov was upgraded to 2.0 actions have been failing

Last successful linux coverage test:
`Unpacking lcov (1.15-1) ...`
Now:
`Unpacking lcov (2.0-4ubuntu2) ...`

```
geninfo: ERROR: mismatched end line for main at /home/runner/work/h3/h3/src/apps/testapps/testBaseCells.c:23: 32 -> 23
	(use "geninfo --ignore-errors mismatch ..." to bypass this error)
```
	
	
I added `--ignore-errors mismatch` as that seems to be what people on other issues recommend.

### Examples

For the example that was failing CI checks it seems it was due to `use-of-uninitialized-value`. I initialised the variables and seems to be good now
