### PR TITLE
ci: include ubuntu arm test, clean up check names

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v2.4.1
         with:

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -18,7 +18,7 @@ jobs:
         compiler: [clang, gcc]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Configure build
         run: |

--- a/.github/workflows/test-fuzzer.yml
+++ b/.github/workflows/test-fuzzer.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   afl-tests:
-    name: Fuzzer Compilation ${{ matrix.compiler }}
+    name: AFL Fuzzer ${{ matrix.compiler }}
     runs-on: ubuntu-latest
     env:
       CC: ${{ matrix.compiler }}
@@ -41,7 +41,7 @@ jobs:
           done
 
   libfuzzer-test:
-    name: LibFuzzer Compilation ${{ matrix.compiler }}
+    name: LibFuzzer ${{ matrix.compiler }}
     runs-on: ubuntu-latest
     env:
       CC: ${{ matrix.compiler }}

--- a/.github/workflows/test-fuzzer.yml
+++ b/.github/workflows/test-fuzzer.yml
@@ -18,7 +18,7 @@ jobs:
         compiler: [clang, gcc]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Configure build
         run: |
@@ -51,7 +51,7 @@ jobs:
         compiler: [clang]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Configure build
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Configure build
         run: cmake -DAUDIT_SOURCE_FILE_LIST=ON .
@@ -29,7 +29,7 @@ jobs:
         runs_on: ["ubuntu-latest", "ubuntu-22.04-arm"]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Install Doxygen
         run: |
@@ -89,7 +89,7 @@ jobs:
         build_type: ["Debug", "Release"]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Install Doxygen
         run: |
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Install Valgrind
         run: |
@@ -167,7 +167,7 @@ jobs:
       CC: gcc
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Install lcov
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,14 +18,15 @@ jobs:
         run: cmake -DAUDIT_SOURCE_FILE_LIST=ON .
 
   gcc-tests:
-    name: Test Compile gcc ${{ matrix.build_type }}
-    runs-on: ubuntu-latest
+    name: gcc ${{ matrix.build_type }} ${{ matrix.runs_on }}
+    runs-on: ${{ matrix.runs_on }}
     env:
       CC: gcc
 
     strategy:
       matrix:
         build_type: ["Debug", "Release"]
+        runs_on: ["ubuntu-latest", "ubuntu-22.04-arm"]
 
     steps:
       - uses: actions/checkout@v2.4.0
@@ -75,7 +76,7 @@ jobs:
           env CTEST_OUTPUT_ON_FAILURE=1 make test 
 
   clang-tests:
-    name: Test Compile clang ${{ matrix.build_type }} ${{ matrix.compile_opt }}
+    name: clang ${{ matrix.build_type }} ${{ matrix.compile_opt }}
     runs-on: ubuntu-latest
     env:
       CC: clang
@@ -135,7 +136,7 @@ jobs:
           env CTEST_OUTPUT_ON_FAILURE=1 make test 
 
   valgrind-tests:
-    name: Test Valgrind
+    name: Valgrind
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -17,7 +17,7 @@ jobs:
         build_type: ["Debug", "Release"]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - name: Configure build
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DWARNINGS_AS_ERRORS=ON .

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v2.4.1
         with:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: Test Compile ${{ matrix.config }} ${{ matrix.arch }}
+    name: ${{ matrix.config }} ${{ matrix.arch }}
     runs-on: windows-latest
     env:
       CC: cl.exe
@@ -46,7 +46,7 @@ jobs:
         run: ctest -C ${{ matrix.config }}
 
   dllcompile:
-    name: Test DLL Compile ${{ matrix.config }} ${{ matrix.arch }}
+    name: DLL ${{ matrix.config }} ${{ matrix.arch }}
     runs-on: windows-latest
     env:
       CC: cl.exe

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,7 +20,7 @@ jobs:
         arch: [Win32, x64]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - uses: tlylt/install-graphviz@v1.0.0
 
@@ -58,7 +58,7 @@ jobs:
         arch: [Win32, x64]
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
 
       - uses: tlylt/install-graphviz@v1.0.0
 


### PR DESCRIPTION
Adds Linux arm64 test. I added it only for GCC to avoid exploding the test matrix (since clang has more options that are tested). It would be a valid configuration to also test, so open to suggestions. Maybe we throw it in?

Since the Github UI already shows which file the test comes from, including "Compile" or "Test" seem superfluous.