### PR TITLE
Fix a memory leak bug in function `polygonStringToGeoPolygon`

### DIFF
--- a/src/apps/filters/h3.c
+++ b/src/apps/filters/h3.c
@@ -1478,6 +1478,7 @@ H3Error polygonStringToGeoPolygon(FILE *fp, char *polygonString,
             }
             if (curDepth > 4) {
                 // This is beyond the depth for a valid input, so we abort early
+                free(verts);
                 return E_FAILED;
             }
             strPos++;


### PR DESCRIPTION
The pointer `verts` at line 14 of function `polygonStringToGeoPolygon` is not freed before the function returns at line 34. Thus there is a memory leak bug.

`LatLng *verts = calloc(numVerts, sizeof(LatLng));`

```
            if (curDepth > 4) {
                // This is beyond the depth for a valid input, so we abort early
                return E_FAILED;
            }
```