### PR TITLE
Website: show the grid at various resolutions

### DIFF
--- a/website/src/components/explorer/map.jsx
+++ b/website/src/components/explorer/map.jsx
@@ -10,7 +10,6 @@ import React, {
 import { Map } from "react-map-gl";
 import DeckGL from "@deck.gl/react";
 import { H3HexagonLayer } from "@deck.gl/geo-layers";
-import { PathStyleExtension } from "@deck.gl/extensions";
 import { WebMercatorViewport, FlyToInterpolator } from "@deck.gl/core";
 import { getRes0Cells, uncompactCells, cellToBoundary } from "h3-js";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -23,6 +22,8 @@ const INITIAL_VIEW_STATE = {
   zoom: 2.5,
   pitch: 0,
   bearing: 0,
+  maxZoom: 22,
+  minZoom: 0,
 };
 
 const MAP_STYLE = "mapbox://styles/mapbox/light-v11";
@@ -121,7 +122,7 @@ const addSelectedHexes = useCallback((hex) => {
 
   const {
     handleResize: hexHandleResize,
-    hexLayer: backgroundHexLayer,
+    hexLayers: backgroundHexLayers,
     resolution,
 } = useHex({
     resolutionFrozen: false,
@@ -147,55 +148,7 @@ const addSelectedHexes = useCallback((hex) => {
           getFillColor: [0, 0, 0, 30],
         }),
       ]
-    : [
-      backgroundHexLayer
-        // new H3HexagonLayer({
-        //   id: "res0",
-        //   data: res0Cells,
-        //   getHexagon: (d) => d.hex,
-        //   extruded: false,
-        //   filled: false,
-        //   stroked: true,
-        //   getLineColor: [0, 0, 0],
-        //   getLineWidth: 3,
-        //   lineWidthMinPixels: 3,
-        //   highPrecision: true,
-        // }),
-        // new H3HexagonLayer({
-        //   id: "res1",
-        //   data: res1Cells,
-        //   getHexagon: (d) => d.hex,
-        //   extruded: false,
-        //   filled: false,
-        //   stroked: true,
-        //   getLineColor: [0, 0, 0],
-        //   getLineWidth: 2,
-        //   lineWidthMinPixels: 2,
-        //   highPrecision: true,
-        //   lineWidthUnits: "pixels",
-        //   getDashArray: [5, 1],
-        //   dashJustified: true,
-        //   dashGapPickable: true,
-        //   extensions: [new PathStyleExtension({ dash: true })],
-        // }),
-        // new H3HexagonLayer({
-        //   id: "res2",
-        //   data: res2Cells,
-        //   getHexagon: (d) => d.hex,
-        //   extruded: false,
-        //   filled: false,
-        //   stroked: true,
-        //   getLineColor: [0, 0, 0],
-        //   getLineWidth: 1,
-        //   lineWidthMinPixels: 1,
-        //   highPrecision: true,
-        //   lineWidthUnits: "pixels",
-        //   getDashArray: [5, 5],
-        //   dashJustified: true,
-        //   dashGapPickable: true,
-        //   extensions: [new PathStyleExtension({ dash: true })],
-        // }),
-      ];
+    : backgroundHexLayers;
 
   const getTooltip = useCallback(({ object }) => {
     if (object && object.hex) {
@@ -216,14 +169,17 @@ const addSelectedHexes = useCallback((hex) => {
   const onClick = useCallback(
     ({ object, coordinate, viewport }) => {
       if (object && object.hex) {
-        // TODO: click to copy?
         if (objectOnClick) {
           objectOnClick({ hex: object.hex });
         }
-      } else {
-        if (coordinateOnClick) {
-          coordinateOnClick({ coordinate, zoom: viewport.zoom });
+      } else if (object && object instanceof string) {
+        if (objectOnClick) {
+          objectOnClick({ hex: object });
         }
+      } else {
+        // if (coordinateOnClick) {
+        //   coordinateOnClick({ coordinate, zoom: viewport.zoom });
+        // }
       }
     },
     [objectOnClick, coordinateOnClick],

--- a/website/src/components/explorer/map.jsx
+++ b/website/src/components/explorer/map.jsx
@@ -15,6 +15,7 @@ import { WebMercatorViewport, FlyToInterpolator } from "@deck.gl/core";
 import { getRes0Cells, uncompactCells, cellToBoundary } from "h3-js";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { MOBILE_CUTOFF_WINDOW_WIDTH } from "../common";
+import { useHex } from "./useHex";
 
 const INITIAL_VIEW_STATE = {
   longitude: -74.012,
@@ -114,6 +115,19 @@ export function ExplorerMap({
     }
   }, [userInput, userValidHex, deckLoaded]);
 
+const addSelectedHexes = useCallback((hex) => {
+  objectOnClick({ hex });
+}, [objectOnClick]);
+
+  const {
+    handleResize: hexHandleResize,
+    hexLayer: backgroundHexLayer,
+    resolution,
+} = useHex({
+    resolutionFrozen: false,
+    addSelectedHexes,
+});
+
   const layers = userValidHex
     ? [
         new H3HexagonLayer({
@@ -134,52 +148,53 @@ export function ExplorerMap({
         }),
       ]
     : [
-        new H3HexagonLayer({
-          id: "res0",
-          data: res0Cells,
-          getHexagon: (d) => d.hex,
-          extruded: false,
-          filled: false,
-          stroked: true,
-          getLineColor: [0, 0, 0],
-          getLineWidth: 3,
-          lineWidthMinPixels: 3,
-          highPrecision: true,
-        }),
-        new H3HexagonLayer({
-          id: "res1",
-          data: res1Cells,
-          getHexagon: (d) => d.hex,
-          extruded: false,
-          filled: false,
-          stroked: true,
-          getLineColor: [0, 0, 0],
-          getLineWidth: 2,
-          lineWidthMinPixels: 2,
-          highPrecision: true,
-          lineWidthUnits: "pixels",
-          getDashArray: [5, 1],
-          dashJustified: true,
-          dashGapPickable: true,
-          extensions: [new PathStyleExtension({ dash: true })],
-        }),
-        new H3HexagonLayer({
-          id: "res2",
-          data: res2Cells,
-          getHexagon: (d) => d.hex,
-          extruded: false,
-          filled: false,
-          stroked: true,
-          getLineColor: [0, 0, 0],
-          getLineWidth: 1,
-          lineWidthMinPixels: 1,
-          highPrecision: true,
-          lineWidthUnits: "pixels",
-          getDashArray: [5, 5],
-          dashJustified: true,
-          dashGapPickable: true,
-          extensions: [new PathStyleExtension({ dash: true })],
-        }),
+      backgroundHexLayer
+        // new H3HexagonLayer({
+        //   id: "res0",
+        //   data: res0Cells,
+        //   getHexagon: (d) => d.hex,
+        //   extruded: false,
+        //   filled: false,
+        //   stroked: true,
+        //   getLineColor: [0, 0, 0],
+        //   getLineWidth: 3,
+        //   lineWidthMinPixels: 3,
+        //   highPrecision: true,
+        // }),
+        // new H3HexagonLayer({
+        //   id: "res1",
+        //   data: res1Cells,
+        //   getHexagon: (d) => d.hex,
+        //   extruded: false,
+        //   filled: false,
+        //   stroked: true,
+        //   getLineColor: [0, 0, 0],
+        //   getLineWidth: 2,
+        //   lineWidthMinPixels: 2,
+        //   highPrecision: true,
+        //   lineWidthUnits: "pixels",
+        //   getDashArray: [5, 1],
+        //   dashJustified: true,
+        //   dashGapPickable: true,
+        //   extensions: [new PathStyleExtension({ dash: true })],
+        // }),
+        // new H3HexagonLayer({
+        //   id: "res2",
+        //   data: res2Cells,
+        //   getHexagon: (d) => d.hex,
+        //   extruded: false,
+        //   filled: false,
+        //   stroked: true,
+        //   getLineColor: [0, 0, 0],
+        //   getLineWidth: 1,
+        //   lineWidthMinPixels: 1,
+        //   highPrecision: true,
+        //   lineWidthUnits: "pixels",
+        //   getDashArray: [5, 5],
+        //   dashJustified: true,
+        //   dashGapPickable: true,
+        //   extensions: [new PathStyleExtension({ dash: true })],
+        // }),
       ];
 
   const getTooltip = useCallback(({ object }) => {
@@ -219,6 +234,9 @@ export function ExplorerMap({
       ref={deckRef}
       layers={layers}
       initialViewState={currentInitialViewState}
+      onViewStateChange={({viewState}) => {
+        hexHandleResize(viewState);
+      }}
       getTooltip={getTooltip}
       getCursor={getCursor}
       onClick={onClick}

--- a/website/src/components/explorer/map.jsx
+++ b/website/src/components/explorer/map.jsx
@@ -116,18 +116,21 @@ export function ExplorerMap({
     }
   }, [userInput, userValidHex, deckLoaded]);
 
-const addSelectedHexes = useCallback((hex) => {
-  objectOnClick({ hex });
-}, [objectOnClick]);
+  const addSelectedHexes = useCallback(
+    (hex) => {
+      objectOnClick({ hex });
+    },
+    [objectOnClick],
+  );
 
   const {
     handleResize: hexHandleResize,
     hexLayers: backgroundHexLayers,
     resolution,
-} = useHex({
+  } = useHex({
     resolutionFrozen: false,
     addSelectedHexes,
-});
+  });
 
   const layers = userValidHex
     ? [
@@ -190,7 +193,7 @@ const addSelectedHexes = useCallback((hex) => {
       ref={deckRef}
       layers={layers}
       initialViewState={currentInitialViewState}
-      onViewStateChange={({viewState}) => {
+      onViewStateChange={({ viewState }) => {
         hexHandleResize(viewState);
       }}
       getTooltip={getTooltip}

--- a/website/src/components/explorer/useHex.ts
+++ b/website/src/components/explorer/useHex.ts
@@ -8,28 +8,28 @@ import { throttle } from "./utils";
 import { PathStyleExtension } from "@deck.gl/extensions";
 
 export type OurViewState = {
-    width: number;
-    height: number;
+  width: number;
+  height: number;
 } & MapViewState;
 
 function adjustToRange(value: number, min: number, max: number): number {
-    const range = max - min;
-    return ((((value - min) % range) + range) % range) + min;
+  const range = max - min;
+  return ((((value - min) % range) + range) % range) + min;
 }
 
 function adjustLongitude(longitude: number): number {
-    return adjustToRange(longitude, -180, 180);
+  return adjustToRange(longitude, -180, 180);
 }
 
 type Bounds = {
-    minLat: number;
-    minLon: number;
-    maxLat: number;
-    maxLon: number;
+  minLat: number;
+  minLon: number;
+  maxLat: number;
+  maxLon: number;
 };
 
 const getVisibleBounds = (viewState: OurViewState) => {
-    try{
+  try {
     const viewport = new WebMercatorViewport(viewState);
     const { width, height } = viewState;
 
@@ -42,216 +42,220 @@ const getVisibleBounds = (viewState: OurViewState) => {
     const maxLon = bottomRight[0];
 
     return {
-        minLat,
-        minLon,
-        maxLat,
-        maxLon,
+      minLat,
+      minLon,
+      maxLat,
+      maxLon,
     } as Bounds;
-} catch (e) {
+  } catch (e) {
     console.error("Problem", e);
     return {
-        minLat: -1,
-        minLon: -1,
-        maxLat: 1,
-        maxLon: 1,
+      minLat: -1,
+      minLon: -1,
+      maxLat: 1,
+      maxLon: 1,
     } as Bounds;
-}
+  }
 };
 
 const splitPolygon = ({ minLat, minLon, maxLat, maxLon }: Bounds) =>
-    splitLongitudeRange(minLon, maxLon).map(([minLon, maxLon]) => ({
-        minLat,
-        minLon,
-        maxLat,
-        maxLon,
-    }));
+  splitLongitudeRange(minLon, maxLon).map(([minLon, maxLon]) => ({
+    minLat,
+    minLon,
+    maxLat,
+    maxLon,
+  }));
 
 function splitLongitudeRange(
-    minLon: number,
-    maxLon: number
+  minLon: number,
+  maxLon: number,
 ): [number, number][] {
-    const result: [number, number][] = [];
+  const result: [number, number][] = [];
 
-    let curPos = minLon;
+  let curPos = minLon;
 
-    const adjustedMax = adjustLongitude(maxLon);
+  const adjustedMax = adjustLongitude(maxLon);
 
-    while (curPos < maxLon) {
-        const normalized = adjustLongitude(curPos);
-        const next = normalized < 0 ? 0 : 180;
-        curPos = curPos + next - normalized;
-        if (curPos > maxLon) {
-            result.push([normalized, adjustedMax]);
-        } else {
-            result.push([normalized, next]);
-        }
+  while (curPos < maxLon) {
+    const normalized = adjustLongitude(curPos);
+    const next = normalized < 0 ? 0 : 180;
+    curPos = curPos + next - normalized;
+    if (curPos > maxLon) {
+      result.push([normalized, adjustedMax]);
+    } else {
+      result.push([normalized, next]);
     }
+  }
 
-    return result;
+  return result;
 }
 
 const boundsToPolygon = ({ minLat, minLon, maxLat, maxLon }: Bounds) => [
-    [minLon, minLat],
-    [maxLon, minLat],
-    [maxLon, maxLat],
-    [minLon, maxLat],
-    [minLon, minLat],
+  [minLon, minLat],
+  [maxLon, minLat],
+  [maxLon, maxLat],
+  [minLon, maxLat],
+  [minLon, minLat],
 ];
 
 export const ZOOM_TO_RESOLUTION: Record<number, number> = {
-    0: 0,
-    1: 0,
-    2: 1,
-    3: 2,
-    4: 2,
-    5: 3,
-    6: 4,
-    7: 5,
-    8: 5,
-    9: 6,
-    10: 6,
-    11: 7,
-    12: 8,
-    13: 9,
-    14: 10,
-    15: 11,
-    16: 11,
-    17: 12,
-    18: 12,
-    19: 13,
-    20: 14,
-    21: 15,
+  0: 0,
+  1: 0,
+  2: 1,
+  3: 2,
+  4: 2,
+  5: 3,
+  6: 4,
+  7: 5,
+  8: 5,
+  9: 6,
+  10: 6,
+  11: 7,
+  12: 8,
+  13: 9,
+  14: 10,
+  15: 11,
+  16: 11,
+  17: 12,
+  18: 12,
+  19: 13,
+  20: 14,
+  21: 15,
 };
 
-export const RESOLUTION_TO_ZOOM: Record<number, number> = Object.entries(ZOOM_TO_RESOLUTION).reduce((acc, [k, v]) => ({ ...acc, [v]: +k }), {});
+export const RESOLUTION_TO_ZOOM: Record<number, number> = Object.entries(
+  ZOOM_TO_RESOLUTION,
+).reduce((acc, [k, v]) => ({ ...acc, [v]: +k }), {});
 
 const getHexagons = (bounds: Bounds, resolution: number) => {
-    if (resolution > 15){
-        return [];}
+  if (resolution > 15) {
+    return [];
+  }
 
-    const all_bounds = splitPolygon(bounds);
+  const all_bounds = splitPolygon(bounds);
 
-    const polygons = all_bounds.map(boundsToPolygon);
+  const polygons = all_bounds.map(boundsToPolygon);
 
-    const hexagons = [
-        ...new Set(
-            polygons.flatMap((polygon) =>
-                polygonToCells(polygon, resolution, true)
-            )
-        ),
-    ];
-    return hexagons
-}
+  const hexagons = [
+    ...new Set(
+      polygons.flatMap((polygon) => polygonToCells(polygon, resolution, true)),
+    ),
+  ];
+  return hexagons;
+};
 
 export interface UseHexProps {
-    resolutionFrozen: boolean;
-    addSelectedHexes: (hexes: string[]) => void;
+  resolutionFrozen: boolean;
+  addSelectedHexes: (hexes: string[]) => void;
 }
 
 export const useHex = ({ resolutionFrozen, addSelectedHexes }: UseHexProps) => {
-    const [hexagons, setHexagons] = useState<string[]>([]);
-    const [hexagons1, setHexagons1] = useState<string[]>([]);
-    const [hexagons2, setHexagons2] = useState<string[]>([]);
-    const [resolution, setResolution] = useState<number>(0);
-    const [hexLayers, setHexLayers] = useState<H3HexagonLayer<string>[] | null>(
-        null
-    );
+  const [hexagons, setHexagons] = useState<string[]>([]);
+  const [hexagons1, setHexagons1] = useState<string[]>([]);
+  const [hexagons2, setHexagons2] = useState<string[]>([]);
+  const [resolution, setResolution] = useState<number>(0);
+  const [hexLayers, setHexLayers] = useState<H3HexagonLayer<string>[] | null>(
+    null,
+  );
 
-    useEffect(() => {
-        setHexLayers([
+  useEffect(() => {
+    setHexLayers([
+      new H3HexagonLayer<string>({
+        id: "H3HexagonLayer",
+        extruded: false,
+        getHexagon: (d: string) => d,
+        getFillColor: [0, 0, 0, 1],
+        getLineColor: [0, 0, 0],
+        getLineWidth: 3,
+        lineWidthMinPixels: 3,
+        highPrecision: true,
+        lineWidthUnits: "pixels",
+        elevationScale: 20,
+        pickable: true,
+        stroked: true,
+        filled: true,
+        data: hexagons,
+        wrapLongitude: true,
+        onClick: (info: PickingInfo<string>) => {
+          if (info.object) {
+            addSelectedHexes([info.object]);
+          }
+        },
+      }),
+      ...(hexagons1.length
+        ? [
             new H3HexagonLayer<string>({
-                id: "H3HexagonLayer",
-                extruded: false,
-                getHexagon: (d: string) => d,
-                getFillColor: [0, 0, 0, 1],
-                getLineColor: [0, 0, 0],
-                  getLineWidth: 3,
-                  lineWidthMinPixels: 3,
-                  highPrecision: true,
-                lineWidthUnits: "pixels",
-                elevationScale: 20,
-                pickable: true,
-                stroked: true,
-                filled: true,
-                data: hexagons,
-                wrapLongitude: true,
-                onClick: (info: PickingInfo<string>) => {
-                    if (info.object) {
-                        addSelectedHexes([info.object]);
-                    }
-                }
+              id: "H3HexagonLayer1",
+              extruded: false,
+              getHexagon: (d: string) => d,
+              getFillColor: [0, 0, 0, 1],
+              getLineColor: [50, 50, 50, 100],
+              getLineWidth: 2,
+              lineWidthMinPixels: 2,
+              highPrecision: true,
+              lineWidthUnits: "pixels",
+              elevationScale: 20,
+              pickable: false,
+              stroked: true,
+              filled: true,
+              data: hexagons1,
+              wrapLongitude: true,
+              // @ts-expect-error
+              getDashArray: [5, 1],
+              dashJustified: true,
+              dashGapPickable: true,
+              extensions: [new PathStyleExtension({ dash: true })],
             }),
-            ...(hexagons1.length ? [
-                new H3HexagonLayer<string>({
-                    id: "H3HexagonLayer1",
-                    extruded: false,
-                    getHexagon: (d: string) => d,
-                    getFillColor: [0, 0, 0, 1],
-                    getLineColor: [50, 50, 50, 100],
-                      getLineWidth: 2,
-                      lineWidthMinPixels: 2,
-                      highPrecision: true,
-                    lineWidthUnits: "pixels",
-                    elevationScale: 20,
-                    pickable: false,
-                    stroked: true,
-                    filled: true,
-                    data: hexagons1,
-                    wrapLongitude: true,
-                    // @ts-expect-error
-                    getDashArray: [5, 1],
-                    dashJustified: true,
-                    dashGapPickable: true,
-                    extensions: [new PathStyleExtension({ dash: true })],
-                })
-            ] : []),
-            ...(hexagons2.length ? [
-                new H3HexagonLayer<string>({
-                    id: "H3HexagonLayer2",
-                    extruded: false,
-                    getHexagon: (d: string) => d,
-                    getFillColor: [0, 0, 0, 1],
-                    getLineColor: [100, 100, 100, 100],
-                      getLineWidth: 1,
-                      lineWidthMinPixels: 1,
-                      highPrecision: true,
-                    lineWidthUnits: "pixels",
-                    elevationScale: 20,
-                    pickable: false,
-                    stroked: true,
-                    filled: true,
-                    data: hexagons2,
-                    wrapLongitude: true,
-                    // @ts-expect-error
-                    getDashArray: [5, 5],
-                    dashJustified: true,
-                    dashGapPickable: true,
-                    extensions: [new PathStyleExtension({ dash: true })],
-                })
-            ] : []),
-        ]
-        );
-    }, [addSelectedHexes, hexagons, hexagons1, hexagons2])
+          ]
+        : []),
+      ...(hexagons2.length
+        ? [
+            new H3HexagonLayer<string>({
+              id: "H3HexagonLayer2",
+              extruded: false,
+              getHexagon: (d: string) => d,
+              getFillColor: [0, 0, 0, 1],
+              getLineColor: [100, 100, 100, 100],
+              getLineWidth: 1,
+              lineWidthMinPixels: 1,
+              highPrecision: true,
+              lineWidthUnits: "pixels",
+              elevationScale: 20,
+              pickable: false,
+              stroked: true,
+              filled: true,
+              data: hexagons2,
+              wrapLongitude: true,
+              // @ts-expect-error
+              getDashArray: [5, 5],
+              dashJustified: true,
+              dashGapPickable: true,
+              extensions: [new PathStyleExtension({ dash: true })],
+            }),
+          ]
+        : []),
+    ]);
+  }, [addSelectedHexes, hexagons, hexagons1, hexagons2]);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const handleResize = useCallback(
-        throttle((viewState: OurViewState) => {
-            if (resolutionFrozen) {
-                return
-            }
-            const zoom = viewState.zoom;
-            const resolution = Math.max(0, ZOOM_TO_RESOLUTION[Math.round(zoom)] - 1);
-            setResolution(resolution)
-            const bounds = getVisibleBounds(viewState);
-            const hexagons = getHexagons(bounds, resolution);
-            setHexagons(hexagons);
-            const hexagons1 = getHexagons(bounds, resolution + 1);
-            setHexagons1(hexagons1);
-            const hexagons2 = getHexagons(bounds, resolution + 2);
-            setHexagons2(hexagons2);
-        }, 200),
-        [setHexagons, setHexagons1, setHexagons2, setResolution, resolutionFrozen]
-    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleResize = useCallback(
+    throttle((viewState: OurViewState) => {
+      if (resolutionFrozen) {
+        return;
+      }
+      const zoom = viewState.zoom;
+      const resolution = Math.max(0, ZOOM_TO_RESOLUTION[Math.round(zoom)] - 1);
+      setResolution(resolution);
+      const bounds = getVisibleBounds(viewState);
+      const hexagons = getHexagons(bounds, resolution);
+      setHexagons(hexagons);
+      const hexagons1 = getHexagons(bounds, resolution + 1);
+      setHexagons1(hexagons1);
+      const hexagons2 = getHexagons(bounds, resolution + 2);
+      setHexagons2(hexagons2);
+    }, 200),
+    [setHexagons, setHexagons1, setHexagons2, setResolution, resolutionFrozen],
+  );
 
-    return { handleResize, hexLayers, resolution };
-}
+  return { handleResize, hexLayers, resolution };
+};

--- a/website/src/components/explorer/useHex.ts
+++ b/website/src/components/explorer/useHex.ts
@@ -29,33 +29,23 @@ type Bounds = {
 };
 
 const getVisibleBounds = (viewState: OurViewState) => {
-  try {
-    const viewport = new WebMercatorViewport(viewState);
-    const { width, height } = viewState;
+  const viewport = new WebMercatorViewport(viewState);
+  const { width, height } = viewState;
 
-    const topLeft = viewport.unproject([0, 0]);
-    const bottomRight = viewport.unproject([width, height]);
+  const topLeft = viewport.unproject([0, 0]);
+  const bottomRight = viewport.unproject([width, height]);
 
-    const minLat = bottomRight[1];
-    const minLon = topLeft[0];
-    const maxLat = topLeft[1];
-    const maxLon = bottomRight[0];
+  const minLat = bottomRight[1];
+  const minLon = topLeft[0];
+  const maxLat = topLeft[1];
+  const maxLon = bottomRight[0];
 
-    return {
-      minLat,
-      minLon,
-      maxLat,
-      maxLon,
-    } as Bounds;
-  } catch (e) {
-    console.error("Problem", e);
-    return {
-      minLat: -1,
-      minLon: -1,
-      maxLat: 1,
-      maxLon: 1,
-    } as Bounds;
-  }
+  return {
+    minLat,
+    minLon,
+    maxLat,
+    maxLon,
+  } as Bounds;
 };
 
 const splitPolygon = ({ minLat, minLon, maxLat, maxLon }: Bounds) =>

--- a/website/src/components/explorer/useHex.ts
+++ b/website/src/components/explorer/useHex.ts
@@ -1,0 +1,197 @@
+// From: https://github.com/JosephChotard/h3-viewer/blob/21da63f9c5056296a6fe3a8f1ab5fbe8afebb754/src/useHex.ts
+// Under MIT License
+import { H3HexagonLayer } from "@deck.gl/geo-layers";
+import { MapViewState, PickingInfo, WebMercatorViewport } from "deck.gl";
+import { polygonToCells } from "h3-js";
+import { useCallback, useEffect, useState } from "react";
+import { throttle } from "./utils";
+
+export type OurViewState = {
+    width: number;
+    height: number;
+} & MapViewState;
+
+function adjustToRange(value: number, min: number, max: number): number {
+    const range = max - min;
+    return ((((value - min) % range) + range) % range) + min;
+}
+
+function adjustLongitude(longitude: number): number {
+    return adjustToRange(longitude, -180, 180);
+}
+
+type Bounds = {
+    minLat: number;
+    minLon: number;
+    maxLat: number;
+    maxLon: number;
+};
+
+const getVisibleBounds = (viewState: OurViewState) => {
+    try{
+    const viewport = new WebMercatorViewport(viewState);
+    const { width, height } = viewState;
+
+    const topLeft = viewport.unproject([0, 0]);
+    const bottomRight = viewport.unproject([width, height]);
+
+    const minLat = bottomRight[1];
+    const minLon = topLeft[0];
+    const maxLat = topLeft[1];
+    const maxLon = bottomRight[0];
+
+    return {
+        minLat,
+        minLon,
+        maxLat,
+        maxLon,
+    } as Bounds;
+} catch (e) {
+    console.error("Problem", e);
+    return {
+        minLat: -1,
+        minLon: -1,
+        maxLat: 1,
+        maxLon: 1,
+    } as Bounds;
+}
+};
+
+const splitPolygon = ({ minLat, minLon, maxLat, maxLon }: Bounds) =>
+    splitLongitudeRange(minLon, maxLon).map(([minLon, maxLon]) => ({
+        minLat,
+        minLon,
+        maxLat,
+        maxLon,
+    }));
+
+function splitLongitudeRange(
+    minLon: number,
+    maxLon: number
+): [number, number][] {
+    const result: [number, number][] = [];
+
+    let curPos = minLon;
+
+    const adjustedMax = adjustLongitude(maxLon);
+
+    while (curPos < maxLon) {
+        const normalized = adjustLongitude(curPos);
+        const next = normalized < 0 ? 0 : 180;
+        curPos = curPos + next - normalized;
+        if (curPos > maxLon) {
+            result.push([normalized, adjustedMax]);
+        } else {
+            result.push([normalized, next]);
+        }
+    }
+
+    return result;
+}
+
+const boundsToPolygon = ({ minLat, minLon, maxLat, maxLon }: Bounds) => [
+    [minLon, minLat],
+    [maxLon, minLat],
+    [maxLon, maxLat],
+    [minLon, maxLat],
+    [minLon, minLat],
+];
+
+export const ZOOM_TO_RESOLUTION: Record<number, number> = {
+    0: 0,
+    1: 0,
+    2: 1,
+    3: 2,
+    4: 2,
+    5: 3,
+    6: 4,
+    7: 5,
+    8: 5,
+    9: 6,
+    10: 6,
+    11: 7,
+    12: 8,
+    13: 9,
+    14: 10,
+    15: 11,
+    16: 11,
+    17: 12,
+    18: 12,
+    19: 13,
+    20: 14,
+    21: 15,
+};
+
+export const RESOLUTION_TO_ZOOM: Record<number, number> = Object.entries(ZOOM_TO_RESOLUTION).reduce((acc, [k, v]) => ({ ...acc, [v]: +k }), {});
+
+const getHexagons = (bounds: Bounds, resolution: number) => {
+    const all_bounds = splitPolygon(bounds);
+
+    const polygons = all_bounds.map(boundsToPolygon);
+
+    const hexagons = [
+        ...new Set(
+            polygons.flatMap((polygon) =>
+                polygonToCells(polygon, resolution, true)
+            )
+        ),
+    ];
+    return hexagons
+}
+
+export interface UseHexProps {
+    resolutionFrozen: boolean;
+    addSelectedHexes: (hexes: string[]) => void;
+}
+
+export const useHex = ({ resolutionFrozen, addSelectedHexes }: UseHexProps) => {
+    const [hexagons, setHexagons] = useState<string[]>([]);
+    const [resolution, setResolution] = useState<number>(0);
+    const [hexLayer, setHexLayer] = useState<H3HexagonLayer<string> | null>(
+        null
+    );
+
+    useEffect(() => {
+        setHexLayer(
+            new H3HexagonLayer<string>({
+                id: "H3HexagonLayer",
+                extruded: false,
+                getHexagon: (d: string) => d,
+                getFillColor: [0, 0, 0, 1],
+                getLineColor: [150, 150, 150, 100],
+                getLineWidth: 2,
+                lineWidthUnits: "pixels",
+                elevationScale: 20,
+                pickable: true,
+                data: hexagons,
+                wrapLongitude: true,
+                onClick: (info: PickingInfo<string>) => {
+                    if (info.object) {
+                        addSelectedHexes([info.object]);
+                    }
+                }
+            })
+        );
+    }, [addSelectedHexes, hexagons])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const handleResize = useCallback(
+        throttle((viewState: OurViewState) => {
+            if (resolutionFrozen) {
+                return
+            }
+            const zoom = viewState.zoom;
+            const resolution = ZOOM_TO_RESOLUTION[Math.round(zoom)];
+            setResolution(resolution)
+            console.log("viewState", viewState, resolution)
+            const bounds = getVisibleBounds(viewState);
+            console.log(bounds);
+            const hexagons = getHexagons(bounds, resolution);
+            console.log(hexagons);
+            setHexagons(hexagons);
+        }, 200),
+        [setHexagons, setResolution, resolutionFrozen]
+    );
+
+    return { handleResize, hexLayer, resolution };
+}

--- a/website/src/components/explorer/utils.ts
+++ b/website/src/components/explorer/utils.ts
@@ -1,0 +1,111 @@
+// From: https://github.com/JosephChotard/h3-viewer/blob/21da63f9c5056296a6fe3a8f1ab5fbe8afebb754/src/utils.ts
+// Under MIT License
+import {
+    cellToLatLng,
+    getHexagonAreaAvg,
+    getResolution,
+    isValidCell,
+    UNITS
+} from "h3-js";
+
+export const isNotNull = <T>(value: T): value is NonNullable<T> => {
+    return value != null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export const throttle = (fn: Function, wait: number = 300) => {
+    let inThrottle: boolean,
+        lastFn: ReturnType<typeof setTimeout>,
+        lastTime: number;
+    return function (this: unknown, ...args: unknown[]) {
+        if (!inThrottle) {
+            fn.apply(this, args);
+            lastTime = Date.now();
+            inThrottle = true;
+        } else {
+            clearTimeout(lastFn);
+            lastFn = setTimeout(() => {
+                if (Date.now() - lastTime >= wait) {
+                    fn.apply(this, args);
+                    lastTime = Date.now();
+                }
+            }, Math.max(wait - (Date.now() - lastTime), 0));
+        }
+    };
+};
+
+export const getH3Center = (hexes: string[]) => {
+    const latLngs = hexes.map(cellToLatLng);
+    const lats = latLngs.map(([lat]) => lat);
+    const lngs = latLngs.map(([, lng]) => lng);
+    const centerLat = lats.reduce((sum, lat) => sum + lat, 0) / lats.length;
+    const centerLng = lngs.reduce((sum, lng) => sum + lng, 0) / lngs.length;
+    return [centerLat, centerLng];
+};
+
+export function split64BitNumber(numberStr: string): [number, number] {
+    const bigIntNumber = BigInt(numberStr);
+    const mask32Bits = BigInt(0xffffffff);
+
+    const lower = Number(bigIntNumber & mask32Bits);
+    const upper = Number((bigIntNumber >> BigInt(32)) & mask32Bits);
+
+    return [lower, upper];
+}
+
+export function isBigIntString(str: string): boolean {
+    try {
+        BigInt(str);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function toCells(str: string): (string | undefined)[] | undefined {
+    str = str.trim();
+    if (isValidCell(str)) {
+        return [str];
+    }
+    if (isBigIntString(str)) {
+        const bigint = BigInt(str);
+        const index = bigint.toString(16);
+        if (isValidCell(index)) {
+            return [index];
+        }
+    }
+    // Check if json
+    try {
+        const parsed = JSON.parse(str);
+        if (Array.isArray(parsed)) {
+            return parsed.flatMap(toCells);
+        }
+    } catch {
+        // Do nothing
+    }
+    if (str.includes(",")) {
+        return str.split(",").flatMap(toCells);
+    }
+    if (str.startsWith("[")) {
+        return toCells(str.slice(1));
+    }
+    if (str.endsWith("]")) {
+        return toCells(str.slice(0, -1));
+    }
+    
+    return undefined;
+}
+
+export const getMinResolution = (hexes: string[]) => {
+    const resolutions = hexes.map(getResolution);
+    return Math.min(...resolutions);
+};
+
+const MAX_PRECISION = 15;
+const MAX_CELLS_PER_AREA = 5_000;
+
+const H3_AREA: number[] = [...Array(MAX_PRECISION).keys()].map((res) => {
+    return MAX_CELLS_PER_AREA * getHexagonAreaAvg(res, UNITS.m2);
+});
+
+export const getMaximumAcceptableResolution = (area: number) => H3_AREA.findIndex((value) => value < area) - 1

--- a/website/src/components/explorer/utils.ts
+++ b/website/src/components/explorer/utils.ts
@@ -1,111 +1,115 @@
 // From: https://github.com/JosephChotard/h3-viewer/blob/21da63f9c5056296a6fe3a8f1ab5fbe8afebb754/src/utils.ts
 // Under MIT License
 import {
-    cellToLatLng,
-    getHexagonAreaAvg,
-    getResolution,
-    isValidCell,
-    UNITS
+  cellToLatLng,
+  getHexagonAreaAvg,
+  getResolution,
+  isValidCell,
+  UNITS,
 } from "h3-js";
 
 export const isNotNull = <T>(value: T): value is NonNullable<T> => {
-    return value != null;
+  return value != null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export const throttle = (fn: Function, wait: number = 300) => {
-    let inThrottle: boolean,
-        lastFn: ReturnType<typeof setTimeout>,
-        lastTime: number;
-    return function (this: unknown, ...args: unknown[]) {
-        if (!inThrottle) {
+  let inThrottle: boolean,
+    lastFn: ReturnType<typeof setTimeout>,
+    lastTime: number;
+  return function (this: unknown, ...args: unknown[]) {
+    if (!inThrottle) {
+      fn.apply(this, args);
+      lastTime = Date.now();
+      inThrottle = true;
+    } else {
+      clearTimeout(lastFn);
+      lastFn = setTimeout(
+        () => {
+          if (Date.now() - lastTime >= wait) {
             fn.apply(this, args);
             lastTime = Date.now();
-            inThrottle = true;
-        } else {
-            clearTimeout(lastFn);
-            lastFn = setTimeout(() => {
-                if (Date.now() - lastTime >= wait) {
-                    fn.apply(this, args);
-                    lastTime = Date.now();
-                }
-            }, Math.max(wait - (Date.now() - lastTime), 0));
-        }
-    };
+          }
+        },
+        Math.max(wait - (Date.now() - lastTime), 0),
+      );
+    }
+  };
 };
 
 export const getH3Center = (hexes: string[]) => {
-    const latLngs = hexes.map(cellToLatLng);
-    const lats = latLngs.map(([lat]) => lat);
-    const lngs = latLngs.map(([, lng]) => lng);
-    const centerLat = lats.reduce((sum, lat) => sum + lat, 0) / lats.length;
-    const centerLng = lngs.reduce((sum, lng) => sum + lng, 0) / lngs.length;
-    return [centerLat, centerLng];
+  const latLngs = hexes.map(cellToLatLng);
+  const lats = latLngs.map(([lat]) => lat);
+  const lngs = latLngs.map(([, lng]) => lng);
+  const centerLat = lats.reduce((sum, lat) => sum + lat, 0) / lats.length;
+  const centerLng = lngs.reduce((sum, lng) => sum + lng, 0) / lngs.length;
+  return [centerLat, centerLng];
 };
 
 export function split64BitNumber(numberStr: string): [number, number] {
-    const bigIntNumber = BigInt(numberStr);
-    const mask32Bits = BigInt(0xffffffff);
+  const bigIntNumber = BigInt(numberStr);
+  const mask32Bits = BigInt(0xffffffff);
 
-    const lower = Number(bigIntNumber & mask32Bits);
-    const upper = Number((bigIntNumber >> BigInt(32)) & mask32Bits);
+  const lower = Number(bigIntNumber & mask32Bits);
+  const upper = Number((bigIntNumber >> BigInt(32)) & mask32Bits);
 
-    return [lower, upper];
+  return [lower, upper];
 }
 
 export function isBigIntString(str: string): boolean {
-    try {
-        BigInt(str);
-        return true;
-    } catch {
-        return false;
-    }
+  try {
+    BigInt(str);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function toCells(str: string): (string | undefined)[] | undefined {
-    str = str.trim();
-    if (isValidCell(str)) {
-        return [str];
+  str = str.trim();
+  if (isValidCell(str)) {
+    return [str];
+  }
+  if (isBigIntString(str)) {
+    const bigint = BigInt(str);
+    const index = bigint.toString(16);
+    if (isValidCell(index)) {
+      return [index];
     }
-    if (isBigIntString(str)) {
-        const bigint = BigInt(str);
-        const index = bigint.toString(16);
-        if (isValidCell(index)) {
-            return [index];
-        }
+  }
+  // Check if json
+  try {
+    const parsed = JSON.parse(str);
+    if (Array.isArray(parsed)) {
+      return parsed.flatMap(toCells);
     }
-    // Check if json
-    try {
-        const parsed = JSON.parse(str);
-        if (Array.isArray(parsed)) {
-            return parsed.flatMap(toCells);
-        }
-    } catch {
-        // Do nothing
-    }
-    if (str.includes(",")) {
-        return str.split(",").flatMap(toCells);
-    }
-    if (str.startsWith("[")) {
-        return toCells(str.slice(1));
-    }
-    if (str.endsWith("]")) {
-        return toCells(str.slice(0, -1));
-    }
-    
-    return undefined;
+  } catch {
+    // Do nothing
+  }
+  if (str.includes(",")) {
+    return str.split(",").flatMap(toCells);
+  }
+  if (str.startsWith("[")) {
+    return toCells(str.slice(1));
+  }
+  if (str.endsWith("]")) {
+    return toCells(str.slice(0, -1));
+  }
+
+  return undefined;
 }
 
 export const getMinResolution = (hexes: string[]) => {
-    const resolutions = hexes.map(getResolution);
-    return Math.min(...resolutions);
+  const resolutions = hexes.map(getResolution);
+  return Math.min(...resolutions);
 };
 
 const MAX_PRECISION = 15;
 const MAX_CELLS_PER_AREA = 5_000;
 
 const H3_AREA: number[] = [...Array(MAX_PRECISION).keys()].map((res) => {
-    return MAX_CELLS_PER_AREA * getHexagonAreaAvg(res, UNITS.m2);
+  return MAX_CELLS_PER_AREA * getHexagonAreaAvg(res, UNITS.m2);
 });
 
-export const getMaximumAcceptableResolution = (area: number) => H3_AREA.findIndex((value) => value < area) - 1
+export const getMaximumAcceptableResolution = (area: number) =>
+  H3_AREA.findIndex((value) => value < area) - 1;


### PR DESCRIPTION
<img width="1491" alt="Screenshot 2025-03-09 at 11 02 01 AM" src="https://github.com/user-attachments/assets/a44021f7-cf96-4a1f-a89c-74c687395674" />
I adapted the useHex code from @JosephChotard to the website's main page. This enables a better exploration experience since you can see how the grid changes at different resolutions. I kept the website's practice of showing multiple grid resolutions since I felt that was helpful for teaching purposes.