### PR TITLE
Add new dart bindings

### DIFF
--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -36,6 +36,7 @@ As a C library, bindings can be made to call H3 functions from different program
 ## Dart 
 
 - [festelo/h3_flutter](https://github.com/festelo/h3_flutter)
+- [codewithsam110g/h3_flutter_plus](https://github.com/codewithsam110g/h3_flutter_bindings)
 
 ## Databricks
 


### PR DESCRIPTION
This PR adds h3_flutter_plus, a new Dart/Flutter bindings package for H3, which is a fork of the original h3_flutter by Festelo. It is actively maintained and updated to support the latest H3 v4 API.