### PR TITLE
Fix valid index bug in getIndexDigit

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+init: purge
+    mkdir build
+
+build:
+    cd build; cmake -DCMAKE_BUILD_TYPE=Release ..; make
+
+purge:
+    rm -rf build
+
+test: build
+    # ./build/bin/testCreateCell
+    # just test-fast
+    ./build/bin/h3 getIndexDigit -c 5 -r 15
+
+test-fast: build
+    cd build; make test-fast
+
+test-slow: build
+    cd build; make test


### PR DESCRIPTION
The following logic in the `getIndexDigit` CLI doesn't correctly identify invalid cells/vertexes/edges:

https://github.com/uber/h3/blob/491eeadeeb3f3689413257f0087dc9330f5fe6ff/src/apps/filters/h3.c#L312-L317

This is because the `isValid*` functions return a boolean, not an `H3Error` code.