### PR TITLE
feat: add E_INDEX_INVALID

### DIFF
--- a/src/apps/filters/h3.c
+++ b/src/apps/filters/h3.c
@@ -262,7 +262,7 @@ SUBCOMMAND(getResolution, "Extracts the resolution (0 - 15) from the H3 cell") {
     Arg *args[] = {&getResolutionArg, &helpArg, &cellArg};
     PARSE_SUBCOMMAND(argc, argv, args);
     if (!H3_EXPORT(isValidIndex)(cell)) {
-        return E_DOMAIN;  // TODO: maybe create a new E_INDEX_INVALID error?
+        return E_INDEX_INVALID;
     }
     // If we got here, we can use `getResolution` safely, as this is one of the
     // few functions that doesn't do any error handling (for some reason? I
@@ -278,7 +278,7 @@ SUBCOMMAND(getBaseCellNumber,
     Arg *args[] = {&getBaseCellNumberArg, &helpArg, &cellArg};
     PARSE_SUBCOMMAND(argc, argv, args);
     if (!H3_EXPORT(isValidIndex)(cell)) {
-        return E_DOMAIN;  // TODO: maybe create a new E_INDEX_INVALID error?
+        return E_INDEX_INVALID;
     }
     // If we got here, we can use `getResolution` safely, as this is one of the
     // few functions that doesn't do any error handling (for some reason? I
@@ -301,7 +301,7 @@ SUBCOMMAND(getIndexDigit,
     Arg *args[] = {&getIndexDigitArg, &helpArg, &cellArg, &digitArg};
     PARSE_SUBCOMMAND(argc, argv, args);
     if (!H3_EXPORT(isValidIndex)(cell)) {
-        return E_DOMAIN;  // TODO: maybe create a new E_INDEX_INVALID error?
+        return E_INDEX_INVALID;
     }
     int value;
     H3Error err = H3_EXPORT(getIndexDigit)(cell, res, &value);
@@ -376,7 +376,7 @@ SUBCOMMAND(isResClassIII,
     Arg *args[] = {&isResClassIIIArg, &helpArg, &cellArg, &formatArg};
     PARSE_SUBCOMMAND(argc, argv, args);
     if (!H3_EXPORT(isValidIndex)(cell)) {
-        return E_DOMAIN;  // TODO: maybe create a new E_INDEX_INVALID error?
+        return E_INDEX_INVALID;
     }
     // If we got here, we can use `getResolution` safely, as this is one of the
     // few functions that doesn't do any error handling (for some reason? I
@@ -401,7 +401,7 @@ SUBCOMMAND(
     Arg *args[] = {&isPentagonArg, &helpArg, &cellArg, &formatArg};
     PARSE_SUBCOMMAND(argc, argv, args);
     if (!H3_EXPORT(isValidIndex)(cell)) {
-        return E_DOMAIN;  // TODO: maybe create a new E_INDEX_INVALID error?
+        return E_INDEX_INVALID;
     }
     // If we got here, we can use `getResolution` safely, as this is one of the
     // few functions that doesn't do any error handling (for some reason? I

--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -80,13 +80,13 @@ typedef uint32_t H3Error;
 
 typedef enum {
     E_SUCCESS = 0,  // Success (no error)
-    E_FAILED =
-        1,  // The operation failed but a more specific error is not available
-    E_DOMAIN = 2,  // Argument was outside of acceptable range (when a more
-                   // specific error code is not available)
-    E_LATLNG_DOMAIN =
-        3,  // Latitude or longitude arguments were outside of acceptable range
-    E_RES_DOMAIN = 4,    // Resolution argument was outside of acceptable range
+    E_FAILED = 1,   // The operation failed but a more specific error is not
+                    // available
+    E_DOMAIN = 2,   // Argument was outside the acceptable range (when a more
+                    // specific error code is not available)
+    E_LATLNG_DOMAIN = 3,  // Latitude or longitude arguments were outside the
+                          // acceptable range
+    E_RES_DOMAIN = 4,    // Resolution argument was outside the acceptable range
     E_CELL_INVALID = 5,  // `H3Index` cell argument was not valid
     E_DIR_EDGE_INVALID = 6,  // `H3Index` directed edge argument was not valid
     E_UNDIR_EDGE_INVALID =
@@ -99,9 +99,10 @@ typedef enum {
     E_NOT_NEIGHBORS = 11,    // `H3Index` cell arguments were not neighbors
     E_RES_MISMATCH =
         12,  // `H3Index` cell arguments had incompatible resolutions
-    E_MEMORY_ALLOC = 13,   // Necessary memory allocation failed
-    E_MEMORY_BOUNDS = 14,  // Bounds of provided memory were not large enough
-    E_OPTION_INVALID = 15  // Mode or flags argument was not valid.
+    E_MEMORY_ALLOC = 13,    // Necessary memory allocation failed
+    E_MEMORY_BOUNDS = 14,   // Bounds of provided memory were not large enough
+    E_OPTION_INVALID = 15,  // Mode or flags argument was not valid
+    E_INDEX_INVALID = 16    // `H3Index` argument was not valid
 } H3ErrorCodes;
 
 /** @defgroup describeH3Error describeH3Error

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -54,7 +54,8 @@ static char *H3ErrorDescriptions[] = {
     /* E_RES_MISMATCH */ "Cell arguments had incompatible resolutions",
     /* E_MEMORY_ALLOC */ "Memory allocation failed",
     /* E_MEMORY_BOUNDS */ "Bounds of provided memory were insufficient",
-    /* E_OPTION_INVALID */ "Mode or flags argument was not valid"};
+    /* E_OPTION_INVALID */ "Mode or flags argument was not valid",
+    /* E_INDEX_INVALID */ "Index argument was not valid"};
 
 /**
  * Returns the string describing the H3Error. This string is internally
@@ -65,11 +66,10 @@ static char *H3ErrorDescriptions[] = {
 const char *H3_EXPORT(describeH3Error)(H3Error err) {
     // err is always non-negative because it is an unsigned integer
     // TODO: Better way to bounds check here?
-    if (err <= 15) {
+    if (err <= 16) {
         return H3ErrorDescriptions[err];
-    } else {
-        return "Invalid error code";
     }
+    return "Invalid error code";
 }
 
 /**

--- a/tests/cli/getBaseCellNumber.txt
+++ b/tests/cli/getBaseCellNumber.txt
@@ -3,4 +3,4 @@ add_h3_cli_test(testCliGetBaseCellNumber "getBaseCellNumber -c 85283473fffffff"
 add_h3_cli_test(
     testCliGetBaseCellNumber_Bad
     "getBaseCellNumber -c 5 2>&1"
-    "Error 2: Argument was outside of acceptable range")
+    "Error 16: Index argument was not valid")

--- a/tests/cli/getIndexDigit.txt
+++ b/tests/cli/getIndexDigit.txt
@@ -5,4 +5,4 @@ add_h3_cli_test(
 add_h3_cli_test(
     test_bad_getIndexDigit
     "getIndexDigit -r 15 -c 5 2>&1"
-    "Error 2: Argument was outside of acceptable range")
+    "Error 16: Index argument was not valid")

--- a/tests/cli/getResolution.txt
+++ b/tests/cli/getResolution.txt
@@ -2,4 +2,4 @@ add_h3_cli_test(testCliGetResolution "getResolution -c 85283473fffffff" "5")
 add_h3_cli_test(
     testCliGetResolution_Bad
     "getResolution -c 5 2>&1"
-    "Error 2: Argument was outside of acceptable range")
+    "Error 16: Index argument was not valid")

--- a/tests/cli/isResClassIII.txt
+++ b/tests/cli/isResClassIII.txt
@@ -2,4 +2,4 @@ add_h3_cli_test(testCliIsResClassIII "isResClassIII -c 85283473fffffff" "true")
 add_h3_cli_test(
     testCliIsResClassIII_Bad
     "isResClassIII -c 5 2>&1"
-    "Error 2: Argument was outside of acceptable range")
+    "Error 16: Index argument was not valid")


### PR DESCRIPTION
Introduces `E_INDEX_INVALID` for cases where the argument can be any index, not necessarily a cell, dir edge, or vertex.
- Resolves #1044