### PR TITLE
upgrade fossa in CI to v3

### DIFF
--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install FOSSA
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
       - name: Test Website Build
         working-directory: website


### PR DESCRIPTION
See here for more on the update: https://github.com/fossas/fossa-cli/blob/master/docs/differences-from-v1.md#how-to-upgrade-to-fossa-3x

I noticed this having a deprecation warning in the CI logs