### PR TITLE
Add Foysal50x/h3-php to PHP bindings list

### DIFF
--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -92,7 +92,7 @@ As a C library, bindings can be made to call H3 functions from different program
 
 - [neatlife/php-h3](https://github.com/neatlife/php-h3)
 - [abler98/h3-php](https://github.com/abler98/h3-php)
-- [Foysal50x/h3-php](https://github.com/Foysal50x/h3-php)
+- [Foysal50x/h3-php](https://github.com/Foysal50x/h3-php) - It uses PHP's built-in FFI extension, Can be installed with composer, avoiding the need to compile C code, manage system dependencies
 
 ## PostgreSQL
 


### PR DESCRIPTION
This PR adds the h3-php library to the "Community Bindings" section of the bindings.md file. This will help PHP developers discover a community-supported binding for the H3 library.

This modern binding leverages PHP's FFI (Foreign Function Interface) binding with precompiled library to provide a bridge to the H3 C library. Unlike other bindings that require compiling a C extension, this package is installed entirely through Composer. This makes it an excellent choice for developers seeking a quick and easy setup, especially in containerized or managed environments where compiling extensions is difficult.


