### PR TITLE
website: support decimal cell input

### DIFF
--- a/website/src/components/explorer/details.jsx
+++ b/website/src/components/explorer/details.jsx
@@ -106,6 +106,7 @@ function ClickableH3IndexList({ hexes, setUserInput, showAll = true }) {
 
 export function SelectedHexDetails({
   setUserInput,
+  showCellId,
   splitUserInput,
   showNavigation = true,
   showDetails = true,
@@ -141,6 +142,12 @@ export function SelectedHexDetails({
     return (
       <p style={{ marginBottom: "0" }}>
         Lat./Lng.: <tt>{coords}</tt>
+        {showCellId ? (
+          <>
+            <br />
+            ID: <ClickableH3Index hex={hex} setUserInput={setUserInput} />
+          </>
+        ) : null}
         {showNavigation ? (
           <>
             <br />


### PR DESCRIPTION
The following can all be accepted as valid, in this order of preference:

`8539644bfffffff`
`0x8539644bfffffff`
`599988397393575935`

This is helpful when copying cell IDs out of e.g. big data systems where they are stored as integers. The system doesn't know this should be rendered as hexadecimal.