### PR TITLE
deploy website permissions

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 # This job installs dependencies, builds the website, and pushes it to `gh-pages`
 jobs:
   deploy-website:


### PR DESCRIPTION
As with the other repos, we need to provide additional permissions to the CI job to make it able to deploy the gh-pages branch:
https://github.com/uber/h3/actions/runs/20285927713/job/58259464608
See also https://github.com/uber/h3-py/pull/472