### PR TITLE
Bidirectional gridPathCells

### DIFF
--- a/src/apps/testapps/testGridPathCells.c
+++ b/src/apps/testapps/testGridPathCells.c
@@ -19,6 +19,7 @@
  *  usage: `testGridPathCells`
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,6 +29,20 @@
 #include "localij.h"
 #include "test.h"
 #include "utility.h"
+
+static void assertPathValid(H3Index start, H3Index end, const H3Index *path,
+                            int64_t size) {
+    t_assert(size > 0, "path size is positive");
+    t_assert(path[0] == start, "path starts with start index");
+    t_assert(path[size - 1] == end, "path ends with end index");
+
+    for (int64_t i = 1; i < size; i++) {
+        int isNeighbor;
+        t_assertSuccess(
+            H3_EXPORT(areNeighborCells)(path[i], path[i - 1], &isNeighbor));
+        t_assert(isNeighbor, "path is contiguous");
+    }
+}
 
 SUITE(gridPathCells) {
     TEST(gridPathCells_acrossMultipleFaces) {
@@ -40,15 +55,40 @@ SUITE(gridPathCells) {
                  "Line not computable across multiple icosa faces");
     }
 
-    TEST(gridPathCells_pentagon) {
+    TEST(gridPathCells_pentagonReverseInterpolation) {
         H3Index start = 0x820807fffffffff;
         H3Index end = 0x8208e7fffffffff;
 
         int64_t size;
         t_assertSuccess(H3_EXPORT(gridPathCellsSize)(start, end, &size));
-        H3Index *path = calloc(sizeof(H3Index), size);
-        t_assert(H3_EXPORT(gridPathCells)(start, end, path) == E_PENTAGON,
-                 "Line not computable due to pentagon distortion");
+        H3Index *path = calloc(size, sizeof(H3Index));
+
+        t_assertSuccess(H3_EXPORT(gridPathCells)(start, end, path));
+        assertPathValid(start, end, path, size);
+
+        free(path);
+    }
+
+    TEST(gridPathCells_knownFailureNotCoveredByReverseInterpolation) {
+        // Known limitation case:
+        //
+        // There are still pairs where `gridDistance` succeeds but interpolation
+        // fails in both origin-anchored local IJK charts (anchored at `start`
+        // and anchored at `end`). Since `gridPathCells` only performs these two
+        // interpolation attempts, it returns an error.
+        //
+        // This test keeps a pinned input pair to demonstrate that the current
+        // approach is not complete.
+        H3Index start = 0x8411b61ffffffff;
+        H3Index end = 0x84016d3ffffffff;
+
+        int64_t size;
+        t_assertSuccess(H3_EXPORT(gridPathCellsSize)(start, end, &size));
+        H3Index *path = calloc(size, sizeof(H3Index));
+
+        H3Error err = H3_EXPORT(gridPathCells)(start, end, path);
+        t_assert(err != E_SUCCESS, "Expected gridPathCells to fail");
+
         free(path);
     }
 }


### PR DESCRIPTION
This makes gridPathCells slightly more robust by attempting interpolation from both sides. Previously failing test is now fixed so I added another example pair.