### PR TITLE
Update documentation for cellsToLinkedMultiPolygon

### DIFF
--- a/src/h3lib/include/h3api.h.in
+++ b/src/h3lib/include/h3api.h.in
@@ -339,7 +339,7 @@ DECLSPEC H3Error H3_EXPORT(polygonToCellsExperimental)(
  * Functions for cellsToMultiPolygon (currently a binding-only concept)
  * @{
  */
-/** @brief Create a LinkedGeoPolygon from a set of contiguous hexagons */
+/** @brief Create a LinkedGeoPolygon from a set of cells */
 DECLSPEC H3Error H3_EXPORT(cellsToLinkedMultiPolygon)(const H3Index *h3Set,
                                                       const int numHexes,
                                                       LinkedGeoPolygon *out);


### PR DESCRIPTION
There's no requirement that the cells be contiguous.