### PR TITLE
Fix typo in bboxNormalization comment: "latitudes" -> "longitudes"

### DIFF
--- a/src/h3lib/lib/bbox.c
+++ b/src/h3lib/lib/bbox.c
@@ -284,7 +284,7 @@ void scaleBBox(BBox *bbox, double scale) {
 /**
  * Determine the longitude normalization scheme for two bounding boxes, either
  * or both of which might cross the antimeridian. The goal is to transform
- * latitudes in one or both boxes so that they are in the same frame of
+ * longitudes in one or both boxes so that they are in the same frame of
  * reference and can be operated on with standard Cartesian functions.
  * @param a              First bounding box
  * @param b              Second bounding box


### PR DESCRIPTION
## Summary
- Fix "latitudes" → "longitudes" in the `bboxNormalization` doc comment (`src/h3lib/lib/bbox.c`)

The comment says "The goal is to transform latitudes..." but the function normalizes longitudes for antimeridian crossing — the `@param` lines right below already say "longitudes", and the param type is `LongitudeNormalization`.

## Test plan
- [x] Verified no logic change — comment-only fix
- [x] Checked no other incorrect "latitudes" usage remains in bbox.c