### PR TITLE
Fix typo in vec3d.h comment: "calulations" -> "calculations"

### DIFF
--- a/src/h3lib/include/vec3d.h
+++ b/src/h3lib/include/vec3d.h
@@ -31,7 +31,7 @@
 /** @struct Vec3d
  *  @brief 3D floating point structure
  *
- *  For geodesic calulations represents a point on the surface of the Earth
+ *  For geodesic calculations represents a point on the surface of the Earth
  *  as a unit vector in 3D Cartesian space (ECEF-like coordinates).
  */
 typedef struct {


### PR DESCRIPTION
Fix "calulations" → "calculations" in `vec3d.h` doc comment. Introduced in #1145. Comment-only change.