### PR TITLE
ci: declare workflow-level `contents: read` on 8 test/fuzz workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Benchmark ${{ matrix.compiler }}

--- a/.github/workflows/test-fuzzer.yml
+++ b/.github/workflows/test-fuzzer.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   afl-tests:
     name: AFL Fuzzer ${{ matrix.compiler }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   cmake:
     name: CMake correctness checks

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.build_type }} on ${{ matrix.os }}

--- a/.github/workflows/test-pkg-config.yml
+++ b/.github/workflows/test-pkg-config.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   pkg-config:
     name: pkg-config on ${{ matrix.os }}

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Test Website and FOSSA

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, stable-*]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: ${{ matrix.config }} ${{ matrix.arch }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 8 workflows in `.github/workflows/` that don't actually need any write scope:

- `cifuzz.yml`: OSS-Fuzz CI integration.
- `test-bench.yml`: micro-benchmarks.
- `test-fuzzer.yml`: standalone fuzzer.
- `test-linux.yml`, `test-macos.yml`, `test-windows.yml`: build and test matrix per OS. `test-linux.yml`'s `coverallsapp/github-action` step uses the `GITHUB_TOKEN` to identify with coveralls.io (token read for auth, not a GitHub API write), so `contents: read` is sufficient.
- `test-pkg-config.yml`: pkg-config sanity check.
- `test-website.yml`: website build check.

`deploy-website.yml` is intentionally left implicit; it needs write scope for the gh-pages deploy and is best declared by a maintainer.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.