### PR TITLE
docs(readme): update dead LCOV link to current GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Otherwise, to build H3 from source, please see the following instructions.
 
 ### Building from source
 
-Still here? To build the H3 C library, you'll need a C compiler (tested with `gcc` and `clang`), [CMake](https://cmake.org/), and [Make](https://www.gnu.org/software/make/). If you intend to contribute to H3, you must have [clang-format](https://clang.llvm.org/docs/ClangFormat.html) installed and we recommend installing [ccmake](https://cmake.org/cmake/help/v3.0/manual/ccmake.1.html) and [LCOV](http://ltp.sourceforge.net/coverage/lcov.php) to configure the `cmake` arguments to build and run the tests and generate the code coverage report. We also recommend using `gcc` for the code coverage as some versions of `clang` generate annotations that aren't compatible with `lcov`. [Doxygen](https://www.doxygen.nl/index.html) is needed to build the API documentation.
+Still here? To build the H3 C library, you'll need a C compiler (tested with `gcc` and `clang`), [CMake](https://cmake.org/), and [Make](https://www.gnu.org/software/make/). If you intend to contribute to H3, you must have [clang-format](https://clang.llvm.org/docs/ClangFormat.html) installed and we recommend installing [ccmake](https://cmake.org/cmake/help/v3.0/manual/ccmake.1.html) and [LCOV](https://github.com/linux-test-project/lcov) to configure the `cmake` arguments to build and run the tests and generate the code coverage report. We also recommend using `gcc` for the code coverage as some versions of `clang` generate annotations that aren't compatible with `lcov`. [Doxygen](https://www.doxygen.nl/index.html) is needed to build the API documentation.
 
 #### Install build-time dependencies
 


### PR DESCRIPTION
The LCOV link in the "Building from source" section of `README.md` (`http://ltp.sourceforge.net/coverage/lcov.php`) is dead — the page redirects through several hops and lands on the unrelated Linux Test Project SourceForge page rather than LCOV. LCOV's current canonical home is the GitHub repo at `linux-test-project/lcov`.

```diff
-[LCOV](http://ltp.sourceforge.net/coverage/lcov.php)
+[LCOV](https://github.com/linux-test-project/lcov)
```

Confirmed: the contributors CLA wording mentions I'll need to sign the Uber CLA before merge — happy to do that.