### PR TITLE
Fix S2 comparison map embed

### DIFF
--- a/website/docs/comparisons/admin.md
+++ b/website/docs/comparisons/admin.md
@@ -21,7 +21,7 @@ The varying size of partitions means the center of a partition may be unrelated 
 
 ## ZIP Codes vs H3 comparison
 
-<iframe width="100%" height="500px" src="https://studio.unfolded.ai/public/72504bc0-184e-4ba0-b10b-72fdf61e2c33/embed" frameborder="0" allowfullscreen></iframe>
+<iframe width="100%" height="500px" src="https://studio.foursquare.com/public/72504bc0-184e-4ba0-b10b-72fdf61e2c33/embed" frameborder="0" allowfullscreen></iframe>
 
 ZIP Codes on the left, H3 on the right. Data: [New York City 2015 Street Tree Census](https://data.cityofnewyork.us/Environment/2015-Street-Tree-Census-Tree-Data/uvpi-gqnh)
 

--- a/website/docs/comparisons/geohash.md
+++ b/website/docs/comparisons/geohash.md
@@ -19,6 +19,6 @@ H3 cell indexes are designed to be 64 bit integers, which can be rendered and tr
 
 ## Geohash vs H3 Comparison
 
-<iframe width="100%" height="500px" src="https://studio.unfolded.ai/public/009a4f1e-2b74-4c0f-a156-95051c6583f3/embed" frameborder="0" allowfullscreen></iframe>
+<iframe width="100%" height="500px" src="https://studio.foursquare.com/public/009a4f1e-2b74-4c0f-a156-95051c6583f3/embed" frameborder="0" allowfullscreen></iframe>
 
 Geohash on the left, H3 on the right. Data: [San Francisco Street Tree List](https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq)

--- a/website/docs/comparisons/hexbin.md
+++ b/website/docs/comparisons/hexbin.md
@@ -15,6 +15,6 @@ Hexbins are also limited by the projection system they are created on top of. Th
 
 ## Hexbin vs H3 Comparison
 
-<iframe width="100%" height="500px" src="https://studio.unfolded.ai/public/0beb2afb-9dd4-400b-90dd-f61580c582b9/embed" frameborder="0" allowfullscreen></iframe>
+<iframe width="100%" height="500px" src="https://studio.foursquare.com/public/0beb2afb-9dd4-400b-90dd-f61580c582b9/embed" frameborder="0" allowfullscreen></iframe>
 
 Hexbins on the left, H3 on the right. Data: [San Francisco Street Tree List](https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq)

--- a/website/docs/comparisons/s2.md
+++ b/website/docs/comparisons/s2.md
@@ -33,6 +33,14 @@ H3 cells have the same non-alignment with the map projection, but in our experie
 
 ## S2 vs H3 Comparison
 
-<iframe width="100%" height="500px" src="https://studio.unfolded.ai/public/851dc25a-c8c8-4f20-96b8-ea47b3e3e9a7/embed" frameborder="0" allowfullscreen></iframe>
+<iframe
+  title="S2 vs H3 comparison map"
+  width="100%"
+  height="500px"
+  src="https://studio.foursquare.com/public/851dc25a-c8c8-4f20-96b8-ea47b3e3e9a7/embed"
+  frameborder="0"
+  allowfullscreen
+></iframe>
+
 
 S2 on the left, H3 on the right. Data: [San Francisco Street Tree List](https://data.sfgov.org/City-Infrastructure/Street-Tree-List/tkzw-k3nq)


### PR DESCRIPTION
The S2 comparison page currently embeds the comparison map using the old `studio.unfolded.ai` URL. In Chrome, the iframe area appears blank on the live docs page.

This updates the iframe to the current `studio.foursquare.com` embed URL. I also added a `title` attribute to the iframe for accessibility.

I verified the updated embed URL manually by loading it in a local HTML file in the browser.