### PR TITLE
docs: fix broken Cell/Directed Edge/Vertex links on H3 indexing page

### DIFF
--- a/website/docs/library/index/h3indexing.md
+++ b/website/docs/library/index/h3indexing.md
@@ -14,10 +14,10 @@ The H3 system assigns a unique hierarchical index to each cell. Each directed ed
 An `H3Index` is the 64-bit integer representation of an H3 index, which may be one of multiple modes to indicate the concept being indexed.
 
 * Mode 0 is reserved and indicates an [invalid H3 index](#invalid-index).
-* Mode 1 is an *[H3 Cell](../library/index/cell)* (Hexagon/Pentagon) index.
-* Mode 2 is an *[H3 Directed Edge](../library/index/directededge)* (Cell A -> Cell B) index.
+* Mode 1 is an *[H3 Cell](./cell)* (Hexagon/Pentagon) index.
+* Mode 2 is an *[H3 Directed Edge](./directededge)* (Cell A -> Cell B) index.
 * Mode 3 is planned to be a bidirectional edge (Cell A <-> Cell B).
-* Mode 4 is an *[H3 Vertex](../library/index/vertex)* (i.e. a single vertex of an H3 Cell).
+* Mode 4 is an *[H3 Vertex](./vertex)* (i.e. a single vertex of an H3 Cell).
 
 The canonical string representation of an `H3Index` is the hexadecimal representation of the integer, using lowercase letters. The string representation is variable length (no zero padding) and is not prefixed or suffixed.
 

--- a/website/docs/library/index/h3indexing.md
+++ b/website/docs/library/index/h3indexing.md
@@ -14,10 +14,10 @@ The H3 system assigns a unique hierarchical index to each cell. Each directed ed
 An `H3Index` is the 64-bit integer representation of an H3 index, which may be one of multiple modes to indicate the concept being indexed.
 
 * Mode 0 is reserved and indicates an [invalid H3 index](#invalid-index).
-* Mode 1 is an *[H3 Cell](./cell)* (Hexagon/Pentagon) index.
-* Mode 2 is an *[H3 Directed Edge](./directededge)* (Cell A -> Cell B) index.
+* Mode 1 is an *[H3 Cell](./cell.md)* (Hexagon/Pentagon) index.
+* Mode 2 is an *[H3 Directed Edge](./directededge.md)* (Cell A -> Cell B) index.
 * Mode 3 is planned to be a bidirectional edge (Cell A <-> Cell B).
-* Mode 4 is an *[H3 Vertex](./vertex)* (i.e. a single vertex of an H3 Cell).
+* Mode 4 is an *[H3 Vertex](./vertex.md)* (i.e. a single vertex of an H3 Cell).
 
 The canonical string representation of an `H3Index` is the hexadecimal representation of the integer, using lowercase letters. The string representation is variable length (no zero padding) and is not prefixed or suffixed.
 


### PR DESCRIPTION
Fixes #1129.

The H3 indexing page (`website/docs/library/index/h3indexing.md`) links to the Cell, Directed Edge, and Vertex pages with `../library/index/cell` (etc.). Those four pages all live in the **same directory** (`website/docs/library/index/`), so the `../library/index/` prefix is one level too high — under a trailing-slash URL it resolves to a non-existent `…/library/index/cell` path and 404s, which is exactly the behavior reported (works without a trailing slash, breaks with one).

Fix: use same-directory relative links `./cell`, `./directededge`, `./vertex`. This matches the **already-working** convention used by the sibling pages — e.g. `vertex.md` and `directededge.md` both link to Cell as `[… cell](./cell#h3-cell-index)` — so the resolution is identical to links that are known to work.

| Before | After |
| --- | --- |
| `[H3 Cell](../library/index/cell)` | `[H3 Cell](./cell)` |
| `[H3 Directed Edge](../library/index/directededge)` | `[H3 Directed Edge](./directededge)` |
| `[H3 Vertex](../library/index/vertex)` | `[H3 Vertex](./vertex)` |

Docs only; three links changed on one page.
