### PR TITLE
test: force C locale for printf in cellAreaM2 CLI test

### DIFF
--- a/tests/cli/cellAreaM2.txt
+++ b/tests/cli/cellAreaM2.txt
@@ -1,5 +1,5 @@
 add_h3_cli_test(
-    testCliCellAreaM2 "cellAreaM2 -c 85283473fffffff | xargs printf '%.3f'"
+    testCliCellAreaM2 "cellAreaM2 -c 85283473fffffff | xargs env LC_ALL=C printf '%.3f'"
     "265092558.128")
 add_h3_cli_test(testCliNotCellAreaM2 "cellAreaM2 -c 115283473fffffff 2>&1"
                 "Error 5: Cell argument was not valid")


### PR DESCRIPTION
Fixes #1170.

`testCliCellAreaM2` runs:

```sh
test "`h3 cellAreaM2 -c 85283473fffffff | xargs printf '%.3f'`" = '265092558.128'
```

`printf`'s `%f` conversion uses the **system locale**'s decimal separator. On a locale such as `en_SE.UTF-8` (which uses `,`), the pipeline produces `265092558,128`, so the comparison against the expected `265092558.128` fails — which blocks the build (e.g. the Arch AUR package, as reported).

`h3` itself outputs the value correctly (`265092558.1282817721`); only the test's `printf` post-processing is locale-sensitive.

Fix: run `printf` under the C locale so the decimal separator is always `.`:

```diff
-"cellAreaM2 -c 85283473fffffff | xargs printf '%.3f'"
+"cellAreaM2 -c 85283473fffffff | xargs env LC_ALL=C printf '%.3f'"
```

`env LC_ALL=C` is used (rather than a bare `LC_ALL=C printf`) because `printf` is launched by `xargs`, which doesn't interpret `VAR=value` env assignments. This is the only CLI test fixture that uses `printf`, so no other tests are affected.
