### PR TITLE
Provide coverage for an iterator cell case

### DIFF
--- a/src/apps/testapps/testH3IteratorsInternal.c
+++ b/src/apps/testapps/testH3IteratorsInternal.c
@@ -126,4 +126,15 @@ SUITE(h3IteratorsInternal) {
         test_ordered(2);
         test_ordered(3);
     }
+
+    TEST(iterator_cell_pent_skipped) {
+        IterCellsChildren iter = iterInitBaseCellNum(4, 1);
+        setH3Index(&iter.h, 1, 4, 2);
+        H3Index expected;
+        setH3Index(&expected, 1, 4, 2);
+        iterStepChild(&iter);
+        t_assert(
+            iter.h == expected,
+            "iterator returns a valid cell after h is set to a modified value");
+    }
 }

--- a/src/apps/testapps/testH3IteratorsInternal.c
+++ b/src/apps/testapps/testH3IteratorsInternal.c
@@ -131,7 +131,7 @@ SUITE(h3IteratorsInternal) {
         IterCellsChildren iter = iterInitBaseCellNum(4, 1);
         setH3Index(&iter.h, 1, 4, 2);
         H3Index expected;
-        setH3Index(&expected, 1, 4, 2);
+        setH3Index(&expected, 1, 4, 3);
         iterStepChild(&iter);
         t_assert(
             iter.h == expected,

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -473,7 +473,12 @@ static void _hex2dToVec3(const Vec2d *v, int face, int res, int substrate,
     // scale accordingly if this is a substrate grid
     if (substrate) {
         r *= M_ONETHIRD;
-        if (isResolutionClassIII(res)) r *= M_RSQRT7;
+        // Never occurs because every case where this function is called with
+        // substrate=1, the res has been adjusted by _faceIjkPentToVerts, which
+        // adjusts the res by +1, making it no longer Class III.
+        if (NEVER(isResolutionClassIII(res))) {
+            r *= M_RSQRT7;
+        }
     }
 
     r *= RES0_U_GNOMONIC;

--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -473,12 +473,7 @@ static void _hex2dToVec3(const Vec2d *v, int face, int res, int substrate,
     // scale accordingly if this is a substrate grid
     if (substrate) {
         r *= M_ONETHIRD;
-        // Never occurs because every case where this function is called with
-        // substrate=1, the res has been adjusted by _faceIjkPentToVerts, which
-        // adjusts the res by +1, making it no longer Class III.
-        if (NEVER(isResolutionClassIII(res))) {
-            r *= M_RSQRT7;
-        }
+        if (isResolutionClassIII(res)) r *= M_RSQRT7;
     }
 
     r *= RES0_U_GNOMONIC;


### PR DESCRIPTION
Provides coverage for a branch in iterators.c where the iterator is expecting to need to skip a child, but ultimately doesn't. The case is reachable if the iterator is modified by the caller, but not during normal operation. I didn't choose to mark it NEVER/ALWAYS because a caller using the iterators could potentially reach it.