### PR TITLE
tag a NEVER case in _hex2dToVec3

### DIFF
--- a/src/h3lib/lib/faceijk.c
+++ b/src/h3lib/lib/faceijk.c
@@ -473,7 +473,12 @@ static void _hex2dToVec3(const Vec2d *v, int face, int res, int substrate,
     // scale accordingly if this is a substrate grid
     if (substrate) {
         r *= M_ONETHIRD;
-        if (isResolutionClassIII(res)) r *= M_RSQRT7;
+        // Never occurs because every case where this function is called with
+        // substrate=1, the res has been adjusted by _faceIjkPentToVerts, which
+        // adjusts the res by +1, making it no longer Class III.
+        if (NEVER(isResolutionClassIII(res))) {
+            r *= M_RSQRT7;
+        }
     }
 
     r *= RES0_U_GNOMONIC;


### PR DESCRIPTION
As described in the comment, the branch is unreachable in our current configuration. An external caller also cannot reach it because the function is declared `static`.