### PR TITLE
Fix documentation typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The public API of this library consists of the functions declared in file
 - Removed a duplicated include preprocessor directive (#682)
 - Improvements to the fuzzer suite and their automatic runs in CI (#671, #674, #687)
 - Increased test coverage (#642)
-- Added a fuzzer targetting internal `algos.c` functions (#675)
+- Added a fuzzer targeting internal `algos.c` functions (#675)
 
 ## [4.0.0] - 2022-08-23
 ### Breaking changes
@@ -395,7 +395,7 @@ The public API of this library consists of the functions declared in file
 ### Added
 - Added a `make install` target.
 ### Changed
-- Improved compatability with building on Windows.
+- Improved compatibility with building on Windows.
 - Fixed various cases where the test suite could crash or not compile.
 
 ## [3.0.0] - 2018-01-08

--- a/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
+++ b/dev-docs/RFCs/v4.0.0/error-handling-rfc.md
@@ -312,7 +312,7 @@ public class H3Exception extends Exception {
     public static String messageFromErrorCode(long errorCode) {
         switch (errorCode) {
             case 4: // E_RES_INVALID
-                return "Resolution arugment was invalid";
+                return "Resolution argument was invalid";
             // elided ...
         }
     }


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `CHANGELOG.md`
- `dev-docs/RFCs/v4.0.0/error-handling-rfc.md`

## Testing
I run `git diff --check`.
