### PR TITLE
Cover a case in h3NeighborRotations when starting within the deleted k subsequence

### DIFF
--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -333,6 +333,8 @@ SUITE(gridDisk) {
     TEST(gridDiskInvalidKSubsequence) {
         H3Index h;
         setH3Index(&h, 2, 4, 0);
+        // Make the indexing digits be `10`, which is invalid
+        // because it has a leading non-zero 1 under a pentagon base cell.
         H3_SET_INDEX_DIGIT(h, 1, K_AXES_DIGIT);
 
         int k = 1;

--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -330,6 +330,20 @@ SUITE(gridDisk) {
         free(neighbors);
     }
 
+    TEST(gridDiskInvalidKSubsequence) {
+        H3Index h;
+        setH3Index(&h, 2, 4, 0);
+        H3_SET_INDEX_DIGIT(h, 1, K_AXES_DIGIT);
+
+        int k = 1;
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
+        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
+        t_assert(H3_EXPORT(gridDisk)(h, k, neighbors) == E_FAILED,
+                 "gridDisk returns error for invalid k subsequence input");
+        free(neighbors);
+    }
+
     TEST(gridDiskInvalidDigit) {
         int k = 2;
         int64_t kSz;

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -558,7 +558,8 @@ H3Error h3NeighborRotations(H3Index origin, Direction dir, int *rotations,
                     current = _h3Rotate60cw(current);
                     *rotations = *rotations + 5;
                 } else {
-                    // TODO: Should never occur, but is reachable by fuzzer
+                    // Could occur on invalid inputs that were already within
+                    // the deleted k subsequence
                     return E_FAILED;
                 }
             }


### PR DESCRIPTION
I used Claude to find an example case that triggers this E_FAILED return. The `oldLeadingDigit` is 1 in this case, which represents an invalid index, so it is fine to fail here.