### PR TITLE
Cover additional cases in localIj with invalid digit, mark ALWAYS

### DIFF
--- a/src/apps/testapps/testCellToLocalIj.c
+++ b/src/apps/testapps/testCellToLocalIj.c
@@ -207,6 +207,16 @@ SUITE(h3ToLocalIj) {
                  "Negative I and J components fail");
     }
 
+    TEST(cellToLocalIj_invalidDigit_otherBC) {
+        H3Index index = 0x820897fffffffff;
+        H3_SET_INDEX_DIGIT(index, 1, INVALID_DIGIT);
+        H3Index other = 0x821f67fffffffff;
+        CoordIJ ij = {.i = 0, .j = 0};
+        t_assert(
+            H3_EXPORT(cellToLocalIj)(index, other, 0, &ij) == E_CELL_INVALID,
+            "cellToLocalIj invalid origin");
+    }
+
     TEST(localIjToCell_overflow_i) {
         for (int res = 0; res <= MAX_H3_RES; res++) {
             H3Index origin;

--- a/src/h3lib/lib/localij.c
+++ b/src/h3lib/lib/localij.c
@@ -257,7 +257,9 @@ H3Error cellToLocalIjk(H3Index origin, H3Index h3, CoordIJK *out) {
         // Perform necessary translation
         _ijkAdd(&indexFijk.coord, &offset, &indexFijk.coord);
         _ijkNormalize(&indexFijk.coord);
-    } else if (originOnPent && indexOnPent) {
+    } else if (originOnPent && ALWAYS(indexOnPent)) {
+        // Since the base cells are the same, indexOnPent above is ALWAYS
+        // since originOnPent is already being checked.
         // If the origin and index are on pentagon, and we checked that the base
         // cells are the same or neighboring, then they must be the same base
         // cell.
@@ -475,7 +477,9 @@ H3Error localIjkToCell(H3Index origin, const CoordIJK *ijk, H3Index *out) {
                 *out = _h3Rotate60ccw(*out);
             }
         }
-    } else if (originOnPent && indexOnPent) {
+    } else if (originOnPent && ALWAYS(indexOnPent)) {
+        // Since the base cells are the same (dir == CENTER_DIGIT), indexOnPent
+        // above is ALWAYS since originOnPent is already being checked.
         const int originLeadingDigit = _h3LeadingNonZeroDigit(origin);
         const int indexLeadingDigit = _h3LeadingNonZeroDigit(*out);
 


### PR DESCRIPTION
* Cover a case on localIj.c around line 203 when the origin has a leading invalid digit.
* Mark two cases as ALWAYS, since the base cell will actually be the same in those cases. So, it is impossible for the pentagon-ness of the base cells to differ.