### PR TITLE
Cover failure cases in gridDisk, gridRing, etc

### DIFF
--- a/src/apps/testapps/testGridDisk.c
+++ b/src/apps/testapps/testGridDisk.c
@@ -341,6 +341,37 @@ SUITE(gridDisk) {
         free(neighbors);
     }
 
+    TEST(gridDiskInvalid2) {
+        H3Index index = 0x8009fffffffffff;
+        H3_SET_RESOLUTION(index, 2);
+        H3_SET_INDEX_DIGIT(index, 1, INVALID_DIGIT);
+        H3_SET_INDEX_DIGIT(index, 2, CENTER_DIGIT);
+
+        int k = 2;
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
+        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
+        t_assert(H3_EXPORT(gridDisk)(index, k, neighbors) == E_CELL_INVALID,
+                 "gridDisk returns error for invalid input");
+        free(neighbors);
+    }
+
+    TEST(gridDiskUnsafeInvalid3) {
+        H3Index index = 0x8009fffffffffff;
+        H3_SET_RESOLUTION(index, 2);
+        H3_SET_INDEX_DIGIT(index, 1, INVALID_DIGIT);
+        H3_SET_INDEX_DIGIT(index, 2, K_AXES_DIGIT);
+
+        int k = 2;
+        int64_t kSz;
+        t_assertSuccess(H3_EXPORT(maxGridDiskSize)(k, &kSz));
+        H3Index *neighbors = calloc(kSz, sizeof(H3Index));
+        t_assert(
+            H3_EXPORT(gridDiskUnsafe)(index, k, neighbors) == E_CELL_INVALID,
+            "gridDisk returns error for invalid input");
+        free(neighbors);
+    }
+
     TEST(gridDiskDistances_invalidK) {
         H3Index index = 0x811d7ffffffffff;
         t_assert(

--- a/src/apps/testapps/testGridRingUnsafe.c
+++ b/src/apps/testapps/testGridRingUnsafe.c
@@ -101,7 +101,7 @@ SUITE(gridRingUnsafe) {
                  "Should return an error when starting at a pentagon");
     }
 
-    TEST(onPentagon) {
+    TEST(invalidPentagon) {
         H3Index index = 0x8009fffffffffff;
         H3_SET_RESOLUTION(index, 2);
         H3_SET_INDEX_DIGIT(index, 1, K_AXES_DIGIT);
@@ -111,7 +111,7 @@ SUITE(gridRingUnsafe) {
                  "Should return an error when starting at a pentagon");
     }
 
-    TEST(onPentagon) {
+    TEST(invalidPentagon2) {
         H3Index index = 0x8009fffffffffff;
         H3_SET_RESOLUTION(index, 2);
         H3_SET_INDEX_DIGIT(index, 1, INVALID_DIGIT);

--- a/src/apps/testapps/testGridRingUnsafe.c
+++ b/src/apps/testapps/testGridRingUnsafe.c
@@ -101,6 +101,26 @@ SUITE(gridRingUnsafe) {
                  "Should return an error when starting at a pentagon");
     }
 
+    TEST(onPentagon) {
+        H3Index index = 0x8009fffffffffff;
+        H3_SET_RESOLUTION(index, 2);
+        H3_SET_INDEX_DIGIT(index, 1, K_AXES_DIGIT);
+        H3_SET_INDEX_DIGIT(index, 2, CENTER_DIGIT);
+        H3Index kp2[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        t_assert(H3_EXPORT(gridRingUnsafe)(index, 2, kp2) == E_FAILED,
+                 "Should return an error when starting at a pentagon");
+    }
+
+    TEST(onPentagon) {
+        H3Index index = 0x8009fffffffffff;
+        H3_SET_RESOLUTION(index, 2);
+        H3_SET_INDEX_DIGIT(index, 1, INVALID_DIGIT);
+        H3_SET_INDEX_DIGIT(index, 2, K_AXES_DIGIT);
+        H3Index kp2[] = {0, 0, 0, 0, 0, 0};
+        t_assert(H3_EXPORT(gridRingUnsafe)(index, 1, kp2) == E_CELL_INVALID,
+                 "Should return an error when starting at a pentagon");
+    }
+
     TEST(gridRingUnsafe_matches_gridDiskDistancesSafe) {
         for (int res = 0; res < 2; res++) {
             for (int i = 0; i < NUM_BASE_CELLS; i++) {


### PR DESCRIPTION
As with #1193, I used Claude to generate examples that exercised the case that gridDisk, gridRingUnsafe, etc. recurse into another cell that then fails. They all require combinations on invalid cells (deleted K subsequence of a pentagon, or invalid digits).