### PR TITLE
Cover cases in polygonToCells which fail after estimation

### DIFF
--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -54,6 +54,19 @@ static LatLng invalid2Verts[] = {{NAN, NAN}, {-NAN, -NAN}};
 static GeoLoop invalid2GeoLoop = {.numVerts = 2, .verts = invalid2Verts};
 static GeoPolygon invalid2GeoPolygon;
 
+static LatLng invalidSfVerts[] = {
+    {0.659966917655, -2.1364398519396},  {NAN, -2.1359434279405},
+    {0.6583348114025, -2.1354884206045}, {0.6581220034068, -2.1382437718946},
+    {0.6594479998527, -2.1384597563896}, {0.6599990002976, -2.1376771158464}};
+static GeoLoop invalidSfGeoLoop = {.numVerts = 6, .verts = invalidSfVerts};
+static GeoPolygon invalidSfGeoPolygon;
+
+static LatLng invalidHoleVerts[] = {{0.6595072188743, -2.1371053983433},
+                                    {0.6591482046471, NAN},
+                                    {0.6592295020837, -2.1365222838402}};
+static GeoLoop invalidHoleGeoLoop = {.numVerts = 3, .verts = invalidHoleVerts};
+static GeoPolygon invalidHoleGeoPolygon;
+
 static LatLng pointVerts[] = {{0, 0}};
 static GeoLoop pointGeoLoop = {.numVerts = 1, .verts = pointVerts};
 static GeoPolygon pointGeoPolygon;
@@ -158,6 +171,13 @@ SUITE(polygonToCells) {
 
     lineGeoPolygon.geoloop = lineGeoLoop;
     lineGeoPolygon.numHoles = 0;
+
+    invalidSfGeoPolygon.geoloop = invalidSfGeoLoop;
+    invalidSfGeoPolygon.numHoles = 0;
+
+    invalidHoleGeoPolygon.geoloop = sfGeoLoop;
+    invalidHoleGeoPolygon.numHoles = 1;
+    invalidHoleGeoPolygon.holes = &invalidHoleGeoLoop;
 
     // --------------------------------------------
     // maxPolygonToCellsSize
@@ -490,6 +510,32 @@ SUITE(polygonToCells) {
         t_assert(H3_EXPORT(polygonToCells)(&invalidGeoPolygon, 9, 0,
                                            hexagons) == E_FAILED,
                  "Invalid geo polygon cannot be evaluated");
+        free(hexagons);
+    }
+
+    TEST(polygonToCells) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&invalidSfGeoPolygon,
+                                                         9, 0, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assert(H3_EXPORT(polygonToCells)(&invalidSfGeoPolygon, 9, 0,
+                                           hexagons) == E_FAILED,
+                 "Partially NAN geo polygon cannot be evaluated");
+
+        free(hexagons);
+    }
+
+    TEST(polygonToCellsHole) {
+        int64_t numHexagons;
+        t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&invalidHoleGeoPolygon,
+                                                         9, 0, &numHexagons));
+        H3Index *hexagons = calloc(numHexagons, sizeof(H3Index));
+
+        t_assert(H3_EXPORT(polygonToCells)(&invalidHoleGeoPolygon, 9, 0,
+                                           hexagons) == E_FAILED,
+                 "Partially NAN geo polygon cannot be evaluated (hole)");
+
         free(hexagons);
     }
 

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -513,7 +513,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCells) {
+    TEST(polygonToCells_oneNanVertex) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&invalidSfGeoPolygon,
                                                          9, 0, &numHexagons));
@@ -526,7 +526,7 @@ SUITE(polygonToCells) {
         free(hexagons);
     }
 
-    TEST(polygonToCellsHole) {
+    TEST(polygonToCells_oneNanHoleVertex) {
         int64_t numHexagons;
         t_assertSuccess(H3_EXPORT(maxPolygonToCellsSize)(&invalidHoleGeoPolygon,
                                                          9, 0, &numHexagons));

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -704,7 +704,6 @@ H3Error H3_EXPORT(gridDiskDistancesUnsafe)(H3Index origin, int k, H3Index *out,
             if (neighborResult) {
                 // Should not be possible because `origin` would have to be a
                 // pentagon
-                // TODO: Reachable via fuzzer
                 return neighborResult;
             }
 
@@ -812,7 +811,6 @@ H3Error H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index *out) {
         if (neighborResult) {
             // Should not be possible because `origin` would have to be a
             // pentagon
-            // TODO: Reachable via fuzzer
             return neighborResult;
         }
 
@@ -833,7 +831,6 @@ H3Error H3_EXPORT(gridRingUnsafe)(H3Index origin, int k, H3Index *out) {
             if (neighborResult) {
                 // Should not be possible because `origin` would have to be a
                 // pentagon
-                // TODO: Reachable via fuzzer
                 return neighborResult;
             }
 
@@ -1055,7 +1052,6 @@ H3Error H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon, int res,
                                             &numSearchHexes, search, found);
     // If this branch is reached, we have exceeded the maximum number of
     // hexagons possible and need to clean up the allocated memory.
-    // TODO: Reachable via fuzzer
     if (edgeHexError) {
         H3_MEMORY(free)(search);
         H3_MEMORY(free)(found);
@@ -1074,7 +1070,6 @@ H3Error H3_EXPORT(polygonToCells)(const GeoPolygon *geoPolygon, int res,
                                         search, found);
         // If this branch is reached, we have exceeded the maximum number of
         // hexagons possible and need to clean up the allocated memory.
-        // TODO: Reachable via fuzzer
         if (edgeHexError) {
             H3_MEMORY(free)(search);
             H3_MEMORY(free)(found);


### PR DESCRIPTION
* These cases are reachable if polygonToCells result size estimation runs but we cannot evaluate the polygons. This happens if the polygon is partially invalid, previously we only tested if all of the vertices were invalid which does not reach this.
* Also, cleanup a few leftover comments resolved by #1195