### PR TITLE
Avoid possible signed integer overflow in uncompactCellsSize

### DIFF
--- a/src/apps/testapps/testCompactCells.c
+++ b/src/apps/testapps/testCompactCells.c
@@ -607,6 +607,23 @@ SUITE(compactCells) {
         free(children);
     }
 
+    TEST(uncompactCells_sizeOverflow) {
+        H3Index origin = 0x8019fffffffffff;
+        size_t sz = 2000000;
+
+        H3Index *data = calloc(sz, sizeof(H3Index));
+        for (size_t i = 0; i < sz; i++) {
+            data[i] = origin;
+        }
+
+        int64_t childrenSz;
+        t_assert(H3_EXPORT(uncompactCellsSize)(data, sz, 15, &childrenSz) ==
+                     E_MEMORY_ALLOC,
+                 "uncompactCellsSize overflow");
+
+        free(data);
+    }
+
     TEST(pentagon) {
         H3Index pentagon;
         setH3Index(&pentagon, 1, 4, 0);

--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -42,6 +42,15 @@ static inline bool ADD_INT32S_OVERFLOWS(int32_t a, int32_t b) {
     }
 }
 
+/** Evaluates to true if a + b would overflow for int64 */
+static inline bool ADD_INT64S_OVERFLOWS(int64_t a, int64_t b) {
+    if (a > 0) {
+        return INT64_MAX - a < b;
+    } else {
+        return INT64_MIN - a > b;
+    }
+}
+
 /** Evaluates to true if a - b would overflow for int32 */
 static inline bool SUB_INT32S_OVERFLOWS(int32_t a, int32_t b) {
     if (a >= 0) {

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -816,6 +816,10 @@ H3Error H3_EXPORT(uncompactCellsSize)(const H3Index *compactedSet,
             // The parent res does not contain `res`.
             return E_RES_MISMATCH;
         }
+        if (ADD_INT64S_OVERFLOWS(numOut, childrenSize)) {
+            // numOut + childrenSize would overflow
+            return E_MEMORY_ALLOC;
+        }
         numOut += childrenSize;
     }
     *out = numOut;


### PR DESCRIPTION
1 of 2 reported issues in #1204. Thanks @anaef for reporting this.

Checks and avoids a signed integer overflow that can occur in `uncompactCellsSize`. Signed integer addition overflow is undefined behavior in C so we should guard against it.