### PR TITLE
Exclude an unreachable branch in polygonToCells->_getEdgeHexagons

### DIFF
--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -943,7 +943,9 @@ H3Error _getEdgeHexagons(const GeoLoop *geoloop, int64_t numHexagons, int res,
                 (destination.lng * j * invNumHexesEst);
             H3Index pointHex;
             H3Error e = H3_EXPORT(latLngToCell)(&interpolate, res, &pointHex);
-            if (e) {
+            if (NEVER(e)) {
+                // Any case that would cause latLngToCell to return an error
+                // would cause lineHexEstimate to return an error, above.
                 return e;
             }
             // A simple hash to store the hexagon, or move to another place if


### PR DESCRIPTION
As explained in the comment, I expect this is unreachable because the only cases where latLngToCell fails are:
* Res is invalid (impossible)
* Lat or lng is not finite (impossible)
* vec3ToCell fails (impossible since the reasons are same as the above two)