### PR TITLE
Compute each Gosper edge boundary once in loop check

### DIFF
--- a/src/apps/testapps/testGosperIter.c
+++ b/src/apps/testapps/testGosperIter.c
@@ -81,24 +81,37 @@ void check_edge_correctness(H3Index h, int childRes) {
     }
 }
 
+// The endpoints and length of one edge. Both come from the edge's boundary,
+// so deriving them together lets a loop walk compute each boundary once
+// rather than recomputing it for every neighboring pair.
+typedef struct {
+    LatLng start;
+    LatLng end;
+    double length;
+} EdgeGeometry;
+
+static void getEdgeGeometry(H3Index edge, EdgeGeometry *out) {
+    CellBoundary bd;
+    t_assertSuccess(H3_EXPORT(directedEdgeToBoundary)(edge, &bd));
+
+    out->start = bd.verts[0];
+    out->end = bd.verts[bd.numVerts - 1];
+    out->length = 0.0;
+    for (int i = 0; i < bd.numVerts - 1; i++) {
+        out->length +=
+            H3_EXPORT(greatCircleDistanceRads)(&bd.verts[i], &bd.verts[i + 1]);
+    }
+}
+
 // Check that edge_a's last vertex matches edge_b's first vertex,
 // i.e. the edges connect end-to-start. Tolerance is relative to
 // the shorter edge length to handle varying resolutions.
 // TODO: Replace floating-point distance check with exact vertex comparison
 // once an edgeToVertexes function exists.
-bool do_edges_connect(H3Index edge_a, H3Index edge_b) {
-    double len_a, len_b;
-    H3_EXPORT(edgeLengthRads)(edge_a, &len_a);
-    H3_EXPORT(edgeLengthRads)(edge_b, &len_b);
-    double tol = MIN(len_a, len_b) / 1000.0;
-
-    CellBoundary bd_a, bd_b;
-    t_assertSuccess(H3_EXPORT(directedEdgeToBoundary)(edge_a, &bd_a));
-    t_assertSuccess(H3_EXPORT(directedEdgeToBoundary)(edge_b, &bd_b));
-
-    LatLng end_a = bd_a.verts[bd_a.numVerts - 1];
-    LatLng start_b = bd_b.verts[0];
-    double dist = H3_EXPORT(greatCircleDistanceRads)(&end_a, &start_b);
+bool do_edges_connect(const EdgeGeometry *edge_a, const EdgeGeometry *edge_b) {
+    double tol = MIN(edge_a->length, edge_b->length) / 1000.0;
+    double dist =
+        H3_EXPORT(greatCircleDistanceRads)(&edge_a->end, &edge_b->start);
 
     return dist < tol;
 }
@@ -108,18 +121,21 @@ bool do_edges_connect(H3Index edge_a, H3Index edge_b) {
 //   2. loop closes (returns to where it started)
 void check_loop_valid(H3Index h, int childRes) {
     IterEdgesGosper iter = iterInitGosper(h, childRes);
-    H3Index first_edge = iter.e;
-    H3Index prev_edge = iter.e;
+    EdgeGeometry first_edge, prev_edge, cur_edge;
+    getEdgeGeometry(iter.e, &first_edge);
+    prev_edge = first_edge;
     iterStepGosper(&iter);
 
     while (iter.e) {
-        t_assert(do_edges_connect(prev_edge, iter.e), "edges should connect");
+        getEdgeGeometry(iter.e, &cur_edge);
+        t_assert(do_edges_connect(&prev_edge, &cur_edge),
+                 "edges should connect");
 
-        prev_edge = iter.e;
+        prev_edge = cur_edge;
         iterStepGosper(&iter);
     }
 
-    t_assert(do_edges_connect(prev_edge, first_edge), "loop should close");
+    t_assert(do_edges_connect(&prev_edge, &first_edge), "loop should close");
 }
 
 void check_gosper_island(H3Index h, int childRes) {


### PR DESCRIPTION
## Problem

`testGosperIter` has been running very close to the 1500 second ctest timeout under Valgrind, and has started tipping over it. Recent `test-linux` runs on master:

| Run | testGosperIter | Result |
|---|---|---|
| [30489861181](https://github.com/uber/h3/actions/runs/30489861181) | 1379.66 s | pass |
| [30598474977](https://github.com/uber/h3/actions/runs/30598474977) | 1457.30 s | pass |
| [30857166201](https://github.com/uber/h3/actions/runs/30857166201) | 1454.48 s | pass |
| [31226363961](https://github.com/uber/h3/actions/runs/31226363961) | — | **Timeout** |

At ~97% of the budget it is effectively a coin flip, and `test-linux` is now failing on master and on unrelated PRs.

## Cause

`check_loop_valid` walks the edge loop and calls `do_edges_connect(prev, cur)` on each neighboring pair. That function derived everything from scratch:

- `edgeLengthRads` internally calls `directedEdgeToBoundary`, so the two length lookups computed two boundaries
- two more boundaries were then computed explicitly for the endpoints

That is four boundary computations per call, and every edge was passed to `do_edges_connect` twice as the walk advanced — eight per edge, seven of them redundant.

## Change

Derive an edge's endpoints and length together from a single boundary, and carry the previous edge's geometry forward so each edge's boundary is computed once per walk.

The connectivity checks themselves are unchanged. The reported assertion count drops by exactly the number of edges (120918689 to 117442702 locally), which is the duplicate `t_assertSuccess` on boundaries that were being recomputed — every edge's boundary is still computed and checked once.

## Verification

Full CI run on the same runner configuration: testGosperIter **1454.48 s to 452.67 s**, 310/310 tests passing, total Valgrind test time 2251.70 s to 1243.53 s.

Unmodified tests in the same job confirm the two runs are directly comparable rather than reflecting a faster runner:

| Test | Before | After |
|---|---|---|
| testCellsToMultiPoly | 7.89 s | 7.90 s |
| testPolygonToCells | 79.68 s | 79.07 s |
| testPolygonToCellsExperimental | 314.69 s | 313.48 s |
| testPolygonToCellsReportedExperimental | 19.84 s | 19.50 s |
| **testGosperIter** | **1454.48 s** | **452.67 s** |

This leaves roughly 3x headroom against the timeout instead of 3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)