### PR TITLE
Fix AnalyzeTemporaryDtors clang-tidy deprecation error

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            isaachier
 CheckOptions:    


### PR DESCRIPTION
Build fails on clang > 18 due to deprecation of AnalyzeTemporaryDtors in clang-tidy. Remove AnalyzeTemporaryDtors for build to succeed.