### PR TITLE
Define the pentagon lookup table once (#984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The public API of this library consists of the functions declared in file
 [h3api.h.in](./src/h3lib/include/h3api.h.in).
 
 ## [Unreleased]
+### Changed
+- The pentagon lookup table is now defined once as `baseCellIsPentagon` in `baseCells.c` instead of being duplicated as a private copy in `h3Index.c`, with a test asserting it stays in sync with `baseCellData` (#984)
+
 ### Fixed
 - Fixed the `polygonToCells` fuzzer regression test to use explicit double literals instead of reinterpreting raw bytes, so it is portable across endianness (#964)
 - No longer emit a CMake warning about a missing `clang-format`/`clang-tidy` when the user explicitly set `ENABLE_FORMAT=OFF`/`ENABLE_LINTING=OFF` (#1158)

--- a/src/apps/testapps/testBaseCellsInternal.c
+++ b/src/apps/testapps/testBaseCellsInternal.c
@@ -41,5 +41,28 @@ SUITE(baseCellsInternal) {
     TEST(isBaseCellPentagon_invalid) {
         t_assert(_isBaseCellPentagon(-1) == false,
                  "isBaseCellPentagon handles negative");
+        t_assert(_isBaseCellPentagon(NUM_BASE_CELLS) == false,
+                 "isBaseCellPentagon handles too large");
+    }
+
+    TEST(baseCellIsPentagon_matchesBaseCellData) {
+        // baseCellIsPentagon duplicates the isPentagon field of baseCellData so
+        // that hot paths get a compact lookup. Nothing in the type system keeps
+        // the two in sync, so assert it here.
+        for (int bc = 0; bc < NUM_BASE_CELLS; bc++) {
+            t_assert(
+                baseCellIsPentagon[bc] == (bool)baseCellData[bc].isPentagon,
+                "baseCellIsPentagon agrees with baseCellData");
+        }
+    }
+
+    TEST(baseCellIsPentagon_paddingIsFalse) {
+        // The array covers the whole 7 bit base cell range so an unvalidated
+        // base cell number read out of an H3Index cannot index out of bounds.
+        // Everything past the real base cells must read false.
+        for (int bc = NUM_BASE_CELLS; bc < NUM_BASE_CELL_VALUES; bc++) {
+            t_assert(baseCellIsPentagon[bc] == false,
+                     "padding entries are not pentagons");
+        }
     }
 }

--- a/src/h3lib/include/baseCells.h
+++ b/src/h3lib/include/baseCells.h
@@ -36,11 +36,26 @@ typedef struct {
 } BaseCellData;
 
 #define INVALID_BASE_CELL 127
+
+/** Number of distinct values the 7 bit base cell field of an H3Index can hold.
+ * Only the first NUM_BASE_CELLS of them name a real base cell. */
+#define NUM_BASE_CELL_VALUES 128
+
 extern const int baseCellNeighbors[NUM_BASE_CELLS][7];
 extern const int baseCellNeighbor60CCWRots[NUM_BASE_CELLS][7];
 
 // resolution 0 base cell data lookup-table (global)
 extern const BaseCellData baseCellData[NUM_BASE_CELLS];
+
+/** Pentagon flag for each base cell, split out of baseCellData so hot paths
+ * touch one contiguous byte array instead of striding through the much larger
+ * BaseCellData structs.
+ *
+ * Sized to the full 7 bit range rather than NUM_BASE_CELLS so that a base cell
+ * number taken straight out of an H3Index, which has not necessarily been
+ * validated, cannot index out of bounds. Entries at and above NUM_BASE_CELLS
+ * are false. */
+extern const bool baseCellIsPentagon[NUM_BASE_CELL_VALUES];
 
 /** Maximum input for any component to face-to-base-cell lookup functions */
 #define MAX_FACE_COORD 2

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -820,13 +820,22 @@ const BaseCellData baseCellData[NUM_BASE_CELLS] = {
     {{18, {1, 0, 0}}, 0, {0, 0}}     // base cell 121
 };
 
+/** @brief Pentagon flag for each base cell.
+ *
+ * Duplicates the isPentagon field of baseCellData in a form that is cheap to
+ * index on hot paths. testBaseCellsInternal asserts the two agree. */
+const bool baseCellIsPentagon[NUM_BASE_CELL_VALUES] = {
+    [4] = true,  [14] = true, [24] = true,  [38] = true,
+    [49] = true, [58] = true, [63] = true,  [72] = true,
+    [83] = true, [97] = true, [107] = true, [117] = true};
+
 /** @brief Return whether or not the indicated base cell is a pentagon. */
 int _isBaseCellPentagon(int baseCell) {
     if (baseCell < 0 || baseCell >= NUM_BASE_CELLS) {
         // Base cells less than zero can not be represented in an index
         return false;
     }
-    return baseCellData[baseCell].isPentagon;
+    return baseCellIsPentagon[baseCell];
 }
 
 /** @brief Return whether the indicated base cell is a pentagon where all

--- a/src/h3lib/lib/h3Index.c
+++ b/src/h3lib/lib/h3Index.c
@@ -33,11 +33,6 @@
 #include "mathExtensions.h"
 #include "vertex.h"
 
-// TODO: https://github.com/uber/h3/issues/984
-static const bool isBaseCellPentagonArr[128] = {
-    [4] = 1,  [14] = 1, [24] = 1, [38] = 1, [49] = 1,  [58] = 1,
-    [63] = 1, [72] = 1, [83] = 1, [97] = 1, [107] = 1, [117] = 1};
-
 /** @var H3ErrorDescriptions
  *  @brief An array of strings describing each of the H3ErrorCodes enum values
  */
@@ -146,7 +141,7 @@ H3Error H3_EXPORT(constructCell)(int res, int baseCellNumber, const int *digits,
     H3_SET_RESOLUTION(h, res);
     H3_SET_BASE_CELL(h, baseCellNumber);
 
-    bool isPentagon = isBaseCellPentagonArr[baseCellNumber];
+    bool isPentagon = baseCellIsPentagon[baseCellNumber];
 
     for (int r = 1; r <= res; r++) {
         int d = digits[r - 1];
@@ -325,7 +320,7 @@ We can check that (in the lower 45 = 15*3 bits) the position of the
 first 1 bit isn't divisible by 3.
 */
 static inline bool _hasDeletedSubsequence(H3Index h, int base_cell) {
-    if (isBaseCellPentagonArr[base_cell]) {
+    if (baseCellIsPentagon[base_cell]) {
         h <<= 19;
         h >>= 19;
 


### PR DESCRIPTION
Partly addresses #984.

## What this changes

`h3Index.c` carried a private `isBaseCellPentagonArr` copy of the pentagon flags, with a `// TODO: https://github.com/uber/h3/issues/984` on it, while `baseCells.c` answered the same question from `baseCellData[].isPentagon`. Two hardcoded tables, nothing keeping them in sync.

This moves the table to `baseCellIsPentagon` in `baseCells.c`, declares it in `baseCells.h`, and points both `_isBaseCellPentagon` and the `h3Index.c` hot paths at it.

The array stays sized to `NUM_BASE_CELL_VALUES` (128) rather than `NUM_BASE_CELLS` (122), matching what the private array did. `_hasDeletedSubsequence` indexes it with a base cell number taken straight out of an index, and although both current callers bounds check first, shrinking the array would turn any future unchecked caller into an out of bounds read. There is a test asserting the padding entries are false.

Two tests added: one asserting `baseCellIsPentagon` agrees with `baseCellData[].isPentagon` for every base cell, so the remaining duplication cannot drift, and one for the padding. I verified the sync test actually fails when the table is perturbed rather than passing vacuously.

## On the other half of #984

The issue also asks to inline `_isBaseCellPentagon`. I tried it and I do not think you want it.

Making it a `static inline` in `baseCells.h` measurably slows `benchmarkIsValidCell`. Interleaved A/B/C on the same machine, `pentagonChildren_8_14_null_2`, microseconds per iteration:

| variant | run 1 | run 2 | run 3 |
|---|---|---|---|
| master | 621.3 | 625.4 | 620.4 |
| this PR (table dedupe only) | 621.1 | 619.1 | 620.9 |
| dedupe + `static inline` | 663.3 | 636.5 | 635.1 |

I also tried defining the table in the header as `static const` so each TU could constant fold it, in case the regression was from losing compile time visibility into the contents. Same ~635. So the cost tracks the inline function itself, not the array linkage.

That result makes sense in hindsight: `isValidCell` reaches the flags through `_hasDeletedSubsequence`, which already indexed the flat array directly after #968, so the hot path was not calling `_isBaseCellPentagon` in the first place. There was no call left to inline away, and adding the inline definition only perturbed codegen.

So this PR keeps `_isBaseCellPentagon` out of line and takes only the deduplication, which measures neutral. Happy to close #984 or leave it open for the array-of-structs vs struct-of-arrays question on the rest of `baseCellData`, whichever you prefer.

## Testing

- `ctest` full suite: 317/317 pass
- `clang-format` clean on all changed files
- benchmark numbers above

## Disclosure

Written with AI assistance (Claude). The benchmark numbers are measured, not estimated, and the mutation check on the new test was run. Happy to explain or revise any part of it.