### PR TITLE
Name the loop argument the way polygonAlgos.h names it

### DIFF
--- a/src/h3lib/include/linkedGeo.h
+++ b/src/h3lib/include/linkedGeo.h
@@ -66,7 +66,7 @@ void destroyLinkedGeoLoop(LinkedGeoLoop *loop);
 
 /**
  * Create a bounding box from a LinkedGeoLoop
- * @param geoloop Input GeoLoop
+ * @param loop    Input GeoLoop
  * @param bbox     Output bbox
  */
 void bboxFromLinkedGeoLoop(const LinkedGeoLoop *loop, BBox *bbox);

--- a/src/h3lib/include/polygon.h
+++ b/src/h3lib/include/polygon.h
@@ -71,7 +71,7 @@ bool lineCrossesLine(const LatLng *a1, const LatLng *a2, const LatLng *b1,
 
 /**
  * Create a bounding box from a GeoLoop
- * @param geoloop Input GeoLoop
+ * @param loop    Input GeoLoop
  * @param bbox     Output bbox
  */
 void bboxFromGeoLoop(const GeoLoop *loop, BBox *bbox);
@@ -92,6 +92,6 @@ bool pointInsideGeoLoop(const GeoLoop *loop, const BBox *bbox,
  * @param loop  The loop to check
  * @return      Whether the loop is clockwise
  */
-bool isClockwiseGeoLoop(const GeoLoop *geoloop);
+bool isClockwiseGeoLoop(const GeoLoop *loop);
 
 #endif


### PR DESCRIPTION
The functions generated by the macros in `polygonAlgos.h` have their signatures written out by hand in `polygon.h` and `linkedGeo.h`, and three of those doc blocks disagree with the declaration sitting right under them:

| where | the comment says | the declaration says |
|---|---|---|
| `polygon.h:72` `bboxFromGeoLoop` | `geoloop` | `loop` |
| `linkedGeo.h:69` `bboxFromLinkedGeoLoop` | `geoloop` | `loop` |
| `polygon.h:94` `isClockwiseGeoLoop` | `loop` | `geoloop` |

The last one goes the other way, so Doxygen loses the description in all three

`polygonAlgos.h`, where these functions are actually generated, calls it `loop` everywhere:

```c
 * @param loop     Loop of coordinates
void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE *loop, BBox *bbox)
```

And `isClockwiseLinkedGeoLoop`, the twin of the third one, already agrees with it — declaration `loop`, comment `loop`. So this brings the remaining three in line with what you already do rather than introducing a new spelling.

So its omments only, plus one parameter name in a declaration, which C ignores. No behaviour change

Found with a checker I wrote and read by hand before proposing