### PR TITLE
Fix out of bounds read in _baseCellToCCWrot60 for face == NUM_ICOSA_FACES (#978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The public API of this library consists of the functions declared in file
 ### Fixed
 - Fixed the `polygonToCells` fuzzer regression test to use explicit double literals instead of reinterpreting raw bytes, so it is portable across endianness (#964)
 - No longer emit a CMake warning about a missing `clang-format`/`clang-tidy` when the user explicitly set `ENABLE_FORMAT=OFF`/`ENABLE_LINTING=OFF` (#1158)
+- Fixed an out of bounds read in `_baseCellToCCWrot60` when passed a face index equal to `NUM_ICOSA_FACES` (#978)
 
 ## [4.5.0] - 2026-05-21
 ### Added

--- a/src/apps/testapps/testBaseCellsInternal.c
+++ b/src/apps/testapps/testBaseCellsInternal.c
@@ -33,6 +33,8 @@ SUITE(baseCellsInternal) {
                  "should return invalid rotation for invalid face");
         t_assert(_baseCellToCCWrot60(16, -1) == INVALID_ROTATIONS,
                  "should return invalid rotation for invalid face (negative)");
+        t_assert(_baseCellToCCWrot60(16, NUM_ICOSA_FACES) == INVALID_ROTATIONS,
+                 "should return invalid rotation for one past the last face");
         t_assert(_baseCellToCCWrot60(1, 0) == INVALID_ROTATIONS,
                  "should return invalid rotation for base cell not appearing "
                  "on face");

--- a/src/h3lib/lib/baseCells.c
+++ b/src/h3lib/lib/baseCells.c
@@ -875,7 +875,7 @@ void _baseCellToFaceIjk(int baseCell, FaceIJK *h) {
  *          cell is not found on the given face
  */
 int _baseCellToCCWrot60(int baseCell, int face) {
-    if (face < 0 || face > NUM_ICOSA_FACES) return INVALID_ROTATIONS;
+    if (face < 0 || face >= NUM_ICOSA_FACES) return INVALID_ROTATIONS;
     for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {
             for (int k = 0; k < 3; k++) {


### PR DESCRIPTION
Fixes #978.

## The bug

`_baseCellToCCWrot60` guards its `face` argument with:

```c
if (face < 0 || face > NUM_ICOSA_FACES) return INVALID_ROTATIONS;
```

The table it then indexes is declared as:

```c
static const BaseCellRotation faceIjkBaseCells[NUM_ICOSA_FACES][3][3][3]
```

so valid indices are `0 .. NUM_ICOSA_FACES - 1`. `face == NUM_ICOSA_FACES` (20) passes the check and the loop reads one whole `[3][3][3]` row past the end of the array.

The sibling function `_faceIjkToBaseCell` and friends use the correct `>=` form; this one is the odd one out.

## Reproduction

Built with the same sanitizer flags the repo CI already uses in `.github/workflows/test-linux.yml` (`-fsanitize=address -fno-sanitize-recover=address`), calling `_baseCellToCCWrot60(16, NUM_ICOSA_FACES)`:

```
==ERROR: AddressSanitizer: global-buffer-overflow on address ...
    #0 ... in _baseCellToCCWrot60 src/h3lib/lib/baseCells.c:882
```

exit code 1. With the fix applied the same binary passes.

Note for reviewers: in a plain non-sanitizer build the added assertion happens to pass without the fix, because the out of bounds read is undefined behaviour that usually returns garbage that does not equal `INVALID_ROTATIONS` anyway. It is an effective regression test specifically under the ASAN/MSAN/UBSAN/Valgrind jobs this repo already runs on every PR, which is where the bug is actually detectable.

## Change

- `>` becomes `>=` in the bounds check.
- Regression test in `testBaseCellsInternal.c` alongside the existing invalid-face assertions.
- CHANGELOG entry.

This is one of the checks called out in #430: "I did not port two of the checks in baseCells.c since I could not readily test them. They could be added in a future PR."

## Testing

Full suite under ASAN: `100% tests passed, 0 tests failed out of 317`.
