### PR TITLE
Clamp polygon bbox latitudes to the valid sphere range

### DIFF
--- a/src/apps/testapps/testPolygonInternal.c
+++ b/src/apps/testapps/testPolygonInternal.c
@@ -211,6 +211,18 @@ SUITE(polygonInternal) {
         t_assert(bboxEquals(&result, &expected), "Got expected bbox");
     }
 
+    TEST(bboxFromGeoLoopClampsOutOfRangeLatitude) {
+        // Extreme latitudes must clamp to +/- pi/2 so polyfill estimates
+        // cannot explode (GitHub issue 1225).
+        LatLng verts[] = {{0.0, 0.0}, {-1.61264e179, 0.0}};
+        GeoLoop geoloop = {.numVerts = 2, .verts = verts};
+
+        BBox result;
+        bboxFromGeoLoop(&geoloop, &result);
+        t_assert(result.north == 0.0, "north unchanged when in range");
+        t_assert(result.south == -M_PI_2, "south clamped to -pi/2");
+    }
+
     TEST(bboxesFromGeoPolygon) {
         LatLng verts[] = {{0.8, 0.3}, {0.7, 0.6}, {1.1, 0.7}, {1.0, 0.2}};
         GeoLoop geoloop = {.numVerts = 4, .verts = verts};

--- a/src/h3lib/include/polygonAlgos.h
+++ b/src/h3lib/include/polygonAlgos.h
@@ -193,6 +193,15 @@ void GENERIC_LOOP_ALGO(bboxFrom)(const TYPE *loop, BBox *bbox) {
         bbox->east = maxNegLng;
         bbox->west = minPosLng;
     }
+    // Latitudes outside [-pi/2, pi/2] are not on the sphere. Clamp so
+    // polyfill size estimates cannot explode on out-of-range vertices
+    // (see GitHub issue #1225).
+    if (bbox->north > M_PI_2) {
+        bbox->north = M_PI_2;
+    }
+    if (bbox->south < -M_PI_2) {
+        bbox->south = -M_PI_2;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
Finite but wildly out of range latitudes were accepted when building a polygon bounding box. That made bbox size estimates huge and caused polygonToCellsExperimental to spend minutes on a tiny fuzzer input (issue 1225).

After constructing the loop bbox, north and south are now clamped to plus or minus pi/2, matching the clamp already used in scaleBBox. In range polygons are unchanged. A unit test covers the extreme latitude case from the fuzzer artifact.

Fixes #1225

## Test plan
1. Build and run the polygon internal test suite, including bboxFromGeoLoopClampsOutOfRangeLatitude.
2. Confirm existing bboxFromGeoLoop cases still pass.
3. Optionally replay the libFuzzer timeout artifact and confirm maxPolygonToCellsSizeExperimental returns quickly.