### PR TITLE
website: add support for rendering vertexes

### DIFF
--- a/website/src/components/explorer/details.jsx
+++ b/website/src/components/explorer/details.jsx
@@ -18,6 +18,7 @@ import {
   getDirectedEdgeOrigin,
   getDirectedEdgeDestination,
   UNITS,
+  vertexToLatLng,
 } from "h3-js";
 
 const THREE_BITS = 7; // 1 | 2 | 4
@@ -153,6 +154,7 @@ function ClickableH3IndexList({
 }
 
 export function SelectedEdgeDetails({ edge, showDetails = true }) {
+  // TODO: Will be fixed in next release
   // getResolution reports -1 for an edge index, so take it from the origin cell.
   const origin = getDirectedEdgeOrigin(edge);
   const destination = getDirectedEdgeDestination(edge);
@@ -175,6 +177,32 @@ export function SelectedEdgeDetails({ edge, showDetails = true }) {
           Destination: <tt>{destination}</tt>
           <br />
           Edge Length: <tt>{length}</tt> {units.dist}
+        </details>
+      ) : (
+        <></>
+      )}
+    </p>
+  );
+}
+
+export function SelectedVertexDetails({ vertex, showDetails = true }) {
+  // TODO: Will be fixed in next release
+  // getResolution reports -1 for a vertex index,
+  const res = 15;
+  const floatPrecision = res / 3 + 7;
+
+  const coords = vertexToLatLng(vertex)
+    .map((n) => n.toPrecision(floatPrecision))
+    .join(", ");
+
+  return (
+    <p style={{ marginBottom: "0" }}>
+      <br />
+      Vertex: <tt>{vertex}</tt>
+      {showDetails ? (
+        <details>
+          <summary>Details</summary>
+          Coords: <tt>{coords}</tt>
         </details>
       ) : (
         <></>

--- a/website/src/components/explorer/index.tsx
+++ b/website/src/components/explorer/index.tsx
@@ -6,6 +6,7 @@ import {
   isValidDirectedEdge,
   latLngToCell,
   getResolution,
+  isValidVertex,
 } from "h3-js";
 import {
   Banner,
@@ -14,7 +15,11 @@ import {
   DemoContainer,
 } from "../styled";
 import { useQueryState } from "use-location-state";
-import { SelectedEdgeDetails, SelectedHexDetails } from "./details";
+import {
+  SelectedEdgeDetails,
+  SelectedVertexDetails,
+  SelectedHexDetails,
+} from "./details";
 import { ExplorerMap } from "./map";
 import { WhereAmIButton } from "./where-am-i";
 import { doSplitUserInput } from "./parseInput";
@@ -48,7 +53,12 @@ export default function HomeExporer({ children }: { children: ReactNode }) {
     () => splitUserInput.filter(isValidDirectedEdge),
     [splitUserInput],
   );
-  const userValidInput = cells.length > 0 || edges.length > 0;
+  const vertexes = useMemo(
+    () => splitUserInput.filter(isValidVertex),
+    [splitUserInput],
+  );
+  const userValidInput =
+    cells.length > 0 || edges.length > 0 || vertexes.length > 0;
   const constantResolution = useMemo(() => {
     const resAsSet = new Set(cells.map(getResolution));
     if (resAsSet.size === 1) {
@@ -104,6 +114,7 @@ export default function HomeExporer({ children }: { children: ReactNode }) {
             <ExplorerMap
               userInput={cells}
               userEdges={edges}
+              userVertexes={vertexes}
               inputGeoJson={inputGeoJson}
               userValidInput={userValidInput}
               objectOnClick={objectOnClick}
@@ -139,6 +150,9 @@ export default function HomeExporer({ children }: { children: ReactNode }) {
             />
           ) : null}
           {edges.length === 1 ? <SelectedEdgeDetails edge={edges[0]} /> : null}
+          {vertexes.length === 1 ? (
+            <SelectedVertexDetails vertex={vertexes[0]} />
+          ) : null}
           {showResolutionInput !== null ? (
             <div>
               <label htmlFor={resolutionInputId}>Resolution:</label>

--- a/website/src/components/explorer/map.jsx
+++ b/website/src/components/explorer/map.jsx
@@ -11,11 +11,11 @@ import { Map } from "react-map-gl";
 import DeckGL from "@deck.gl/react";
 import { H3HexagonLayer } from "@deck.gl/geo-layers";
 import { WebMercatorViewport, FlyToInterpolator, MapView } from "@deck.gl/core";
-import { cellToBoundary, directedEdgeToBoundary } from "h3-js";
+import { cellToBoundary, directedEdgeToBoundary, vertexToLatLng } from "h3-js";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { MOBILE_CUTOFF_WINDOW_WIDTH } from "../common";
 import { useHex } from "./useHex";
-import { GeoJsonLayer, PathLayer } from "deck.gl";
+import { GeoJsonLayer, PathLayer, ScatterplotLayer } from "deck.gl";
 import { PathStyleExtension } from "@deck.gl/extensions";
 import { useColorMode } from "@docusaurus/theme-common";
 
@@ -35,8 +35,9 @@ const DARK_MAP_STYLE = "mapbox://styles/mapbox/dark-v11";
 /**
  *
  * @param {Object} opts
- * @param {string[]} opts.userInput
+ * @param {string[]} [opts.userInput]
  * @param {string[]} [opts.userEdges]
+ * @param {string[]} [opts.userVertexes]
  * @param {object | null} opts.inputGeoJson
  * @param {boolean} opts.userValidInput
  * @param {Object} [opts.initialViewState]
@@ -49,6 +50,7 @@ export function ExplorerMap(opts) {
   const {
     userInput = [],
     userEdges = [],
+    userVertexes = [],
     inputGeoJson = null,
     userValidInput = false,
     initialViewState = INITIAL_VIEW_STATE,
@@ -88,17 +90,23 @@ export function ExplorerMap(opts) {
       const boundaries = [
         ...userInput.map((hex) => cellToBoundary(hex, true)),
         ...userEdges.map((edge) => directedEdgeToBoundary(edge, true)),
+        ...userVertexes.map((vertex) => {
+          const latLng = vertexToLatLng(vertex);
+          return [[latLng[1], latLng[0]]];
+        }),
       ];
       for (const coords of boundaries) {
         for (const coord of coords) {
           if (coord[0] < minX) {
             minX = coord[0];
-          } else if (coord[0] > maxX) {
+          }
+          if (coord[0] > maxX) {
             maxX = coord[0];
           }
           if (coord[1] < minY) {
             minY = coord[1];
-          } else if (coord[1] > maxY) {
+          }
+          if (coord[1] > maxY) {
             maxY = coord[1];
           }
         }
@@ -112,12 +120,16 @@ export function ExplorerMap(opts) {
         width > 1 &&
         height > 1
       ) {
+        const hasVertex = userVertexes.length > 0;
         const { latitude, longitude, zoom } = viewport.fitBounds(
           [
             [minX, minY],
             [maxX, maxY],
           ],
-          { padding: 96 },
+          {
+            maxZoom: hasVertex ? 22 : undefined,
+            padding: 96,
+          },
         );
 
         setCurrentInitialViewState({
@@ -129,7 +141,7 @@ export function ExplorerMap(opts) {
         });
       }
     }
-  }, [userInput, userEdges, userValidInput, deckLoaded]);
+  }, [userInput, userEdges, userVertexes, userValidInput, deckLoaded]);
 
   const addSelectedHexes = useCallback(
     (hex) => {
@@ -213,6 +225,27 @@ export function ExplorerMap(opts) {
       ]
     : [];
 
+  const inputVertexLayers = userVertexes.length
+    ? [
+        new ScatterplotLayer({
+          id: "uservertex",
+          data: userVertexes.map((hex) => ({ hex })),
+          getPosition: (v) => {
+            const latLng = vertexToLatLng(v.hex);
+            return [latLng[1], latLng[0]];
+          },
+          filled: true,
+          stroked: false,
+          getFillColor: colorMode === "dark" ? [255, 255, 255] : [0, 0, 0],
+          getRadius: 3,
+          radiusMinPixels: 2,
+          radiusUnits: "pixels",
+          radiusScale: 1,
+          pickable: true,
+        }),
+      ]
+    : [];
+
   const layers = userValidInput
     ? [
         new H3HexagonLayer({
@@ -232,6 +265,7 @@ export function ExplorerMap(opts) {
           getFillColor:
             colorMode === "dark" ? [255, 255, 255, 30] : [0, 0, 0, 30],
         }),
+        ...inputVertexLayers,
         ...inputEdgeLayers,
         ...inputPreviewLayers,
         ...inputGeoJsonLayers,

--- a/website/src/components/explorer/parseInput.ts
+++ b/website/src/components/explorer/parseInput.ts
@@ -1,6 +1,11 @@
 // Contains code adapted from https://observablehq.com/@nrabinowitz/h3-index-inspector under the ISC license
 
-import { isValidCell, isValidDirectedEdge, latLngToCell } from "h3-js";
+import {
+  isValidCell,
+  isValidDirectedEdge,
+  isValidVertex,
+  latLngToCell,
+} from "h3-js";
 import geojson2h3 from "geojson2h3";
 import wkt from "wkt";
 import { Feature, MultiPolygon, Polygon } from "geojson";
@@ -127,6 +132,7 @@ export function doSplitUserInput(userInput: string, userResolution: number) {
     // Valid hexadecimal cell ID, prefixed by 0x
     // Valid decimal cell ID
     // Valid hexadecimal directed edge ID, optionally prefixed by 0x
+    // Valid hexadecimal vertex ID, optionally prefixed by 0x
     // lat,lng coordinate pairs
 
     const resultPolygon = tryParsePolygonInput(userInput, userResolution);
@@ -163,6 +169,15 @@ export function doSplitUserInput(userInput: string, userResolution: number) {
       } else if (
         indexFromPrefixedHex !== null &&
         isValidDirectedEdge(indexFromPrefixedHex)
+      ) {
+        result.push(indexFromPrefixedHex);
+        // Show what the edge ID would look like normally
+        showCellId = true;
+      } else if (isValidVertex(currentInput)) {
+        result.push(currentInput);
+      } else if (
+        indexFromPrefixedHex !== null &&
+        isValidVertex(indexFromPrefixedHex)
       ) {
         result.push(indexFromPrefixedHex);
         // Show what the edge ID would look like normally


### PR DESCRIPTION
Follow up from #1223, this adds support for rendering vertex indexes on the map.

This also adds support for automatic zoom-to of directed edge and vertex indexes.