### PR TITLE
Avoid signed overflow accumulating vertex counts in maxPolygonToCellsSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The public API of this library consists of the functions declared in file
 
 ## [Unreleased]
 ### Fixed
+- Avoid signed integer overflow when accumulating vertex counts in `maxPolygonToCellsSize` (#1204)
 - Fixed the `polygonToCells` fuzzer regression test to use explicit double literals instead of reinterpreting raw bytes, so it is portable across endianness (#964)
 - No longer emit a CMake warning about a missing `clang-format`/`clang-tidy` when the user explicitly set `ENABLE_FORMAT=OFF`/`ENABLE_LINTING=OFF` (#1158)
 - Fixed an out of bounds read in `_baseCellToCCWrot60` when passed a face index equal to `NUM_ICOSA_FACES` (#978)

--- a/src/apps/testapps/testPolygonToCells.c
+++ b/src/apps/testapps/testPolygonToCells.c
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "algos.h"
@@ -281,6 +282,22 @@ SUITE(polygonToCells) {
         t_assert(H3_EXPORT(maxPolygonToCellsSize)(&invalid2GeoPolygon, 9, 0,
                                                   &numHexagons) == E_FAILED,
                  "Cannot determine cell size to invalid geo polygon with NaNs");
+    }
+
+    TEST(maxPolygonToCellsSizeHoleVertsOverflow) {
+        // holes[i].verts are not read by maxPolygonToCellsSize, only numVerts,
+        // so oversized counts exercise the vertex accumulation without
+        // allocation
+        GeoLoop bigHole = {.numVerts = INT32_MAX, .verts = NULL};
+        GeoLoop holes[] = {bigHole, bigHole, bigHole};
+        GeoPolygon polygon = {
+            .geoloop = sfGeoLoop, .numHoles = 3, .holes = holes};
+
+        int64_t numHexagons;
+        t_assertSuccess(
+            H3_EXPORT(maxPolygonToCellsSize)(&polygon, 9, 0, &numHexagons));
+        t_assert(numHexagons >= 3LL * INT32_MAX,
+                 "hole vertex counts accumulate without overflowing");
     }
 
     TEST(maxPolygonToCellsSizePoint) {

--- a/src/h3lib/include/mathExtensions.h
+++ b/src/h3lib/include/mathExtensions.h
@@ -42,6 +42,15 @@ static inline bool ADD_INT32S_OVERFLOWS(int32_t a, int32_t b) {
     }
 }
 
+/** Evaluates to true if a + b would overflow for int64 */
+static inline bool ADD_INT64S_OVERFLOWS(int64_t a, int64_t b) {
+    if (a > 0) {
+        return INT64_MAX - a < b;
+    } else {
+        return INT64_MIN - a > b;
+    }
+}
+
 /** Evaluates to true if a - b would overflow for int32 */
 static inline bool SUB_INT32S_OVERFLOWS(int32_t a, int32_t b) {
     if (a >= 0) {

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -900,6 +900,9 @@ H3Error H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon *geoPolygon, int res,
     // resolution, the line tracing needs an extra buffer than the estimator
     // function provides (but beefing that up to cover causes most situations to
     // overallocate memory)
+    if (ADD_INT64S_OVERFLOWS(numHexagons, POLYGON_TO_CELLS_BUFFER)) {
+        return E_MEMORY_ALLOC;
+    }
     numHexagons += POLYGON_TO_CELLS_BUFFER;
     *out = numHexagons;
     return E_SUCCESS;

--- a/src/h3lib/lib/algos.c
+++ b/src/h3lib/lib/algos.c
@@ -36,6 +36,7 @@
 #include "h3api.h"
 #include "latLng.h"
 #include "linkedGeo.h"
+#include "mathExtensions.h"
 #include "polygon.h"
 
 /*
@@ -887,8 +888,11 @@ H3Error H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon *geoPolygon, int res,
     // This algorithm assumes that the number of vertices is usually less than
     // the number of hexagons, but when it's wrong, this will keep it from
     // failing
-    int totalVerts = geoloop.numVerts;
+    int64_t totalVerts = geoloop.numVerts;
     for (int i = 0; i < geoPolygon->numHoles; i++) {
+        if (ADD_INT64S_OVERFLOWS(totalVerts, geoPolygon->holes[i].numVerts)) {
+            return E_MEMORY_ALLOC;
+        }
         totalVerts += geoPolygon->holes[i].numVerts;
     }
     if (numHexagons < totalVerts) numHexagons = totalVerts;


### PR DESCRIPTION
Addresses the `maxPolygonToCellsSize` half of #1204 (#1205 covers `uncompactCellsSize`).

`totalVerts` was an `int` accumulating each loop's `numVerts`, so a polygon with enough hole vertices wraps to a negative value, the `numHexagons < totalVerts` guard stops working, and the caller under-allocates. Widened it to `int64_t` per @isaacbrodsky's note and guarded the accumulation with `ADD_INT64S_OVERFLOWS`, returning `E_MEMORY_ALLOC` like `uncompactCellsSize`.

`ADD_INT64S_OVERFLOWS` is the int64 companion to the existing `ADD_INT32S_OVERFLOWS`; #1205 adds the same helper, so whichever lands second just drops the duplicate.

Test: `maxPolygonToCellsSize` only reads `holes[i].numVerts`, not the vertex arrays, so the new case uses oversized counts with null `verts` to exercise the accumulation without allocating. Built with MinGW and ran `testPolygonToCells` (120822 assertions) and `testH3Memory` - both pass. The `E_MEMORY_ALLOC` path itself isn't reachable in a test without billions of holes, same as it would be for the int64 guard in #1205.
