### PR TITLE
Add vgorte/react-native-nitro-h3 to community bindings

### DIFF
--- a/website/docs/community/bindings.md
+++ b/website/docs/community/bindings.md
@@ -71,6 +71,7 @@ As a C library, bindings can be made to call H3 functions from different program
 - [uber/h3-js](https://github.com/uber/h3-js)
 - [dfellis/h3-node](https://github.com/dfellis/h3-node)
 - [realPrimoh/h3-reactnative](https://github.com/realPrimoh/h3-reactnative)
+- [vgorte/react-native-nitro-h3](https://github.com/vgorte/react-native-nitro-h3) - React Native via Nitro Modules
 
 ## Julia
 


### PR DESCRIPTION
Adds `react-native-nitro-h3` to the JavaScript section of the community bindings list.

It is a React Native binding for iOS and Android. The H3 C library (v4.5.0) is vendored and called directly from C++ through Nitro Modules, with no `h3-js` dependency. It mirrors the 64-function `h3-js` 4.5.0 API under the same names, with cell indexes as `bigint` and cell collections as `BigUint64Array` so results cross the JS boundary as typed arrays.

- npm: https://www.npmjs.com/package/react-native-nitro-h3
- Licence: MIT; the vendored H3 sources stay under Apache-2.0 in `third_party/h3`